### PR TITLE
TypeScript rewrite: MV3 service worker, dependency-free UI, side-panel settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      # Runs the TypeScript project build (typecheck included) and packages
+      # the extension into dist/.
+      - run: npm run build
+
+      - run: npm test
+
+      - name: Install Chrome
+        id: chrome
+        uses: browser-actions/setup-chrome@v2
+        with:
+          chrome-version: stable
+
+      # The e2e scripts drive a real browser over CDP; HEADLESS=1 adds
+      # --headless=new plus the sandbox flags CI runners need.
+      - name: End-to-end tests (headless Chrome)
+        run: npm run e2e
+        env:
+          CHROME_PATH: ${{ steps.chrome.outputs.chrome-path }}
+          HEADLESS: '1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Node 22+: the e2e scripts use the global WebSocket.
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - run: npm ci

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bower_components
 dist/
 *.tsbuildinfo
 packages/ui/dist/
+dist/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 bower_components
+dist/
+*.tsbuildinfo

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 bower_components
 dist/
 *.tsbuildinfo
+packages/ui/dist/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 *.tsbuildinfo
 packages/ui/dist/
 dist/
+.dev-chrome-profile/

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -9,7 +9,7 @@ AngularJS onto TypeScript + npm workspaces + Vite/esbuild + Vitest.
 | --- | --- | --- |
 | `packages/pac` (`@switchydelta/pac`) | `omega-pac` | Done, 174 tests |
 | `packages/target` (`@switchydelta/target`) | `omega-target` | In progress |
-| `packages/extension` | `omega-target-chromium-extension` | Not started |
+| `packages/extension` | `omega-target-chromium-extension` | Minimal worker, in progress |
 | `packages/ui` (`@switchydelta/ui`) | `omega-web` | Foundation done |
 
 The old directories are still present and untouched. Nothing is deleted until
@@ -153,28 +153,40 @@ Two smaller judgement calls, both deliberate:
   keys stay in lockstep with the regexes `Conditions` builds for the same
   pattern.
 
+## Scope of the service worker
+
+The worker is deliberately reduced to what only it can do:
+
+- **proxy authentication** — `chrome.webRequest.onAuthRequired` has no other
+  host, and its listener must be registered in the worker's first turn or the
+  event that woke the worker is lost
+- **scheduled downloads** — `chrome.alarms` is the only timer that survives
+  suspension
+- **applying the profile** to `chrome.proxy.settings`
+- **answering RPC** from the options page and popup
+
+Dropped from this build: external-proxy-change watching and
+`-revertProxyChanges`, quick-switch cycling, the badge and per-tab
+icons/titles, the request monitor, the inspect context menus, and the
+SwitchySharp / external-extension bridges. `proxy_impl_script` and
+`proxy_impl_listener` are Firefox-only and were already dead on Chromium.
+
+Note that this does not reduce idle memory: MV3 workers are already
+event-driven and terminate when idle. The 743 KB -> 30 KB PAC reduction is what
+actually addresses the cost that motivated the previous `af4efbe` work.
+
 ## Remaining work
 
 1. **`packages/target`** — `options.ts` (the 1059-line controller) is the last
    file; the rest is ported and typechecks. It has no tests yet: the only
    existing suite was `omega-target/test/options_sync.coffee`, which still needs
    porting, and `Options` itself was never covered.
-2. **`packages/extension`** — not started. Port `src/module/*` and the service
-   worker. Notes from the survey worth keeping:
-   - `ProxyAuth` must keep registering `onAuthRequired` synchronously in the
-     worker's first turn, or the wake-up event that started the worker is lost.
-     Its `chrome.storage.session` + `chrome.storage.local` dual-write is what
-     survives worker suspension; do not "simplify" it away.
-   - `_pacWithCompiler` and its `importScripts` hack should disappear with the
-     single-bundle PAC package.
-   - `proxy_impl.coffee` calls a bare global `OmegaPac`, relying on
-     `importScripts` ordering. Give it a real import.
-   - `tabs.coffee`, `web_request_monitor.coffee` and `inspect.coffee` are not
-     wired into the current build. Decide whether to revive or drop them rather
-     than porting them by reflex.
-   - The Firefox-only `proxy_impl_script` / `proxy_impl_listener` paths are dead
-     on Chromium; the comment forbidding bluebird in `onRequest` becomes moot
-     with native promises.
+2. **`packages/extension`** — the reduced worker (see above) is in progress:
+   `sw.ts`, `chrome-options.ts` and `fetch-url.ts` are written; `proxy-auth.ts`,
+   `proxy-settings.ts` and `chrome-storage.ts` are the remainder. `ProxyAuth`
+   carries the constraints that matter: register `onAuthRequired` in the
+   worker's first turn, and keep the `chrome.storage.session` +
+   `chrome.storage.local` dual-write that survives suspension.
 3. **`packages/ui`** — editors for Pac, Switch, RuleList and Virtual profiles;
    the rule table with drag reorder; the modal flows (new/rename/replace/delete);
    options sync UI; the guided tours. The `switch_profile` controller was the

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -87,6 +87,14 @@ Each is fixed in the rewrite and noted in a comment at the site.
 - `OptionsSync._legacyGet` declared its parsed `value` function-scoped and only
   assigned it inside a `try`, so a key whose JSON failed to parse inherited the
   previous key's value instead of falling back to the supplied default.
+- `Options`'s constructor defaulted its storages with `@_storage ?= Storage()`,
+  calling a class without `new`. That yields `undefined`, so the fallback never
+  produced a usable storage.
+- `fetch_url` compared the raw `Content-Type` header against a hint, so
+  `text/html; charset=utf-8` never equalled `text/html`. Servers almost always
+  send a charset, so the "response must not be HTML" guard silently never fired
+  and HTML error pages were accepted as rule lists. The port compares the media
+  type without parameters.
 
 ### Needs a decision
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -48,6 +48,9 @@ entry point.
 
 Net: **743 KB -> 30 KB** (10.7 KB gzipped), with the generator included.
 
+Across the whole packaged extension, JavaScript goes from **1,730,921 bytes to
+122,174** (93% smaller), both minified.
+
 **The UI drops its framework.** 19 bower runtime packages become 44 KB of JS and
 CSS with no runtime dependency. See the commit message on the UI package for why
 Vite rather than Next.js.
@@ -113,6 +116,19 @@ Each is fixed in the rewrite and noted in a comment at the site.
   from identifiers that did not resolve: an undeclared `name` (which found the
   *global* `name`, an empty string), and `@profile.name` where `profile` is a
   method, yielding the literal string `"profile"`.
+- `ChromeStorage.parseStorageErrors` built the new `RateLimitExceededError`
+  first and then tested `err.message` on that *new* error, whose message is
+  empty. The `perHour` / `perMinute` flags were therefore never set.
+- `ChromeStorage.watch` only converted the array form of `keys` into a lookup
+  map. A single string key stayed a string, so the membership test indexed it
+  by character and never matched — watches on one key silently never fired.
+- `ChromeStorage.watch` derived its watcher id from `Date.now()` in a `while`
+  loop, busy-spinning until the clock ticked whenever two watchers registered
+  in the same millisecond.
+- `proxy_impl_settings` iterated `profile.bypassList` unguarded, though it is
+  optional on a FixedProfile, so a profile without one threw.
+- `proxy_impl.coffee` referenced a free `OmegaPac` variable it never required.
+  It worked only because the built worker happened to expose it as a global.
 - `fetch_url` compared the raw `Content-Type` header against a hint, so
   `text/html; charset=utf-8` never equalled `text/html`. Servers almost always
   send a charset, so the "response must not be HTML" guard silently never fired

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -90,6 +90,29 @@ Each is fixed in the rewrite and noted in a comment at the site.
 - `Options`'s constructor defaulted its storages with `@_storage ?= Storage()`,
   calling a class without `new`. That yields `undefined`, so the fallback never
   produced a usable storage.
+- `Options.addTempRule` indexed the rule into `_tempProfileRulesByProfile`
+  unconditionally, so calling it twice for the same domain and profile appended
+  the same object again. The stale-rule cleanup in `applyProfile` then spliced
+  by `indexOf` once per duplicate, and after the first removal `indexOf` returns
+  `-1` — `splice(-1, 1)` deletes the last, unrelated rule. Both the duplicate
+  push and the two unguarded splices are fixed.
+- `Options.loadOptions` dereferenced `this.sync` unguarded while bootstrapping
+  `syncOptions`. The write that would set `'unsupported'` is fire-and-forget, so
+  with no sync available there is a window where the key is still empty and the
+  dereference throws. That `TypeError` lands in the retry `catch`, which treats
+  it as a serious failure and **reinstalls default options over the user's**.
+- `Options.setExternalProfile` called `applyProfile(this._revertToProfileName)`
+  on the first external change, when nothing had been remembered yet. It passed
+  null, rejected with `ProfileNotExistError`, and nothing awaited it — so
+  `-revertProxyChanges` silently never reverted the first change.
+- `Options._setOptions` did not chain `_storage.remove(removed)`, so the
+  returned promise could resolve before the keys were gone.
+- `reloadQuickSwitch` and `_replaceRefChanges` dereferenced
+  `-quickSwitchProfiles` with no guard against the key being absent.
+- `renameProfile`, `addCondition` and `setDefaultProfile` built error messages
+  from identifiers that did not resolve: an undeclared `name` (which found the
+  *global* `name`, an empty string), and `@profile.name` where `profile` is a
+  method, yielding the literal string `"profile"`.
 - `fetch_url` compared the raw `Content-Type` header against a hint, so
   `text/html; charset=utf-8` never equalled `text/html`. Servers almost always
   send a charset, so the "response must not be HTML" guard silently never fired

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,163 @@
+# TypeScript rewrite
+
+SwitchyDelta is being moved off CoffeeScript + Grunt + Browserify + Bower +
+AngularJS onto TypeScript + npm workspaces + Vite/esbuild + Vitest.
+
+## Layout
+
+| New package | Replaces | State |
+| --- | --- | --- |
+| `packages/pac` (`@switchydelta/pac`) | `omega-pac` | Done, 174 tests |
+| `packages/target` (`@switchydelta/target`) | `omega-target` | In progress |
+| `packages/extension` | `omega-target-chromium-extension` | Not started |
+| `packages/ui` (`@switchydelta/ui`) | `omega-web` | Foundation done |
+
+The old directories are still present and untouched. Nothing is deleted until
+the replacement is verified, so the two can be diffed against each other.
+
+## Commands
+
+```sh
+npm install          # workspace root
+npm test             # vitest, all packages
+npm run typecheck    # tsc --build across project references
+npm run build        # per-package builds
+```
+
+## The main optimisations
+
+**The PAC generator no longer uses a minifier.** The CoffeeScript version built
+an UglifyJS 2 AST and then ran Uglify's compressor and mangler over it. A
+general-purpose minifier is only needed when you do not control the input; this
+generator controls every byte it emits, so it now emits compact code directly
+through a small precedence-aware string emitter (`packages/pac/src/codegen.ts`).
+
+That removed `uglify-js` (1.4 MB) and, with it, the reason for the two-bundle
+architecture: `omega_pac.min.js` (match only, 448 KB) plus a lazily
+`importScripts`-ed `omega_pac_full.min.js` (743 KB) existed purely to keep the
+minifier out of the service worker's startup path. There is now one bundle.
+
+`ip-address` (204 KB with `jsbn` and `sprintf-js`) is replaced by
+`packages/pac/src/ip.ts`, which holds addresses as bytes, so subnet tests are a
+byte compare rather than BigInteger arithmetic.
+
+`tldjs` (356 KB, almost all of it the public suffix list) was reachable from the
+service worker for exactly one call site — suggesting `*.example.com` when a
+user adds a rule. It now lives behind the separate `@switchydelta/pac/psl`
+entry point.
+
+Net: **743 KB -> 30 KB** (10.7 KB gzipped), with the generator included.
+
+**The UI drops its framework.** 19 bower runtime packages become 44 KB of JS and
+CSS with no runtime dependency. See the commit message on the UI package for why
+Vite rather than Next.js.
+
+**Other reductions in flight:** bluebird replaced by native `async`/`await`;
+`limiter` replaced by a ~60-line token bucket; `heap` dropped with the dead
+`WebRequestMonitor`; `xhr` replaced by `fetch`. `jsondiffpatch` stays only where
+a real structural diff is needed.
+
+**Logging.** `Log.method` ran on every storage read and write and pretty-prints
+its subject with `JSON.stringify(..., 4)`, i.e. it serialised the whole options
+object on every operation. Tracing is now opt-in via `setTracing`.
+
+## Bugs found while porting
+
+Each is fixed in the rewrite and noted in a comment at the site.
+
+- `BypassCondition.analyze` assigned to `normalizedPattern` instead of appending,
+  so `Conditions.str` silently dropped the scheme from patterns like
+  `http://*.example.com`. Round-tripping such a rule changed its meaning.
+- `Conditions.regTest` called `regexSafe()`, which is defined nowhere. Dead only
+  because every caller happens to pass a `RegExp` rather than a string.
+- `Options.init`: `if not err instanceof ProfileNotExistError` parses as
+  `(not err) instanceof ...`, which is always false, so startup errors were
+  never logged.
+- `Options.loadOptions`: a branch tested an `options` identifier that does not
+  exist in that scope, making it permanently dead.
+- `Options` declared `_watchingProfiles: {}` and friends at prototype level,
+  which shares one mutable object across all instances.
+- `AttachedCache` used `Object.defineProperty` to hang a `_cache` property on
+  caller-owned profile objects. It now uses a `WeakMap`, so profiles stay clean
+  for serialisation.
+- `OptionsSync._doPush` cleared its `_waiting` latch only on the success path.
+  One transient failure reading remote state left the latch set, so every later
+  push returned early and syncing stayed wedged for the life of the object. The
+  same read also sat outside the `catch`, producing an unhandled rejection.
+- `OptionsSync._legacyGet` declared its parsed `value` function-scoped and only
+  assigned it inside a `try`, so a key whose JSON failed to parse inherited the
+  previous key's value instead of falling back to the supplied default.
+
+### Needs a decision
+
+`OptionsSync.copyTo` has a pass meant to delete local profiles that are gone
+upstream. Its guard reads `not base[key]?.syncOptions == 'disabled'`, which
+compiles to `!(...) === 'disabled'` — a boolean compared against a string, so it
+is always false. The intent was plainly `!=`. **This pass has therefore never
+run.** It is preserved as-is, because "fixing" it would start deleting
+local-only profiles on the first sync of an existing install. Enabling it should
+be a deliberate, separately tested change.
+
+Two smaller judgement calls, both deliberate:
+
+- The token bucket starts **full**, whereas `limiter`'s starts empty (its
+  `RateLimiter` wrapper refilled it, which is why nobody noticed). An empty
+  start costs 6 s before the first sync write. Under MV2's persistent background
+  page that was once per session; under MV3 the worker is recycled constantly,
+  so it would be 6 s after every wake-up.
+- The quota handler mutates caller-owned profile objects in place and depends on
+  them being the same references already re-queued into `_pending`. Preserved,
+  with the ordering dependency commented, and verified not to retry forever.
+
+## Deliberate behaviour changes
+
+- Requests are parsed with the WHATWG `URL` instead of Node's legacy
+  `url.parse`. IPv6 hosts are therefore canonicalised the way Chrome
+  canonicalises them before invoking a PAC script, so `http://[::1.2.3.4]/`
+  presents as `::102:304`. This changes `<local>` matching for that input and is
+  covered by a comment in `packages/pac/test/conditions.test.ts`.
+- Generated PAC is always compact. The old exporter could emit a beautified,
+  commented script; the emitter does not implement a pretty mode.
+- `hostPatternToTrieKeys` is exported so tests can assert that the DomainTrie
+  keys stay in lockstep with the regexes `Conditions` builds for the same
+  pattern.
+
+## Remaining work
+
+1. **`packages/target`** — `options.ts` (the 1059-line controller) is the last
+   file; the rest is ported and typechecks. It has no tests yet: the only
+   existing suite was `omega-target/test/options_sync.coffee`, which still needs
+   porting, and `Options` itself was never covered.
+2. **`packages/extension`** — not started. Port `src/module/*` and the service
+   worker. Notes from the survey worth keeping:
+   - `ProxyAuth` must keep registering `onAuthRequired` synchronously in the
+     worker's first turn, or the wake-up event that started the worker is lost.
+     Its `chrome.storage.session` + `chrome.storage.local` dual-write is what
+     survives worker suspension; do not "simplify" it away.
+   - `_pacWithCompiler` and its `importScripts` hack should disappear with the
+     single-bundle PAC package.
+   - `proxy_impl.coffee` calls a bare global `OmegaPac`, relying on
+     `importScripts` ordering. Give it a real import.
+   - `tabs.coffee`, `web_request_monitor.coffee` and `inspect.coffee` are not
+     wired into the current build. Decide whether to revive or drop them rather
+     than porting them by reflex.
+   - The Firefox-only `proxy_impl_script` / `proxy_impl_listener` paths are dead
+     on Chromium; the comment forbidding bluebird in `onRequest` becomes moot
+     with native promises.
+3. **`packages/ui`** — editors for Pac, Switch, RuleList and Virtual profiles;
+   the rule table with drag reorder; the modal flows (new/rename/replace/delete);
+   options sync UI; the guided tours. The `switch_profile` controller was the
+   largest piece of the old UI (460 lines) and carries the attached-rule-list
+   logic, which is the subtlest part.
+4. **Build glue** — a manifest generator and a step to compile the `omega-locales`
+   `.po` catalogues into `_locales/*/messages.json`, replacing `grunt-po2crx`.
+5. **Delete the old packages** once the extension loads and is exercised.
+
+## Verification
+
+`packages/pac` behaviour is pinned by the ported suite. The important invariant
+is in `conditions.test.ts`: for every fixture, `match()` evaluated in-process and
+the compiled PAC expression evaluated as real JavaScript must agree. That is what
+makes replacing the code generator safe.
+
+Nothing has been loaded in a browser yet.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -129,6 +129,11 @@ Each is fixed in the rewrite and noted in a comment at the site.
   optional on a FixedProfile, so a profile without one threw.
 - `proxy_impl.coffee` referenced a free `OmegaPac` variable it never required.
   It worked only because the built worker happened to expose it as a global.
+- The `h()` DOM helper assigned every unrecognised key as a JS property, so
+  `aria-current` created a plain property instead of the attribute and the
+  `[aria-current="true"]` rule that highlights the active profile in the popup
+  never matched. Found only once the UI was added to the typecheck, which it
+  had never been in.
 - `fetch_url` compared the raw `Content-Type` header against a hint, so
   `text/html; charset=utf-8` never equalled `text/html`. Servers almost always
   send a charset, so the "response must not be HTML" guard silently never fired
@@ -190,6 +195,18 @@ SwitchySharp / external-extension bridges. `proxy_impl_script` and
 Note that this does not reduce idle memory: MV3 workers are already
 event-driven and terminate when idle. The 743 KB -> 30 KB PAC reduction is what
 actually addresses the cost that motivated the previous `af4efbe` work.
+
+## Surfaces
+
+The settings page is registered as a Chrome side panel
+(`side_panel.default_path`), and the popup's settings button opens it via
+`chrome.sidePanel.open`. `sidePanel` landed in Chrome 114, so
+`minimum_chrome_version` moved from 109 to 114.
+
+At panel width the sidebar collapses from a column into a horizontally
+scrollable strip of chips, and an "open in tab" button appears, since the rule
+tables are not usable at ~360px. The page is still registered as
+`options_page`/`options_ui`, so the full-tab route is unchanged.
 
 ## Remaining work
 

--- a/omega-pac/package-lock.json
+++ b/omega-pac/package-lock.json
@@ -1,0 +1,6997 @@
+{
+  "name": "omega-pac",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "omega-pac",
+      "version": "0.0.1",
+      "dependencies": {
+        "ip-address": "^4.0.0",
+        "tldjs": "^1.5.2",
+        "uglify-js": "^2.4.15"
+      },
+      "devDependencies": {
+        "chai": "~1.9.1",
+        "coffee-script": "^1.7.1",
+        "coffeeify": "^0.7.0",
+        "coffeelint": "^1.16.0",
+        "grunt": "^0.4.5",
+        "grunt-browserify": "^3.0.0",
+        "grunt-coffeelint": "^0.0.13",
+        "grunt-contrib-coffee": "^0.11.1",
+        "grunt-contrib-watch": "^0.6.1",
+        "grunt-mocha-test": "~0.11.0",
+        "load-grunt-config": "^0.13.1",
+        "lolex": "^1.4.0",
+        "minifyify": "^4.1.1"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/acorn": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+      "integrity": "sha512-fu2ygVGuMmlzG8ZeRJ0bvR41nsAkxxhbyk8bZ1SS521Z7vmgJFTQQlfz/Mp/nJexGBz+v8sC9bM6+lNgskt4Ug==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-node": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
+      "integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^7.0.0",
+        "acorn-walk": "^7.0.0",
+        "xtend": "^4.0.2"
+      }
+    },
+    "node_modules/acorn-node/node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha512-GrTZLRpmp6wIC2ztrWW9MjjTgSKccffgFagbNDOX95/dcjEcYZibYTeaOntySQLcdw1ztBoFkviiUvTMbb9MYg==",
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
+      "dev": true,
+      "license": "BSD-3-Clause OR MIT",
+      "engines": {
+        "node": ">=0.4.2"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+      "integrity": "sha512-LjmC2dNpdn2L4UzyoaIr11ELYoLn37ZFy9zObrQFHsSuOepeUEMKnM8w5KL4Tnrp2gy88rRuQt6Ky8Bjml+Baw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "underscore": "~1.7.0",
+        "underscore.string": "~2.4.0"
+      }
+    },
+    "node_modules/argparse/node_modules/underscore.string": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+      "integrity": "sha512-yxkabuCaIBnzfIvX3kBxQqCs0ar/bfJwDnFEHJUm/ZrRVhT3IItdRF5cZjARLzEnyQYtIUhsZ2LG2j3HidFOFQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/asn1.js": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/asn1.js/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/assert": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
+      "integrity": "sha512-5aKcpD+XnHpZ7EGxsuo6uoILNh0rvm0Ypa17GlkrF2CNSPhvdgi3ft9XsL2ajdVOI2I3xuGZnHvlXAeqTZYvXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "util": "0.10.3"
+      }
+    },
+    "node_modules/assert/node_modules/inherits": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+      "integrity": "sha512-8nWq2nLTAwd02jTqJExUYFSD/fKq6VH9Y/oG2accc/kdI0V98Bag8d5a4gi3XHz73rDWa2PvTtvcWYquKqSENA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/assert/node_modules/util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "integrity": "sha512-5KiHfsmkqacuKjkRkdV7SsfDJ2EGiPsK92s2MhNSY0craxjTdKTtqKsJaCWp4LW33ZZ0OPUv1WO/TFvNQRiQxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "2.0.1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
+      "integrity": "sha512-g/gZV+G476cnmtYI+Ko9d5khxSoCSoom/EaNmmCfwpOvBXEJ18qwFrxfP1/CsIqk2no1sAKKwxndV0tP7ROOFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/astw": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/astw/-/astw-2.2.0.tgz",
+      "integrity": "sha512-E/4z//dvN0lfr8zAx8hXeQ8o3nRoQaL/wqI7fAALEvh/40mnyUxfFB9MwyDHYKVDtS3cp3Pow5s96djZR5lkWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^4.0.3"
+      }
+    },
+    "node_modules/async": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+      "integrity": "sha512-2tEzliJmf5fHNafNwQLJXUasGzQCVctvsNkXmnlELHwypU0p08/rHohYvkqKIjyXpx+0rkrYv6QbhJ+UF4QkBg==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/async-each": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.6.tgz",
+      "integrity": "sha512-c646jH1avxr+aVpndVMeAfYw7wAa6idufrlN3LPA4PmKS0QEGp6PIC9nwz0WQkkvBGAMEki3pFdtxaF39J9vvg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true,
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/base/node_modules/define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+      "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/Base64": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
+      "integrity": "sha512-reGEWshDmTDQDsCec/HduOO9Wyj6yMOupMfhIf3ugN1TDlK2NQW4DDJSqNNtp380SNcvRfXtO8HSCQot0d0SMw==",
+      "dev": true
+    },
+    "node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/browser-pack": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-5.0.1.tgz",
+      "integrity": "sha512-BFMQuYXCcwr3Uvna1y1hikqd3r2dQpWIQBIN3m5YwE3ClfnXDeF3tqP6Wqjhs1LRUeBJpgHn8yD+fPX/YSEgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "combine-source-map": "~0.6.1",
+        "defined": "^1.0.0",
+        "JSONStream": "^1.0.3",
+        "through2": "^1.0.0",
+        "umd": "^3.0.0"
+      },
+      "bin": {
+        "browser-pack": "bin/cmd.js"
+      }
+    },
+    "node_modules/browser-resolve": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+      "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve": "1.1.7"
+      }
+    },
+    "node_modules/browser-resolve/node_modules/resolve": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+      "integrity": "sha512-9znBF0vBcaSN3W2j7wKvdERPwqTxSpCq+if5C0WoTCyV9n24rua28jeuQ2pL/HOf+yUe/Mef+H/5p60K0Id3bg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/browserify": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/browserify/-/browserify-10.2.6.tgz",
+      "integrity": "sha512-rhKmIuWDcE1ULm6lrd3kQdUTqFsLd/UJp3yYt4Ur5rDzk/Gj2AH6+ZTNqkaMqwMphkf8Rp83S1GfMxtu9QjGDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert": "~1.3.0",
+        "browser-pack": "^5.0.0",
+        "browser-resolve": "^1.7.1",
+        "browserify-zlib": "~0.1.2",
+        "buffer": "^3.0.0",
+        "builtins": "~0.0.3",
+        "commondir": "0.0.1",
+        "concat-stream": "~1.4.1",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "~0.0.1",
+        "crypto-browserify": "^3.0.0",
+        "defined": "^1.0.0",
+        "deps-sort": "^1.3.7",
+        "domain-browser": "~1.1.0",
+        "duplexer2": "~0.0.2",
+        "events": "~1.0.0",
+        "glob": "^4.0.5",
+        "has": "^1.0.0",
+        "htmlescape": "^1.1.0",
+        "http-browserify": "^1.4.0",
+        "https-browserify": "~0.0.0",
+        "inherits": "~2.0.1",
+        "insert-module-globals": "^6.4.1",
+        "isarray": "0.0.1",
+        "JSONStream": "^1.0.3",
+        "labeled-stream-splicer": "^1.0.0",
+        "module-deps": "^3.7.11",
+        "os-browserify": "~0.1.1",
+        "parents": "^1.0.1",
+        "path-browserify": "~0.0.0",
+        "process": "~0.11.0",
+        "punycode": "^1.3.2",
+        "querystring-es3": "~0.2.0",
+        "read-only-stream": "^1.1.1",
+        "readable-stream": "^1.1.13",
+        "resolve": "^1.1.4",
+        "shasum": "^1.0.0",
+        "shell-quote": "~0.0.1",
+        "stream-browserify": "^1.0.0",
+        "string_decoder": "~0.10.0",
+        "subarg": "^1.0.0",
+        "syntax-error": "^1.1.1",
+        "through2": "^1.0.0",
+        "timers-browserify": "^1.0.1",
+        "tty-browserify": "~0.0.0",
+        "url": "~0.10.1",
+        "util": "~0.10.1",
+        "vm-browserify": "~0.0.1",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "browserify": "bin/cmd.js"
+      }
+    },
+    "node_modules/browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/browserify-cipher": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      }
+    },
+    "node_modules/browserify-des": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/browserify-rsa": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
+      "integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^5.2.1",
+        "randombytes": "^2.1.0",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/browserify-sign": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.5.tgz",
+      "integrity": "sha512-C2AUdAJg6rlM2W5QMp2Q4KGQMVBwR1lIimTsUnutJ8bMpW5B52pGpR2gEnNBNwijumDo5FojQ0L9JrXA8m4YEw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "bn.js": "^5.2.2",
+        "browserify-rsa": "^4.1.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.6.1",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.9",
+        "readable-stream": "^2.3.8",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/browserify-sign/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/browserify-sign/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/browserify-sign/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/browserify-sign/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/browserify-sign/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+      "integrity": "sha512-19OEpq7vWgsH6WkvkBJQDFvJS1uPcbFOQ4v9CU839dO+ZZXUZO6XpE6hNCqvlIIj+4fZvRiJ6DsAQ382GwiyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~0.2.0"
+      }
+    },
+    "node_modules/browserify/node_modules/glob": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+      "integrity": "sha512-I0rTWUKSZKxPSIAIaqhSXTM/DiII6wame+rEC3cFA5Lqmr9YmdL7z6Hj9+bdWtTvoY1Su4/OiMLmb37Y7JzvJQ==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^2.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/browserify/node_modules/minimatch": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+      "integrity": "sha512-jQo6o1qSVLEWaw3l+bwYA2X0uLuK2KjNh2wjgO7Q/9UJnXr1Q3yQKR8BI0/Bt/rPg75e6SMW4hW/6cBHVTZUjA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/browserify/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.2.tgz",
+      "integrity": "sha512-c3M77NkHJxS0zx/ErxXhDLr1v3y2MDXPeTJPvLNOaIYJ4ymHBUFQ9EXzt9HYuqAJllMoNb/EZ8hIiulnQFAUuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/buffer/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/builtin-status-codes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/builtins": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
+      "integrity": "sha512-T8uCGKc0/2aLVt6omt8JxDRBoWEMkku+wFesxnhxnt4NygVZG99zqxo7ciK8eebszceKamGoUiLdkXCgGQyrQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cached-path-relative": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.1.0.tgz",
+      "integrity": "sha512-WF0LihfemtesFcJgO7xfOoOcnWzY/QHR4qeDqV44jPU3HTI54+LnfXK3SA27AVVGCdZFgjjFFaqUA9Jx7dMJZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha512-wzLkDa4K/mzI1OSITC+DUyjgIl/ETNHE9QvYgy6J6Jvqyyz4C0Xfd+lQhb19sX2jMpZV4IssUn0VDVmglV+s4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha512-Baz3aNe2gd2LP2qk5U+sDk/m4oSuwSDcBfayTCTBoWpfIGO5XFxPmjILQII4NGiZjD6DoDI6kf7gKaxkf7s3VQ==",
+      "license": "MIT",
+      "dependencies": {
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/chai": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-1.9.2.tgz",
+      "integrity": "sha512-olRoaitftnzWHFEAza6MXR4w+FfZrOVyV7r7U/Z8ObJefCgL8IuWkAuASJjSXrpP9wvgoL8+1dB9RbMLc2FkNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "1.0.0",
+        "deep-eql": "0.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+      "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "^2.0.0",
+        "async-each": "^1.0.1",
+        "braces": "^2.3.2",
+        "glob-parent": "^3.1.0",
+        "inherits": "^2.0.3",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "normalize-path": "^3.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.2.1",
+        "upath": "^1.1.1"
+      },
+      "optionalDependencies": {
+        "fsevents": "^1.2.7"
+      }
+    },
+    "node_modules/chokidar/node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cipher-base": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
+      "integrity": "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/class-utils/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/class-utils/node_modules/is-descriptor": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.8.tgz",
+      "integrity": "sha512-SceYGWXvdqlWa/OnQ5FQuV+NxvNmMRhMw/w9AHkH71hTzveND4BTYgvp16g+oITK47qbOl/3D0bl0iygehWAWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.1",
+        "is-data-descriptor": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/cli": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
+      "integrity": "sha512-4H6IzYk78R+VBeJ3fH3VQejcQRkGPR+kMjA9n30srEN+YVMPJLHfoQDtLquIzcLnfrlUrVA8qSQRB9fdgWpUBw==",
+      "dependencies": {
+        "exit": "0.1.2",
+        "glob": "~ 3.2.1"
+      },
+      "engines": {
+        "node": ">=0.2.5"
+      }
+    },
+    "node_modules/cli/node_modules/glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha512-hVb0zwEZwC1FXSKRPFTeOtN7AArJcJlI6ULGLtrstaswKNlrTJqAA+1lYlSUop4vjA423xlBzqfVS3iWGlqJ+g==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "BSD",
+      "dependencies": {
+        "inherits": "2",
+        "minimatch": "0.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cli/node_modules/minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha512-WFX1jI1AaxNTZVOHLBVazwTWKaQjoykSzCBNXB72vDTCzopQGtyP91tKdFK5cv1+qMwPyiTu1HqUriqplI8pcA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cliff": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/cliff/-/cliff-0.1.10.tgz",
+      "integrity": "sha512-roZWcC2Cxo/kKjRXw7YUpVNtxJccbvcl7VzTjUYgLQk6Ot0R8bm2netbhSZYWWNrKlOO/7HD6GXHl8dtzE6SiQ==",
+      "dependencies": {
+        "colors": "~1.0.3",
+        "eyes": "~0.1.8",
+        "winston": "0.8.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/cliff/node_modules/colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "integrity": "sha512-GIOYRizG+TGoc7Wgc1LiOTLare95R3mzKgoln+Q/lE4ceiYH19gUpl0l0Ffq4lJDEf3FxujMe6IBfOCs7pfqNA==",
+      "license": "ISC",
+      "dependencies": {
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
+        "wordwrap": "0.0.2"
+      }
+    },
+    "node_modules/cliui/node_modules/wordwrap": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+      "integrity": "sha512-xSBsCeh+g+dinoBv3GAOWM4LcVVO68wLXRanibtBSdUvkGWQRGeE9P7IwU9EmDDi4jA6L44lz15CGMwdw9N5+Q==",
+      "license": "MIT/X11",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/coffee-script": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
+      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/coffeeify": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/coffeeify/-/coffeeify-0.7.0.tgz",
+      "integrity": "sha512-4TYM0xE8hO8sj0omU6Y7EE4H75V4cslt3PwcycL+rN1RGoYorvzLGXTJeIuyw90JBmMKQUatXWERuNQt3GhXvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "coffee-script": "^1.7.1",
+        "convert-source-map": "^0.3.5",
+        "through": "^2.3.4"
+      }
+    },
+    "node_modules/coffeelint": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/coffeelint/-/coffeelint-1.16.2.tgz",
+      "integrity": "sha512-6mzgOo4zb17WfdrSui/cSUEgQ0AQkW3gXDht+6lHkfkqGUtSYKwGdGcXsDfAyuScVzTlTtKdfwkAlJWfqul7zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "coffee-script": "~1.11.0",
+        "glob": "^7.0.6",
+        "ignore": "^3.0.9",
+        "optimist": "^0.6.1",
+        "resolve": "^0.6.3",
+        "strip-json-comments": "^1.0.2"
+      },
+      "bin": {
+        "coffeelint": "bin/coffeelint"
+      },
+      "engines": {
+        "node": ">=0.8.0",
+        "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/coffeelint-stylish": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/coffeelint-stylish/-/coffeelint-stylish-0.1.2.tgz",
+      "integrity": "sha512-VcuzfB0bC9lvdvwckLzh3njKce68VVmOOXp0igyNl50D/uRLbFb4HSjQtTNGFEYiQ9Z0hjhfTqKe4v8UQxnngA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^1.0.0",
+        "text-table": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/coffeelint/node_modules/coffee-script": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.11.1.tgz",
+      "integrity": "sha512-NIWm59Fh1zkXq6TS6PQvSO3AR9DbGq1IBNZHa1E3fUCNmJhIwLf1YKcWgaHqaU7zWGC/OE2V7K3GVAXFzcmu+A==",
+      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha512-lNkKvzEeMBBjUGHZ+q6z9pSJla0KWAQPvtzhEV9+iGyQYG+pBpl7xKDhxoNSOZH2hhv0v5k0y2yAM4o4SjoSkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/colors": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+      "integrity": "sha512-OsSVtHK8Ir8r3+Fxw/b4jS1ZLPXkV6ZxDRJQzeD7qo0SqMXWrHDM71DgYzPMHY8SFJ0Ao+nNU2p1MmwdzKqPrw==",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/combine-source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
+      "integrity": "sha512-XKRNtuZRlVDTuSGKsfZpXYz80y0XDbYS4a+FzafTgmYHy/ckruFBx7Nd6WaQnFHVI3O6IseWVdXUvZutMpjSkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "convert-source-map": "~1.1.0",
+        "inline-source-map": "~0.5.0",
+        "lodash.memoize": "~3.0.3",
+        "source-map": "~0.4.2"
+      }
+    },
+    "node_modules/combine-source-map/node_modules/convert-source-map": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+      "integrity": "sha512-Y8L5rp6jo+g9VEPgvqNfEopjTR4OTYct8lXlS8iVQdmnjDvbdbzYe9rjtFCB9egC86JoNCU61WRY+ScjkZpnIg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz",
+      "integrity": "sha512-qebjpyeaA/nJ4w3EO2cV2++/zEkccPnjWogzA2rff+Lk8ILI75vULeTmyd4wPxWdKwtP3J+G39IXVZadh0UHyw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.x"
+      }
+    },
+    "node_modules/commondir": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
+      "integrity": "sha512-Ghe1LmLv3G3c0XJYu+c88MCRIPqWQ67qaqKY1KvuN4uPAjfUj+y4hvcpZ2kCPrjpRNyklW4dpAZZ8a7vOh50tg==",
+      "dev": true,
+      "license": "MIT/X11",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.11.tgz",
+      "integrity": "sha512-X3JMh8+4je3U1cQpG87+f9lXHDrqcb2MVLg9L7o8b1UZ0DzhRrUpdn65ttzu10PpJPPI3MQNkis+oha6TSA9Mw==",
+      "dev": true,
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "~1.1.9",
+        "typedarray": "~0.0.5"
+      }
+    },
+    "node_modules/console-browserify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+      "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
+      "dev": true
+    },
+    "node_modules/constants-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
+      "integrity": "sha512-FL+diDS9AKR5BAA2M+GNk8lnH64tRE3zepTG9hucxc7o04LgCRhkQZhF7u/OKHZT8LLRT+sZEi9qFzXUchq9pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
+      "integrity": "sha512-+4nRk0k3oEpwUB7/CalD7xE2z4VmtEnnq0GO2IPTkrooTrAhEsWvuLF5iWP1dXrwluki/azwXV1ve7gtYuPldg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-ecdh": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.5.3"
+      }
+    },
+    "node_modules/create-ecdh/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "node_modules/create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/crypto-browserify": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.1.tgz",
+      "integrity": "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browserify-cipher": "^1.0.1",
+        "browserify-sign": "^4.2.3",
+        "create-ecdh": "^4.0.4",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "diffie-hellman": "^5.0.3",
+        "hash-base": "~3.0.4",
+        "inherits": "^2.0.4",
+        "pbkdf2": "^3.1.2",
+        "public-encrypt": "^4.0.3",
+        "randombytes": "^2.1.0",
+        "randomfill": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha512-TVF6svNzeQCOpjCqsy0/CSy8VgObG3wXusJ73xW2GbG5rGx7lC8zxDSURicsXI2UsGdi2L0QNRCi745/wUDvsA==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dash-ast": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dash-ast/-/dash-ast-1.0.0.tgz",
+      "integrity": "sha512-Vy4dx7gquTeMcQR/hDkYLGUnwVil6vk4FOOct+djUnHOUWt+zJPJAaRIXaAFkPXtJjvlY7o3rfRu0/3hpnwoUA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dateformat": {
+      "version": "1.0.2-1.2.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+      "integrity": "sha512-AXvW8g7tO4ilk5HgOWeDmPi/ZPaCnMJ+9Cg1I3p19w6mcvAAXBuuGEXAxybC+Djj1PSZUiHUcyoYu7WneCX8gQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decode-uri-component": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha512-6sEotTRGBFiNcqVoeHwnfopbSpi5NbH1VWJmYCVkmxMmaVTT0bUTrNaGyBwhgP4MZL012W/mkzIn3Da+iDYweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "0.1.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/defined": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.1.tgz",
+      "integrity": "sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/deps-sort": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
+      "integrity": "sha512-aEnmQuu/Hf5h8akL8QshYWzk9MVBg/JYMyNq/Lz68i69nR17tunjP6o/AC6Tn48c8ayzG6aeKs6OoFOtVCtvrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "JSONStream": "^1.0.3",
+        "shasum": "^1.0.0",
+        "subarg": "^1.0.0",
+        "through2": "^1.0.0"
+      },
+      "bin": {
+        "deps-sort": "bin/cmd.js"
+      }
+    },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/detective": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
+      "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^5.2.1",
+        "defined": "^1.0.0"
+      }
+    },
+    "node_modules/detective/node_modules/acorn": {
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/diff": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.7.tgz",
+      "integrity": "sha512-0bTLzyr1S59cPsgAD/lR+ivvHTbgPb+k/mUR6WGqma1J6QDU+kUegI8uQFuH/cMUNK7JGN3Tk1Y5Jf2MO85WrA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/diffie-hellman": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      }
+    },
+    "node_modules/diffie-hellman/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/domain-browser": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+      "integrity": "sha512-fJ5MoHxe69h3E4/lJtFRhcWwLb04bhIBSfvCEMS1YDH+/9yEZTqBHTSTgch8nCP5tE5k2gdQEjodUqJzy7qJ9Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4",
+        "npm": ">=1.2"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexer2": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+      "integrity": "sha512-+AWBwjGadtksxjOQSFDhPNQbed7icNXApT4+2BNpsXzcCBiInq2H9XW0O8sfHFaPmnQRs7cg/P0fAr2IWQSW0g==",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "readable-stream": "~1.1.9"
+      }
+    },
+    "node_modules/elliptic": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/elliptic/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+      "integrity": "sha512-rp5dMKN8zEs9dfi9g0X1ClLmV//WRyk/R15mppFNICIFRG5P92VP7Z04p8pk++gABo9W2tY+kHyu6P1mEHgmTA==",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/eventemitter2": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "integrity": "sha512-K7J4xq5xAD5jHsGM5ReWXRTFa3JRGofHiMcVgQ8PRwgWxzjHpMWCIzsmyf60+mh8KLsqYPcjUMa0AC4hd6lPyQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/events": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz",
+      "integrity": "sha512-XK19KwlDJo8XsceooxNDK1pObtcT44+Xte6V/jQc4a+fHq1qEouThyyX2ePmS0hS8RcCulmRxzg+T8jiLKAFFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha512-w/ozOKR9Obk3qoWeY/WDi6MFta9AoMR+zud60mdnbniMcBxRuFJyDt2LdX/14A1UABeqk+Uk+LDfUpvoGKppZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expand-brackets/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/expand-brackets/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expand-brackets/node_modules/is-descriptor": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.8.tgz",
+      "integrity": "sha512-SceYGWXvdqlWa/OnQ5FQuV+NxvNmMRhMw/w9AHkH71hTzveND4BTYgvp16g+oITK47qbOl/3D0bl0iygehWAWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.1",
+        "is-data-descriptor": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/expand-brackets/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extglob/node_modules/define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+      "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==",
+      "engines": {
+        "node": "> 0.1.90"
+      }
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/faye-websocket": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz",
+      "integrity": "sha512-78pqrJbvGZSe8i+PLsPd+aJqTyGqgyWLnMw5NOwtXCTVMzEFh1zQPwIuIL/ycTj4rkDy5zZ9B6frYPqVPJBzyQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+      "integrity": "sha512-yjftfYnF4ThYEvKEV/kEFR15dmtyXTAh3vQnzpJUoc7Naj5y1P0Ck7Zs1+Vroa00E3KT3IYsk756S+8WA5dNLw==",
+      "dev": true,
+      "dependencies": {
+        "glob": "~3.2.9",
+        "lodash": "~2.4.1"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha512-hVb0zwEZwC1FXSKRPFTeOtN7AArJcJlI6ULGLtrstaswKNlrTJqAA+1lYlSUop4vjA423xlBzqfVS3iWGlqJ+g==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "inherits": "2",
+        "minimatch": "0.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/findup-sync/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/findup-sync/node_modules/minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha512-WFX1jI1AaxNTZVOHLBVazwTWKaQjoykSzCBNXB72vDTCzopQGtyP91tKdFK5cv1+qMwPyiTu1HqUriqplI8pcA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "map-cache": "^0.2.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.9.1.tgz",
+      "integrity": "sha512-yctbTOCHGDktj3eorstAjY0Z8WtbzoHlKKiUZRbX25b34BnuIGsdI9HG2dYO72kimROUPRgJhdSxlBRhDtEZqw==",
+      "dev": true,
+      "dependencies": {
+        "jsonfile": "~1.1.0",
+        "mkdirp": "^0.5.0",
+        "ncp": "^0.5.1",
+        "rimraf": "^2.2.8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "deprecated": "Upgrade to fsevents v2 to mitigate potential security issues",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1"
+      },
+      "engines": {
+        "node": ">= 4.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaze": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
+      "integrity": "sha512-3IWbXGkDDHFX8zIlNdfnmhvlSMhpBO6tDr4InB8fGku6dh/gjFPGNqcdsXJajZg05x9jRzXbL6gCnCnuMap4tw==",
+      "dev": true,
+      "dependencies": {
+        "globule": "~0.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/get-assigned-identifiers": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
+      "integrity": "sha512-mBBwmeGTrxEMO4pMaaf/uUEFHnYtwr8FTe8Y/mer4rcV/bye0qGm6pw1bGZFGStxC5O76c5ZAVBGnqHmOaJpdQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/getobject": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+      "integrity": "sha512-hIGEBfnHcZpWkXPsAVeVmpYDvfy/matVl03yOY91FPmnpCC12Lm5izNxCjO3lHAeO6uaTwMxu7g450Siknlhig==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
+      }
+    },
+    "node_modules/glob-parent/node_modules/is-glob": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+      "integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/globule": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+      "integrity": "sha512-3eIcA2OjPCm4VvwIwZPzIxCVssA8HSpM2C6c6kK5ufJH4FGwWoyqL3In19uuX4oe+TwH3w2P1nQDmW56iehO4A==",
+      "dev": true,
+      "dependencies": {
+        "glob": "~3.1.21",
+        "lodash": "~1.0.1",
+        "minimatch": "~0.2.11"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/globule/node_modules/glob": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+      "integrity": "sha512-ANhy2V2+tFpRajE3wN4DhkNQ08KDr0Ir1qL12/cUe5+a7STEK8jkW4onUYuY8/06qAFuT5je7mjAqzx0eKI2tQ==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "graceful-fs": "~1.2.0",
+        "inherits": "1",
+        "minimatch": "~0.2.11"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/globule/node_modules/graceful-fs": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+      "integrity": "sha512-iiTUZ5vZ+2ZV+h71XAgwCSu6+NAizhFU3Yw8aC/hH5SQ3SnISqEqAek40imAFGtDcwJKNhXvSY+hzIolnLwcdQ==",
+      "deprecated": "please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js",
+      "dev": true,
+      "license": "BSD",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/globule/node_modules/inherits": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+      "integrity": "sha512-Al67oatbRSo3RV5hRqIoln6Y5yMVbJSIn4jEJNL7VCImzq/kLr7vvb6sFRJXqr8rpHc/2kJOM+y0sPKN47VdzA==",
+      "dev": true
+    },
+    "node_modules/globule/node_modules/lodash": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+      "integrity": "sha512-0VSEDVec/Me2eATuoiQd8IjyBMMX0fahob8YJ96V1go2RjvCk1m1GxmtfXn8RNSaLaTtop7fsuhhu9oLk3hUgA==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/globule/node_modules/minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha512-zZ+Jy8lVWlvqqeM8iZB7w7KmQkoJn8djM585z88rywrEbzoqawVa9FR5p2hwD+y74nfuKOjmNvi9gtWJNLqHvA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/growl": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz",
+      "integrity": "sha512-VWv7s1EI41AG2LiCr7uAuxWikLDN1SQOuEUc37d/P34NAIIYgkvWYngNw0d9d9iCrDFL0SYCE9UQpxhIjjtuLg==",
+      "dev": true
+    },
+    "node_modules/grunt": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+      "integrity": "sha512-1iq3ylLjzXqz/KSq1OAE2qhnpcbkF2WyhsQcavZt+YmgvHu0EbPMEhGhy2gr0FP67isHpRdfwjB5WVeXXcJemQ==",
+      "dev": true,
+      "dependencies": {
+        "async": "~0.1.22",
+        "coffee-script": "~1.3.3",
+        "colors": "~0.6.2",
+        "dateformat": "1.0.2-1.2.3",
+        "eventemitter2": "~0.4.13",
+        "exit": "~0.1.1",
+        "findup-sync": "~0.1.2",
+        "getobject": "~0.1.0",
+        "glob": "~3.1.21",
+        "grunt-legacy-log": "~0.1.0",
+        "grunt-legacy-util": "~0.2.0",
+        "hooker": "~0.2.3",
+        "iconv-lite": "~0.2.11",
+        "js-yaml": "~2.0.5",
+        "lodash": "~0.9.2",
+        "minimatch": "~0.2.12",
+        "nopt": "~1.0.10",
+        "rimraf": "~2.2.8",
+        "underscore.string": "~2.2.1",
+        "which": "~1.0.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/grunt-browserify": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/grunt-browserify/-/grunt-browserify-3.8.0.tgz",
+      "integrity": "sha512-0wnAp/xFi/BKSEVRGR7ktaEnCXsRW+yWjVrKj1x+dwWKjRFMQt2nl1Rh5rpwbDuOYATOpYkbuOv6fDi0avxV0Q==",
+      "dev": true,
+      "dependencies": {
+        "async": "^0.9.0",
+        "browserify": "^10.0.0",
+        "glob": "^5.0.5",
+        "lodash": "^3.8.0",
+        "resolve": "^1.1.6",
+        "watchify": "^3.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.x"
+      }
+    },
+    "node_modules/grunt-browserify/node_modules/async": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+      "integrity": "sha512-l6ToIJIotphWahxxHyzK9bnLR6kM4jJIIgLShZeqLY7iboHoGkdgFl7W2/Ivi4SkMJYGKqW8vSuk0uKUj6qsSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/grunt-browserify/node_modules/glob": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+      "integrity": "sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/grunt-browserify/node_modules/lodash": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "integrity": "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/grunt-browserify/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/grunt-coffeelint": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/grunt-coffeelint/-/grunt-coffeelint-0.0.13.tgz",
+      "integrity": "sha512-AjoY762pHh703irpowkm45FkrWlDuNAcEo6PdfCMPFClV0+vPeoipeuq/qCSEQmklXtuOpnWrH+lwatrTBzVYg==",
+      "dev": true,
+      "dependencies": {
+        "coffeelint-stylish": "~0.1.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "peerDependencies": {
+        "coffeelint": "^1",
+        "grunt": "~0.4"
+      }
+    },
+    "node_modules/grunt-contrib-coffee": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-coffee/-/grunt-contrib-coffee-0.11.1.tgz",
+      "integrity": "sha512-Gu8BMXbVns+Zfyy4DiGOnYpEd4Ac6YIZzA24FzxLbNQqupxgk6EKk8YibXXd3umn/1KXcrSNGXjDyAJPIAlhHw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "~0.5.0",
+        "coffee-script": "~1.7.0",
+        "lodash": "~2.4.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "peerDependencies": {
+        "grunt": "~0.4.0"
+      }
+    },
+    "node_modules/grunt-contrib-coffee/node_modules/ansi-regex": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+      "integrity": "sha512-sGwIGMjhYdW26/IhwK2gkWWI8DRCVO6uj3hYgHT+zD+QL1pa37tM3ujhyfcJIYSbsxp7Gxhy7zrRW/1AHm4BmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/grunt-contrib-coffee/node_modules/ansi-styles": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+      "integrity": "sha512-f2PKUkN5QngiSemowa6Mrk9MPCdtFiOSmibjZ+j1qhLGHHYsqZwmBMRF3IRMVXo8sybDqx2fJl2d/8OphBoWkA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/grunt-contrib-coffee/node_modules/chalk": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+      "integrity": "sha512-bIKA54hP8iZhyDT81TOsJiQvR1gW+ZYSXFaZUAvoD4wCHdbHY2actmpTE4x344ZlFqHbvoxKOaESULTZN2gstg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^1.1.0",
+        "escape-string-regexp": "^1.0.0",
+        "has-ansi": "^0.1.0",
+        "strip-ansi": "^0.3.0",
+        "supports-color": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/grunt-contrib-coffee/node_modules/coffee-script": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.7.1.tgz",
+      "integrity": "sha512-W3s+SROY73OmrSGtPTTW/2wp2rmW5vuh0/tUuCK1NvTuyzLOVPccIP9whmhZ4cYWcr2NJPNENZIFaAMkTD5G3w==",
+      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mkdirp": "~0.3.5"
+      },
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/grunt-contrib-coffee/node_modules/has-ansi": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+      "integrity": "sha512-1YsTg1fk2/6JToQhtZkArMkurq8UoWU1Qe0aR3VUHjgij4nOylSWLWAtBXoZ4/dXOmugfLGm1c+QhuD0JyedFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^0.2.0"
+      },
+      "bin": {
+        "has-ansi": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/grunt-contrib-coffee/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/grunt-contrib-coffee/node_modules/mkdirp": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+      "integrity": "sha512-8OCq0De/h9ZxseqzCH8Kw/Filf5pF/vMI6+BH7Lu0jXz2pqYCjTAQRolSxRIi+Ax+oCCjlxoJMP0YQ4XlrQNHg==",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/grunt-contrib-coffee/node_modules/strip-ansi": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+      "integrity": "sha512-DerhZL7j6i6/nEnVG0qViKXI0OKouvvpsAiaj7c+LfqZZZxdwZtv8+UiA/w4VUJpT8UzX0pR1dcHOii1GbmruQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^0.2.1"
+      },
+      "bin": {
+        "strip-ansi": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/grunt-contrib-coffee/node_modules/supports-color": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+      "integrity": "sha512-tdCZ28MnM7k7cJDJc7Eq80A9CsRFAAOZUy41npOZCs++qSjfIy7o5Rh46CBk+Dk5FbKJ33X3Tqg4YrV07N5RaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "supports-color": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/grunt-contrib-watch": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-0.6.1.tgz",
+      "integrity": "sha512-Ea4f3anehA6G+S88vyTwewA/Mf6SbadTIxSgQClKbZYnHOcJ0PrGc2p+uzR6hS9gp7DG6ObvaxkmE8HKnLOsfA==",
+      "dev": true,
+      "dependencies": {
+        "async": "~0.2.9",
+        "gaze": "~0.5.1",
+        "lodash": "~2.4.1",
+        "tiny-lr-fork": "0.0.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "peerDependencies": {
+        "grunt": "~0.4.0"
+      }
+    },
+    "node_modules/grunt-contrib-watch/node_modules/async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ==",
+      "dev": true
+    },
+    "node_modules/grunt-contrib-watch/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/grunt-legacy-log": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
+      "integrity": "sha512-qYs/uM0ImdzwIXLhS4O5WLV5soAM+PEqqHI/hzSxlo450ERSccEhnXqoeDA9ZozOdaWuYnzTOTwRcVRogleMxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colors": "~0.6.2",
+        "grunt-legacy-log-utils": "~0.1.1",
+        "hooker": "~0.2.3",
+        "lodash": "~2.4.1",
+        "underscore.string": "~2.3.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/grunt-legacy-log-utils": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
+      "integrity": "sha512-D0vbUX00TFYCKNZtcZzemMpwT8TR/FdRs1pmfiBw6qnUw80PfsjV+lhIozY/3eJ3PSG2zj89wd2mH/7f4tNAlw==",
+      "dev": true,
+      "dependencies": {
+        "colors": "~0.6.2",
+        "lodash": "~2.4.1",
+        "underscore.string": "~2.3.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/grunt-legacy-log-utils/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/grunt-legacy-log-utils/node_modules/underscore.string": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+      "integrity": "sha512-hbD5MibthuDAu4yA5wxes5bzFgqd3PpBJuClbRxaNddxfdsz+qf+1kHwrGQFrmchmDHb9iNU+6EHDn8uj0xDJg==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/grunt-legacy-log/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/grunt-legacy-log/node_modules/underscore.string": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+      "integrity": "sha512-hbD5MibthuDAu4yA5wxes5bzFgqd3PpBJuClbRxaNddxfdsz+qf+1kHwrGQFrmchmDHb9iNU+6EHDn8uj0xDJg==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/grunt-legacy-util": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+      "integrity": "sha512-cXPbfF8aM+pvveQeN1K872D5fRm30xfJWZiS63Y8W8oyIPLClCsmI8bW96Txqzac9cyL4lRqEBhbhJ3n5EzUUQ==",
+      "dev": true,
+      "dependencies": {
+        "async": "~0.1.22",
+        "exit": "~0.1.1",
+        "getobject": "~0.1.0",
+        "hooker": "~0.2.3",
+        "lodash": "~0.9.2",
+        "underscore.string": "~2.2.1",
+        "which": "~1.0.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/grunt-mocha-test": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/grunt-mocha-test/-/grunt-mocha-test-0.11.0.tgz",
+      "integrity": "sha512-BDffDt8Y724rbeUhSg3GZdhTx918hJ5WoHRdW3uXCIYNxeySoECjkmTiAEf2tHp6GYwW5sMKXk2jTqCU/LbajA==",
+      "dev": true,
+      "dependencies": {
+        "fs-extra": "~0.9.1",
+        "hooker": "~0.2.3",
+        "mocha": "~1.20.0"
+      },
+      "engines": {
+        "node": ">= 0.10.4"
+      }
+    },
+    "node_modules/grunt/node_modules/coffee-script": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+      "integrity": "sha512-QjQ1T4BqyHv19k6XSfdhy/QLlIOhywz0ekBUCa9h71zYMJlfDTGan/Z1JXzYkZ6v8R+GhvL/p4FZPbPW8WNXlg==",
+      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
+      "dev": true,
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/grunt/node_modules/glob": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+      "integrity": "sha512-ANhy2V2+tFpRajE3wN4DhkNQ08KDr0Ir1qL12/cUe5+a7STEK8jkW4onUYuY8/06qAFuT5je7mjAqzx0eKI2tQ==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "graceful-fs": "~1.2.0",
+        "inherits": "1",
+        "minimatch": "~0.2.11"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/grunt/node_modules/graceful-fs": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+      "integrity": "sha512-iiTUZ5vZ+2ZV+h71XAgwCSu6+NAizhFU3Yw8aC/hH5SQ3SnISqEqAek40imAFGtDcwJKNhXvSY+hzIolnLwcdQ==",
+      "deprecated": "please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js",
+      "dev": true,
+      "license": "BSD",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/grunt/node_modules/inherits": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+      "integrity": "sha512-Al67oatbRSo3RV5hRqIoln6Y5yMVbJSIn4jEJNL7VCImzq/kLr7vvb6sFRJXqr8rpHc/2kJOM+y0sPKN47VdzA==",
+      "dev": true
+    },
+    "node_modules/grunt/node_modules/minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha512-zZ+Jy8lVWlvqqeM8iZB7w7KmQkoJn8djM585z88rywrEbzoqawVa9FR5p2hwD+y74nfuKOjmNvi9gtWJNLqHvA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
+      "integrity": "sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha512-IBXk4GTsLYdQ7Rvt+GRBrFSVEkmuOUy4re0Xjd9kJSUQpnTrWR4/y9RpfexN9vkAPMFuQoeWKwqzPozRTlasGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha512-ODYZC64uqzmtfGMEAX/FvZiRyWLpAC3vYnNunURUnkGVTS+mI0smVsWaPydRBsE3g+ok7h960jChO8mFcWlHaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-values/node_modules/kind-of": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+      "integrity": "sha512-24XsCxmEbRwEDbz/qz3stgin8TTzZ1ESR56OMCN0ujYg+vRutNSiOj9bHH9u85DKgXguraugV5sFuvbD4FW/hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/hash-base": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.5.tgz",
+      "integrity": "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/hooker": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+      "integrity": "sha512-t+UerCsQviSymAInD01Pw+Dn/usmz1sRO+3Zk1+lx8eg+WKpD2ulcwWqHHL0+aseRBr+3+vIhiG1K1JTwaIcTA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/htmlescape": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
+      "integrity": "sha512-eVcrzgbR4tim7c7soKQKtxa/kQM4TzjnlU83rcZ9bHU6t31ehfV7SktN6McWgwPWg+JYMA/O3qpGxBvFq1z2Jg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/http-browserify": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
+      "integrity": "sha512-Irf/LJXmE3cBzU1eaR4+NEX6bmVLqt1wkmDiA7kBwH7zmb0D8kBAXsDmQ88hhj/qv9iEZKlyGx/hrMcFi8sOHw==",
+      "dev": true,
+      "license": "MIT/X11",
+      "dependencies": {
+        "Base64": "~0.2.0",
+        "inherits": "~2.0.1"
+      }
+    },
+    "node_modules/https-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
+      "integrity": "sha512-EjDQFbgJr1vDD/175UJeSX3ncQ3+RUnCL5NkthQGHvF4VNHlzTy8ifJfTqz47qiPRqaFH58+CbuG3x51WuB1XQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+      "integrity": "sha512-KhmFWgaQZY83Cbhi+ADInoUQ8Etn6BG5fikM9syeOjQltvR45h7cRKJ/9uvQEuD61I3Uju77yYce0/LhKVClQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg==",
+      "dev": true
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/inline-source-map": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz",
+      "integrity": "sha512-2WtHG0qX9OH9TVcxsLVfq3Tzr+qtL6PtWgoh0XAAKe4KkdA/57Q+OGJuRJHA4mZ2OZnkJ/ZAaXf9krLB12/nIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "~0.4.0"
+      }
+    },
+    "node_modules/insert-module-globals": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.3.tgz",
+      "integrity": "sha512-ryk8hTKUZCc300SPOOwx30WhE5oRUssPDVlIoO8vtoMNBy5HGeesVRl3HF7ra4ll42T0IdnwD9XR9svh6+RRhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "combine-source-map": "~0.6.1",
+        "concat-stream": "~1.4.1",
+        "is-buffer": "^1.1.0",
+        "JSONStream": "^1.0.3",
+        "lexical-scope": "^1.2.0",
+        "process": "~0.11.0",
+        "through2": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "insert-module-globals": "bin/cmd.js"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-4.2.0.tgz",
+      "integrity": "sha512-MPkX8eVcV/BrfS2fyTpxPE1ZUpHXLqhjHTltEwrEtTK2ZviG0Y7Xs98yOPwgxzndhRSfRW5jeGK7gZqQZ9ZFZA==",
+      "license": "MIT",
+      "dependencies": {
+        "cli": "0.6.x",
+        "cliff": "0.1.x",
+        "jsbn": "0.0.0",
+        "lodash.find": "^3.2.0",
+        "lodash.merge": "^3.2.1",
+        "sprintf": "0.1.x"
+      },
+      "bin": {
+        "ipv6": "bin/ipv6.js",
+        "ipv6grep": "bin/ipv6grep.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-accessor-descriptor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.2.tgz",
+      "integrity": "sha512-AIbwAcazqP3R65dGvqk1V+a+vE5Fg1yu/ZKMOiBWSUIXXiwQkYmXQcVa2O0nh0tSDKDFKxG2mY7dB1Sr4hEP1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "integrity": "sha512-9fRVlXc0uCxEDj1nQzaWONSpbTfx0FmJfzHF7pwlI8DkWGoHBBea4Pg5Ky0ojwwxQmnSifgbKkI06Qv0Ljgj+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT"
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-descriptor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.1.tgz",
+      "integrity": "sha512-bc4NlCDiCr28U4aEsQ3Qs2491gVq4V8G7MQyws968ImqjKuYtTJXrl7Vq7jsN7Ly/C3xj5KWFrY7sHNeDkAzXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-descriptor": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.4.tgz",
+      "integrity": "sha512-bv5z95W0dDtLfKwDfkTNxaRxmISBD3eQBKJeVxv2AQ7MjuUnDNG7cIQqvFtMOUYhsILWHhMayWdoGqNqYYYjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.2",
+        "is-data-descriptor": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+      "license": "MIT"
+    },
+    "node_modules/jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha512-mkk3vzUHFjzKjpCXeu+IjXeZD+QOTjUUdubgmHtHTDwvAO2ZTkMTTVrapts5CWz3JvJryh/4KWZpjeZrCepZ3A==",
+      "deprecated": "Jade has been renamed to pug, please install the latest version of pug instead of jade",
+      "dev": true,
+      "dependencies": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "bin": {
+        "jade": "bin/jade"
+      }
+    },
+    "node_modules/jade/node_modules/commander": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+      "integrity": "sha512-0fLycpl1UMTGX257hRsu/arL/cUbcvQM4zMKwvLvzXtfdezIV4yotPS2dYtknF+NmEfWSoCEF6+hj9XLm/6hEw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.x"
+      }
+    },
+    "node_modules/jade/node_modules/mkdirp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+      "integrity": "sha512-OHsdUcVAQ6pOtg5JYWpCBo9W/GySVuwvP9hueRMW7UqshC0tbfzLv8wjySTPm3tfUZ/21CE9E1pJagOA91Pxew==",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "dev": true,
+      "license": "MIT/X11",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/jit-grunt": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/jit-grunt/-/jit-grunt-0.8.0.tgz",
+      "integrity": "sha512-mJ80LXh3rDLhlLMhqZsLu38QZlUR2bKrnT993DnlcvKSECKdt3/1+MNoMaUV8jbKIw16EdxODMPTuLsC8rGg/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      },
+      "peerDependencies": {
+        "grunt": "~0.4.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+      "integrity": "sha512-VEKcIksckDBUhg2JS874xVouiPkywVUh4yyUmLCDe1Zg3bCd6M+F1eGPenPeHLc2XC8pp9G8bsuofK0NeEqRkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "~ 0.1.11",
+        "esprima": "~ 1.0.2"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/jsbn": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.0.0.tgz",
+      "integrity": "sha512-0QJ9Y7EnU2hLfA/xQYrCbJGGIb+eI7qbDVkWIyaKMLpE9EqLA9NUJkvqWagQs4Rl+WndRP+HycMgw2Cfoe0tww==",
+      "license": "BSD"
+    },
+    "node_modules/json-stable-stringify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+      "integrity": "sha512-nKtD/Qxm7tWdZqJoldEC7fF0S41v0mWbeaXG3637stOWfyGxTgWTYE2wtfKmjzpvxv2MA2xzxsXOIiwUpkX6Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsonify": "~0.0.0"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-1.1.1.tgz",
+      "integrity": "sha512-yrmo536TrJWDHNYlkCjtkPSqNnAkt6u1k89O5Xxr53zc4DkdikTHE+Fx6VF7syJd18xsdo24U4csedAkhLgxVQ==",
+      "dev": true
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      },
+      "bin": {
+        "JSONStream": "bin.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/labeled-stream-splicer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
+      "integrity": "sha512-3KBjPRnXrYC5h2jEf/d6hO7Lcl+38QzRVTOyHA2sFzZVMYwsUFuejlrOMwAjmz13hVBr9ruDS1RwE4YEz8P58w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "isarray": "~0.0.1",
+        "stream-splicer": "^1.1.0"
+      }
+    },
+    "node_modules/lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lexical-scope": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
+      "integrity": "sha512-ntJ8IcBCuKwudML7vAuT/L0aIMU0+9vO25K4CjLPYgzf1NZ0bAhJJBZrvkO+oUGgKcbdkH8UZdRsaEg+wULLRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "astw": "^2.0.0"
+      }
+    },
+    "node_modules/load-grunt-config": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/load-grunt-config/-/load-grunt-config-0.13.2.tgz",
+      "integrity": "sha512-8rtJvmyRxZwZ5+dYJChdOljF457OEEEIfv4JT8Qsp3TX0Pcoq2y8KRukbrC0bujyh8tv38cx0CrbSsEeFR9Xhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "~0.2.10",
+        "glob": "~3.2.6",
+        "jit-grunt": "~0.8.0",
+        "js-yaml": "~3.0.1",
+        "load-grunt-tasks": "~0.3.0",
+        "lodash-node": "~2.4.1"
+      }
+    },
+    "node_modules/load-grunt-config/node_modules/async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ==",
+      "dev": true
+    },
+    "node_modules/load-grunt-config/node_modules/glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha512-hVb0zwEZwC1FXSKRPFTeOtN7AArJcJlI6ULGLtrstaswKNlrTJqAA+1lYlSUop4vjA423xlBzqfVS3iWGlqJ+g==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "inherits": "2",
+        "minimatch": "0.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/load-grunt-config/node_modules/js-yaml": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.2.tgz",
+      "integrity": "sha512-8PVwV1480dnAPMj8FCW3I/mZZ+gvtOoMAZFWJKagkFq2eWv5kcyzWTR+6MloV0SY57t6jSIaKc7DIz86K9ZCfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "~ 0.1.11",
+        "esprima": "~ 1.0.2"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/load-grunt-config/node_modules/minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha512-WFX1jI1AaxNTZVOHLBVazwTWKaQjoykSzCBNXB72vDTCzopQGtyP91tKdFK5cv1+qMwPyiTu1HqUriqplI8pcA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/load-grunt-tasks": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-0.3.0.tgz",
+      "integrity": "sha512-bgZqR+scmG37RTcJbZgXbH6pfohQl2F7j5wVqNHXS35B280LQKvI5ftMik0Q5qMR8tTecWEtLVNLRdSQGtQeWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "findup-sync": "~0.1.2",
+        "globule": "~0.2.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/load-grunt-tasks/node_modules/glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha512-hVb0zwEZwC1FXSKRPFTeOtN7AArJcJlI6ULGLtrstaswKNlrTJqAA+1lYlSUop4vjA423xlBzqfVS3iWGlqJ+g==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "inherits": "2",
+        "minimatch": "0.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/load-grunt-tasks/node_modules/glob/node_modules/minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha512-WFX1jI1AaxNTZVOHLBVazwTWKaQjoykSzCBNXB72vDTCzopQGtyP91tKdFK5cv1+qMwPyiTu1HqUriqplI8pcA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/load-grunt-tasks/node_modules/globule": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-0.2.0.tgz",
+      "integrity": "sha512-mMhYxzb8wpE7VtHkJi+jk0yjlBLFetYMAnkcFutmDo4uSFAHu/1tLgVm9Y6HcaTaX1DZBJjZOM1KqqCZDvBLBw==",
+      "dev": true,
+      "dependencies": {
+        "glob": "~3.2.7",
+        "lodash": "~2.4.1",
+        "minimatch": "~0.2.11"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/load-grunt-tasks/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/load-grunt-tasks/node_modules/minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha512-zZ+Jy8lVWlvqqeM8iZB7w7KmQkoJn8djM585z88rywrEbzoqawVa9FR5p2hwD+y74nfuKOjmNvi9gtWJNLqHvA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+      "integrity": "sha512-LVbt/rjK62gSbhehDVKL0vlaime4Y1IBixL+bKeNfoY4L2zab/jGrxU6Ka05tMA/zBxkTk5t3ivtphdyYupczw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/lodash-node": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz",
+      "integrity": "sha512-egEt8eNQp2kZWRmngahiqMoDCDCENv3uM188S7Ed5t4k3v6RrLELXC+FqLNMUnhCo7gvQX3G1V8opK/Lcslahg==",
+      "deprecated": "This package is discontinued. Use lodash@^4.0.0.",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash._arraycopy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+      "integrity": "sha512-RHShTDnPKP7aWxlvXKiDT6IX2jCs6YZLCtNhOru/OX2Q/tzX295vVBK5oX1ECtN+2r86S0Ogy8ykP1sgCZAN0A==",
+      "license": "MIT"
+    },
+    "node_modules/lodash._arrayeach": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
+      "integrity": "sha512-Mn7HidOVcl3mkQtbPsuKR0Fj0N6Q6DQB77CtYncZcJc0bx5qv2q4Gl6a0LC1AN+GSxpnBDNnK3CKEm9XNA4zqQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash._basebind": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz",
+      "integrity": "sha512-VGHm6DH+1UiuafQdE/DNMqxOcSyhRu0xO9+jPDq7xITRn5YOorGrHVQmavMVXCYmTm80YRTZZCn/jTW7MokwLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._basecreate": "~2.4.1",
+        "lodash._setbinddata": "~2.4.1",
+        "lodash._slice": "~2.4.1",
+        "lodash.isobject": "~2.4.1"
+      }
+    },
+    "node_modules/lodash._basecallback": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecallback/-/lodash._basecallback-3.3.1.tgz",
+      "integrity": "sha512-LQffghuO63ufDY33KKO1ezGKbcFZK3ngYV7JpxaUomoM5acf0YeXU3Pm8csVE0girVs50TXzfNibl69Co3ggJA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash._baseisequal": "^3.0.0",
+        "lodash._bindcallback": "^3.0.0",
+        "lodash.isarray": "^3.0.0",
+        "lodash.pairs": "^3.0.0"
+      }
+    },
+    "node_modules/lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha512-rFR6Vpm4HeCK1WPGvjZSJ+7yik8d8PVUdCJx5rT2pogG4Ve/2ZS7kfmO5l5T2o5V2mqlNIfSF5MZlr1+xOoYQQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash._basecreate": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+      "integrity": "sha512-8JJ3FnMPm54t3BwPLk8q8mPyQKQXm/rt9df+awr4NGtyJrtcCXM3Of1I86S6jVy1b4yAyFBb8wbKPEauuqzRmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._isnative": "~2.4.1",
+        "lodash.isobject": "~2.4.1",
+        "lodash.noop": "~2.4.1"
+      }
+    },
+    "node_modules/lodash._basecreatecallback": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz",
+      "integrity": "sha512-SLczhg860fGW7AKlYcuOFstDtJuQhaANlJ4Y/jrOoRxhmVtK41vbJDH3OefVRSRkSCQo4HI82QVkAVsoGa5gSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._setbinddata": "~2.4.1",
+        "lodash.bind": "~2.4.1",
+        "lodash.identity": "~2.4.1",
+        "lodash.support": "~2.4.1"
+      }
+    },
+    "node_modules/lodash._basecreatewrapper": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz",
+      "integrity": "sha512-x2ja1fa/qmzbizuXgVM4QAP9svtMbdxjG8Anl9bCeDAwLOVQ1vLrA0hLb/NkpbGi9evjtkl0aWLTEoOlUdBPQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._basecreate": "~2.4.1",
+        "lodash._setbinddata": "~2.4.1",
+        "lodash._slice": "~2.4.1",
+        "lodash.isobject": "~2.4.1"
+      }
+    },
+    "node_modules/lodash._baseeach": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz",
+      "integrity": "sha512-IqUZ9MQo2UT1XPGuBntInqTOlc+oV+bCo0kMp+yuKGsfvRSNgUW0YjWVZUrG/gs+8z/Eyuc0jkJjOBESt9BXxg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.keys": "^3.0.0"
+      }
+    },
+    "node_modules/lodash._basefind": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._basefind/-/lodash._basefind-3.0.0.tgz",
+      "integrity": "sha512-OCYxW9f0nMWjRaJyvGxrM/x/xGZTIYEiz+PyFux4YIZr7DtXLQpmCc6aDJdhPA1vnnsrY+N7BvS76hAdlnGHfg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash._basefindindex": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/lodash._basefindindex/-/lodash._basefindindex-3.6.0.tgz",
+      "integrity": "sha512-Ay3Ok74tVwGB79L5lVZlVgpGYjV9ty8DEVPxIUhgGGkqrqk6I+BPJ5kUIxd5S1b2Qg03VXtdg/Dpv2zcwQReoA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash._basefor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+      "integrity": "sha512-6bc3b8grkpMgDcVJv9JYZAk/mHgcqMljzm7OsbmcE2FGUMmmLQTPHlh/dFqR8LA0GQ7z4K67JSotVKu5058v1A==",
+      "license": "MIT"
+    },
+    "node_modules/lodash._baseisequal": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
+      "integrity": "sha512-U+3GsNEZj9ebI03ncLC2pLmYVjgtYZEwdkAPO7UGgtGvAz36JVFPAQUufpSaVL93Cz5arc6JGRKZRhaOhyVJYA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.isarray": "^3.0.0",
+        "lodash.istypedarray": "^3.0.0",
+        "lodash.keys": "^3.0.0"
+      }
+    },
+    "node_modules/lodash._bindcallback": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+      "integrity": "sha512-2wlI0JRAGX8WEf4Gm1p/mv/SZ+jLijpj0jyaE/AXeuQphzCgD8ZQW4oSpoN8JAopujOFGU3KMuq7qfHBWlGpjQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash._createassigner": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+      "integrity": "sha512-LziVL7IDnJjQeeV95Wvhw6G28Z8Q6da87LWKOPWmzBLv4u6FAT/x5v00pyGW0u38UoogNF2JnD3bGgZZDaNEBw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash._bindcallback": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0",
+        "lodash.restparam": "^3.0.0"
+      }
+    },
+    "node_modules/lodash._createwrapper": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz",
+      "integrity": "sha512-5TCfLt1haQpsa7bgLYRKNNE4yqhO4ZxIayN1btQmazMchO6Q8JYFRMqbJ3W+uNmMm4R0Jw7KGkZX5YfDDnywuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._basebind": "~2.4.1",
+        "lodash._basecreatewrapper": "~2.4.1",
+        "lodash._slice": "~2.4.1",
+        "lodash.isfunction": "~2.4.1"
+      }
+    },
+    "node_modules/lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha512-RrL9VxMEPyDMHOd9uFbvMe8X55X16/cGM5IgOKgRElQZutpX89iS6vwl64duTV1/16w5JY7tuFNXqoekmh1EmA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha512-De+ZbrMu6eThFti/CSzhRvTKMgQToLxbij58LMfM8JnYDNSOjkjTCIaa8ixglOeGh2nyPlakbt5bJWJ7gvpYlQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash._isnative": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+      "integrity": "sha512-BOlKGKNHhCHswGOWtmVb5zBygyxN7EmTuzVOSQI6QSoGhG+kvv71gICFS1TBpnqvT1n53txK8CDK3u5D2/GZxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash._objecttypes": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+      "integrity": "sha512-XpqGh1e7hhkOzftBfWE7zt+Yn9mVHFkDhicVttvKLsoCMLVVL+xTQjfjB4X4vtznauxv0QZ5ZAeqjvat0dh62Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash._setbinddata": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
+      "integrity": "sha512-Vx0XKzpg2DFbQw4wrp1xSWd2sfl3W/BG6bucSRZmftS1AzbWRemCmBQDxyQTNhlLNec428PXkuuja+VNBZgu2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._isnative": "~2.4.1",
+        "lodash.noop": "~2.4.1"
+      }
+    },
+    "node_modules/lodash._shimkeys": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+      "integrity": "sha512-lBrglYxLD/6KAJ8IEa5Lg+YHgNAL7FyKqXg4XOUI+Du/vtniLs1ZqS+yHNKPkK54waAgkdUnDOYaWf+rv4B+AA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._objecttypes": "~2.4.1"
+      }
+    },
+    "node_modules/lodash._slice": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz",
+      "integrity": "sha512-+odPJa4PE2UgYnQgJgkLs0UD03QU78R2ivhrFnG9GdtYOZdE6ObxOj7KiUEUlqOOgatFT+ZqSypFjDSduTigKg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.bind": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz",
+      "integrity": "sha512-hn2VWYZ+N9aYncRad4jORvlGgpFrn+axnPIWRvFxjk6CWcZH5b5alI8EymYsHITI23Z9wrW/+ORq+azrVFpOfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._createwrapper": "~2.4.1",
+        "lodash._slice": "~2.4.1"
+      }
+    },
+    "node_modules/lodash.defaults": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+      "integrity": "sha512-5wTIPWwGGr07JFysAZB8+7JB2NjJKXDIwogSaRX5zED85zyUAQwtOqUk8AsJkkigUcL3akbHYXd5+BPtTGQPZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._objecttypes": "~2.4.1",
+        "lodash.keys": "~2.4.1"
+      }
+    },
+    "node_modules/lodash.defaults/node_modules/lodash.keys": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+      "integrity": "sha512-ZpJhwvUXHSNL5wYd1RM6CUa2ZuqorG9ngoJ9Ix5Cce+uX7I5O/E06FCJdhSZ33b5dVyeQDnIlWH7B2s5uByZ7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._isnative": "~2.4.1",
+        "lodash._shimkeys": "~2.4.1",
+        "lodash.isobject": "~2.4.1"
+      }
+    },
+    "node_modules/lodash.find": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-3.2.1.tgz",
+      "integrity": "sha512-pN4ZB4KEepNd/97vLC5F3rl1tAAa5uWvISru2psLyLA8BtqBQwOA+2D7fdusG0aGmElOEurbSMlKI3UxjqoLQg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash._basecallback": "^3.0.0",
+        "lodash._baseeach": "^3.0.0",
+        "lodash._basefind": "^3.0.0",
+        "lodash._basefindindex": "^3.0.0",
+        "lodash.isarray": "^3.0.0",
+        "lodash.keys": "^3.0.0"
+      }
+    },
+    "node_modules/lodash.foreach": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-2.4.1.tgz",
+      "integrity": "sha512-AvOobAkE7qBtIiHU5QHQIfveWH5Usr9pIcFIzBv7u4S6bvb3FWpFrh9ltqBY7UeL5lw6e8d+SggiUXQVyh+FpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._basecreatecallback": "~2.4.1",
+        "lodash.forown": "~2.4.1"
+      }
+    },
+    "node_modules/lodash.forown": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.forown/-/lodash.forown-2.4.1.tgz",
+      "integrity": "sha512-VC+CKm/zSs5t3i/MHv71HZoQphuqOvez1xhjWBwHU5zAbsCYrqwHr+MyQyMk14HzA3hSRNA5lCqDMSw5G2Qscg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._basecreatecallback": "~2.4.1",
+        "lodash._objecttypes": "~2.4.1",
+        "lodash.keys": "~2.4.1"
+      }
+    },
+    "node_modules/lodash.forown/node_modules/lodash.keys": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+      "integrity": "sha512-ZpJhwvUXHSNL5wYd1RM6CUa2ZuqorG9ngoJ9Ix5Cce+uX7I5O/E06FCJdhSZ33b5dVyeQDnIlWH7B2s5uByZ7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._isnative": "~2.4.1",
+        "lodash._shimkeys": "~2.4.1",
+        "lodash.isobject": "~2.4.1"
+      }
+    },
+    "node_modules/lodash.identity": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz",
+      "integrity": "sha512-VRYX+8XipeLjorag5bz3YBBRJ+5kj8hVBzfnaHgXPZAVTYowBdY5l0M5ZnOmlAMCOXBFabQtm7f5VqjMKEji0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha512-JwObCrNJuT0Nnbuecmqr5DgtuBppuCvGD9lxjFpAzwnVtdGoDQ1zig+5W8k5/6Gcn0gZ3936HDAlGd28i7sOGQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isfunction": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz",
+      "integrity": "sha512-6XcAB3izeQxPOQQNAJbbdjXbvWEt2Pn9ezPrjr4CwoLwmqsLVbsiEXD19cmmt4mbzOCOCdHzOQiUivUOJLra7w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isobject": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+      "integrity": "sha512-sTebg2a1PoicYEZXD5PBdQcTlIJ6hUslrlWr7iV0O7n+i4596s2NQ9I5CaZ5FbXSfya/9WQsrYLANUJv9paYVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._objecttypes": "~2.4.1"
+      }
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+      "integrity": "sha512-P4wZnho5curNqeEq/x292Pb57e1v+woR7DJ84DURelKB46lby8aDEGVobSaYtzHdQBWQrJSdxcCwjlGOvvdIyg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash._basefor": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.keysin": "^3.0.0"
+      }
+    },
+    "node_modules/lodash.istypedarray": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
+      "integrity": "sha512-lGWJ6N8AA3KSv+ZZxlTdn4f6A7kMfpJboeyvbFdE7IU9YAgweODqmOgdUHOA+c6lVWeVLysdaxciFXi+foVsWw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha512-CuBsapFjcubOGMn3VD+24HOAPxM79tH+V6ivJL3CHYjtrawauDJHUk//Yew9Hvc6e9rbCrURGk8z6PC+8WJBfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
+    },
+    "node_modules/lodash.keysin": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+      "integrity": "sha512-YDB/5xkL3fBKFMDaC+cfGV00pbiJ6XoJIfRmBhv7aR6wWtbCW6IzkiWnTfkiHTF6ALD7ff83dAtB3OEaSoyQPg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
+    },
+    "node_modules/lodash.memoize": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
+      "integrity": "sha512-eDn9kqrAmVUC1wmZvlQ6Uhde44n+tXpqPrN8olQJbttgh0oKclk+SF54P47VEGE9CEiMeRwAP8BaM7UHvBkz2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
+      "integrity": "sha512-ZgGZpRhWLjivGUbjtApZR4HyLv/UAyoYqESVYkK4aLBJVHRrbFpG+GNnE9JPijliME4LkKM0SFI/WyOiBiv1+w==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash._arraycopy": "^3.0.0",
+        "lodash._arrayeach": "^3.0.0",
+        "lodash._createassigner": "^3.0.0",
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0",
+        "lodash.isplainobject": "^3.0.0",
+        "lodash.istypedarray": "^3.0.0",
+        "lodash.keys": "^3.0.0",
+        "lodash.keysin": "^3.0.0",
+        "lodash.toplainobject": "^3.0.0"
+      }
+    },
+    "node_modules/lodash.noop": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
+      "integrity": "sha512-uNcV98/blRhInPUGQEnj9ekXXfG+q+rfoNSFZgl/eBfog9yBDW9gfUv2AHX/rAF7zZRlzWhbslGhbGQFZlCkZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.pairs": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.pairs/-/lodash.pairs-3.0.1.tgz",
+      "integrity": "sha512-lgXvpU43ZNQrZ/pK2cR97YzKeAno3e3HhcyvLKsofljeHKrQcZhT1vW7fg4X61c92tM+mjD/DypoLZYuAKNIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.keys": "^3.0.0"
+      }
+    },
+    "node_modules/lodash.restparam": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "integrity": "sha512-L4/arjjuq4noiUJpt3yS6KIKDtJwNe2fIYgMqyYYKoeIfV1iEqvPwhCx23o+R9dzouGihDAPN1dTIRWa7zk8tw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.support": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.4.1.tgz",
+      "integrity": "sha512-6SwqWwGFHhTXEiqB/yQgu8FYd//tm786d49y7kizHVCJH7zdzs191UQn3ES3tkkDbUddNRfkCRYqJFHtbLnbCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._isnative": "~2.4.1"
+      }
+    },
+    "node_modules/lodash.toplainobject": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
+      "integrity": "sha512-wMI0Ju1bvSmnBS3EcRRH/3zDnZOPpDtMtNDzbbNMKuTrEpALsf+sPyMeogmv63Y11qZQO7H1xFzohIEGRMjPYA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keysin": "^3.0.0"
+      }
+    },
+    "node_modules/lolex": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+      "integrity": "sha512-/bpxDL56TG5LS5zoXxKqA6Ro5tkOS5M8cm/7yQcwLIKIcM2HR5fjjNCaIhJNv96SEk4hNGSafYMZK42Xv5fihQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha512-k+yt5n3l48JU4k8ftnKG6V7u32wyH2NfKzeMto9F/QRE0amxy/LayxwlvjjkZEIzqR+19IrtFO8p5kB9QaYUFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ==",
+      "license": "ISC"
+    },
+    "node_modules/map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-visit": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/micromatch/node_modules/extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/micromatch/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/micromatch/node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/miller-rabin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
+      },
+      "bin": {
+        "miller-rabin": "bin/miller-rabin"
+      }
+    },
+    "node_modules/miller-rabin/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minifyify": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/minifyify/-/minifyify-4.4.0.tgz",
+      "integrity": "sha512-Btguwl72Z3WUAJoOPWV599R30/VwIHqs2IlCKZSHlFTftFaoyfJoDfcTS66cqbsEhHSdXy4+PGEgjrI4QRYE6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "concat-stream": "1.4.x",
+        "convert-source-map": "^0.4.0",
+        "lodash.bind": "2.4.x",
+        "lodash.defaults": "2.4.x",
+        "lodash.foreach": "2.4.x",
+        "mkdirp": "^0.5.0",
+        "source-map": "0.1.34",
+        "through": "2.3.x",
+        "tmp": "0.0.23",
+        "uglify-js": "2.4.x"
+      },
+      "engines": {
+        "node": "0.10.x"
+      }
+    },
+    "node_modules/minifyify/node_modules/async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ==",
+      "dev": true
+    },
+    "node_modules/minifyify/node_modules/convert-source-map": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.4.1.tgz",
+      "integrity": "sha512-yFU/yTFbnlUH0wnu33o7hZwbcGmmnKw2uLAxLPnWW8zh+o7+xq7LmB4DMqKo5IniPcRs6quLHZ/A5ogSYhU1qw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minifyify/node_modules/source-map": {
+      "version": "0.1.34",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+      "integrity": "sha512-yfCwDj0vR9RTwt3pEzglgb3ZgmcXHt6DjG3bjJvzPwTL+5zDQ2MhmSzAcTy0GTiQuCiriSWXvWM1/NhKdXuoQA==",
+      "dev": true,
+      "dependencies": {
+        "amdefine": ">=0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/minifyify/node_modules/uglify-js": {
+      "version": "2.4.24",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
+      "integrity": "sha512-tktIjwackfZLd893KGJmXc1hrRHH1vH9Po3xFh1XBjjeGAnN02xJ3SuoA+n1L29/ZaCA18KzCFlckS+vfPugiA==",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "async": "~0.2.6",
+        "source-map": "0.1.34",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.5.4"
+      },
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/minifyify/node_modules/wordwrap": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+      "integrity": "sha512-xSBsCeh+g+dinoBv3GAOWM4LcVVO68wLXRanibtBSdUvkGWQRGeE9P7IwU9EmDDi4jA6L44lz15CGMwdw9N5+Q==",
+      "dev": true,
+      "license": "MIT/X11",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/minifyify/node_modules/yargs": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+      "integrity": "sha512-5j382E4xQSs71p/xZQsU1PtRA2HXPAjX0E0DkoGLxwNASMOKX6A9doV1NrZmj85u2Pjquz402qonBzz/yLPbPA==",
+      "dev": true,
+      "license": "MIT/X11",
+      "dependencies": {
+        "camelcase": "^1.0.2",
+        "decamelize": "^1.0.0",
+        "window-size": "0.1.0",
+        "wordwrap": "0.0.2"
+      }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mixin-deep": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mixin-deep/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mocha": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.20.1.tgz",
+      "integrity": "sha512-25Nq3BuIYCy80uEix+hBlZcr/gnLzpcYqfsaPAxZm2qbMFmed8I3nP8N05KagK4BTkGYUvsRJ47istvRqFO8fw==",
+      "deprecated": "Mocha v1.x is no longer supported.",
+      "dev": true,
+      "dependencies": {
+        "commander": "2.0.0",
+        "debug": "*",
+        "diff": "1.0.7",
+        "glob": "3.2.3",
+        "growl": "1.7.x",
+        "jade": "0.26.3",
+        "mkdirp": "0.3.5"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 0.4.x"
+      }
+    },
+    "node_modules/mocha/node_modules/glob": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+      "integrity": "sha512-WPaLsMHD1lYEqAmIQI6VOJSPwuBdGShDWnj1yUo0vQqEO809R8W3LM9OVU13CnnDhyv/EiNwOtxEW74SmrzS6w==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "graceful-fs": "~2.0.0",
+        "inherits": "2",
+        "minimatch": "~0.2.11"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mocha/node_modules/graceful-fs": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+      "integrity": "sha512-hcj/NTUWv+C3MbqrVb9F+aH6lvTwEHJdx2foBxlrVq5h6zE8Bfu4pv4CAAqbDcZrw/9Ak5lsRXlY9Ao8/F0Tuw==",
+      "deprecated": "please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js",
+      "dev": true,
+      "license": "BSD",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha512-zZ+Jy8lVWlvqqeM8iZB7w7KmQkoJn8djM585z88rywrEbzoqawVa9FR5p2hwD+y74nfuKOjmNvi9gtWJNLqHvA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mocha/node_modules/mkdirp": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+      "integrity": "sha512-8OCq0De/h9ZxseqzCH8Kw/Filf5pF/vMI6+BH7Lu0jXz2pqYCjTAQRolSxRIi+Ax+oCCjlxoJMP0YQ4XlrQNHg==",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/module-deps": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
+      "integrity": "sha512-EbWWlSGaCVidEsLsSzkY6l/jm0IcGDSQ8tGwtjM8joTrxqxP0om02Px9Np8D7FMZ/vZFdsOGbio+WqkKQxYuTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browser-resolve": "^1.7.0",
+        "concat-stream": "~1.4.5",
+        "defined": "^1.0.0",
+        "detective": "^4.0.0",
+        "duplexer2": "0.0.2",
+        "inherits": "^2.0.1",
+        "JSONStream": "^1.0.3",
+        "parents": "^1.0.0",
+        "readable-stream": "^1.1.13",
+        "resolve": "^1.1.3",
+        "stream-combiner2": "~1.0.0",
+        "subarg": "^1.0.0",
+        "through2": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "module-deps": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/module-deps/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nan": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.27.0.tgz",
+      "integrity": "sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nanomatch/node_modules/extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nanomatch/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nanomatch/node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ncp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.5.1.tgz",
+      "integrity": "sha512-l+pJxuLlzwp11Dy72MJgCPNwIbXdv6imaACLiEMb2TIDyr54qz+nAZeD5qDlJefveaJ+R9Ug6KuozCxRpQXO0Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "ncp": "bin/ncp"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/noptify": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
+      "integrity": "sha512-EZT35r9AuK+hig+iYv4144kwfDEDhlj3zncVHw9b9d86TUYk/67BtBApkfPD1kslAT/8TTD262xdsVbV+iCSTw==",
+      "dev": true,
+      "dependencies": {
+        "nopt": "~2.0.0"
+      }
+    },
+    "node_modules/noptify/node_modules/nopt": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
+      "integrity": "sha512-uVTsuT8Hm3aN3VttY+BPKw4KU9lVpI0F22UAr/I1r6+kugMr3oyhMALkycikLcdfvGRsgzCYN48DYLBFcJEUVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "remove-trailing-separator": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha512-79LYn6VAb63zgtmAteVOWo9Vdj71ZVBy3Pbse+VqxDpEP83XuujMrGqHIwAXJ5I/aM0zU7dIyIAhifVTPrNItQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-copy/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-copy/node_modules/is-descriptor": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.8.tgz",
+      "integrity": "sha512-SceYGWXvdqlWa/OnQ5FQuV+NxvNmMRhMw/w9AHkH71hTzveND4BTYgvp16g+oITK47qbOl/3D0bl0iygehWAWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.1",
+        "is-data-descriptor": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha512-GBaMwwAVK9qbQN3Scdo0OyvgPW7l3lnaVMj84uTOZlswkX0KpF6fyDBJhtTthf7pymztoN36/KEr1DyhF96zEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha512-snN4O4TkigujZphWLN0E//nQmm7790RYaE53DdL7ZYwee2D8DDo9/EyYiKUfN3rneWUjhJnueija3G9I2i0h3g==",
+      "dev": true,
+      "license": "MIT/X11",
+      "dependencies": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      }
+    },
+    "node_modules/optimist/node_modules/minimist": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+      "integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/os-browserify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+      "integrity": "sha512-aZicJZccvxWOZ0Bja2eAch2L8RIJWBuRYmM8Gwl/JjNtRltH0Itcz4eH/ESyuIWfse8cc93ZCf0XrzhXK2HEDA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/outpipe": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz",
+      "integrity": "sha512-BnNY/RwnDrkmQdUa9U+OfN/Y7AWmKuUPCCd+hbRclZnnANvYpO72zp/a6Q4n829hPbdqEac31XCcsvlEvb+rtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shell-quote": "^1.4.2"
+      }
+    },
+    "node_modules/outpipe/node_modules/shell-quote": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parents": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+      "integrity": "sha512-mXKF3xkoUt5td2DoxpLmtOmZvko9VfFpwRwkKDHSNvgmpLAeBo18YDhcPbBzJq+QLCHMbGOfzia2cX4U+0v9Mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-platform": "~0.11.15"
+      }
+    },
+    "node_modules/parse-asn1": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.9.tgz",
+      "integrity": "sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asn1.js": "^4.10.1",
+        "browserify-aes": "^1.2.0",
+        "evp_bytestokey": "^1.0.3",
+        "pbkdf2": "^3.1.5",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-platform": {
+      "version": "0.11.15",
+      "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+      "integrity": "sha512-Y30dB6rab1A/nfEKsZxmr01nUotHX0c/ZiIAsCTatEe1CmS5Pm5He7fZ195bPT7RdquoaL8lLxFCMQi/bS7IJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/pbkdf2": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.5.tgz",
+      "integrity": "sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "ripemd160": "^2.0.3",
+        "safe-buffer": "^5.2.1",
+        "sha.js": "^2.4.12",
+        "to-buffer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/pkginfo": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+      "integrity": "sha512-yO5feByMzAp96LtP58wvPKSbaKAi/1C4kV9XpTctr6EepnP6F33RBNOiVrdz9BrPA98U2BMFsTNHo44TWcbQ2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/public-encrypt": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/public-encrypt/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz",
+      "integrity": "sha512-KbOrQrP5Ye+0gmq+hwxoJwAFRwExACWqwxj1IDFFgqOw9Poxy3wwSbafd9ZqP6T6ykMfnxM573kt/a4i9ybatQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/querystring-es3": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "integrity": "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/randomfill": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/read-only-stream": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-1.1.1.tgz",
+      "integrity": "sha512-CNGbvYZYr0b1F41aN7bYLHUBvvoynSS7ZTf2RLa5egnjZxKJPJUpUdWplD+jxQPijP/eL02IJxBhY8hwJlI3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^1.0.31",
+        "readable-wrap": "^1.0.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/readable-wrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
+      "integrity": "sha512-/8n0Mr10S+HGKFygQ42Z40JIXwafPH3A72pwmlNClThgsImV5LJJiCue5Je1asxwY082sYxq/+kTxH6nTn0w3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^1.1.13-1"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11",
+        "micromatch": "^3.1.10",
+        "readable-stream": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/readdirp/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readdirp/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readdirp/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readdirp/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/regex-not/node_modules/extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/regex-not/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/repeat-element": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
+      "integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz",
+      "integrity": "sha512-UHBY3viPlJKf85YijDUcikKX6tmF4SokIDp518ZDVT92JNDcG5uKIthaT/owt3Sar0lwtOafsQuwrg22/v2Dwg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==",
+      "deprecated": "https://github.com/lydell/resolve-url#deprecated",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha512-yqINtL/G7vs2v+dFIZmFUDbnVyFUJFKd6gK22Kgo6R4jfJGFtisKyncWDDULgjfqf4ASQuIQyjJ7XZ+3aWpsAg==",
+      "license": "MIT",
+      "dependencies": {
+        "align-text": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+      "integrity": "sha512-R5KMKHnPAQaZMqLOsyuyUmcIjSeDm+73eoqQpaXA7AZ22BL+6C+1mcUscgOsNd8WVlJuvlgAPsegcx7pjlV0Dg==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ripemd160": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
+      "integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^3.1.2",
+        "inherits": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/ripemd160/node_modules/hash-base": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
+      "integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^2.3.8",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/ripemd160/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ripemd160/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/ripemd160/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ripemd160/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/ripemd160/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha512-aJXcif4xnaNUzvUuC5gcb46oTS7zvg4jpMTnuqtrEPlR3vFr4pxtdTwaF1Qs3Enjn9HK+ZlwQui+a7z0SywIzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.1.10"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-value": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "dev": true,
+      "license": "(MIT AND BSD-3-Clause)",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/shasum": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+      "integrity": "sha512-UTzHm/+AzKfO9RgPgRpDIuMSNie1ubXRaljjlhFMNGYoG7z+rm9AHLPMf70R7887xboDH9Q+5YQbWKObFHEAtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-stable-stringify": "~0.0.0",
+        "sha.js": "~2.4.4"
+      }
+    },
+    "node_modules/shasum-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/shasum-object/-/shasum-object-1.0.1.tgz",
+      "integrity": "sha512-SsC+1tW7XKQ/94D4k1JhLmjDFpVGET/Nf54jVDtbavbALf8Zhp0Td9zTlxScjMW6nbEIrpADtPWfLk9iCXzHDQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fast-safe-stringify": "^2.0.7"
+      },
+      "bin": {
+        "shasum-object": "bin.js"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz",
+      "integrity": "sha512-uEWz7wa9vnCi9w4mvKZMgbHFk3DCKjLQlZcy0tJxUH4NwZjRrPPHXAYIEt2TmJs600Dcgj0Z3fZLZKVPVdGNbQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==",
+      "license": "ISC"
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon-node/node_modules/define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+      "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/snapdragon/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon/node_modules/is-descriptor": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.8.tgz",
+      "integrity": "sha512-SceYGWXvdqlWa/OnQ5FQuV+NxvNmMRhMw/w9AHkH71hTzveND4BTYgvp16g+oITK47qbOl/3D0bl0iygehWAWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.1",
+        "is-data-descriptor": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/snapdragon/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/snapdragon/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+      "integrity": "sha512-Y8nIfcb1s/7DcobUz1yOO1GSp7gyL+D9zLHDehT7iRESqGSxjJ448Sg7rvfgsRJCnKLdSl11uGf0s9X80cH0/A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "amdefine": ">=0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/source-map-resolve": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+      "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
+    },
+    "node_modules/source-map-url": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
+      "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
+      "deprecated": "See https://github.com/lydell/source-map-url#deprecated",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split-string/node_modules/extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split-string/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sprintf": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/sprintf/-/sprintf-0.1.5.tgz",
+      "integrity": "sha512-4X5KsuXFQ7f+d7Y+bi4qSb6eI+YoifDTGr0MQJXRoYO7BO7evfRCjds6kk3z7l5CiJYxgDN1x5Er4WiyCt+zTQ==",
+      "deprecated": "The sprintf package is deprecated in favor of sprintf-js.",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.2.4"
+      }
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha512-72E9+uLc27Mt718pMHt9VMNiAL4LMsmDbBva8mxWUCkT07fSzEGMYUCk0XWY6lp0j6RBAG4cJ3mWuZv2OE3s0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/static-extend/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/static-extend/node_modules/is-descriptor": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.8.tgz",
+      "integrity": "sha512-SceYGWXvdqlWa/OnQ5FQuV+NxvNmMRhMw/w9AHkH71hTzveND4BTYgvp16g+oITK47qbOl/3D0bl0iygehWAWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.1",
+        "is-data-descriptor": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/stream-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
+      "integrity": "sha512-e+V5xc4LlkOiRr64kZTUdb11exsbpSnwb9uwmXaHeDXCpfHg7vaefMJOxi21Pe74ZOqjZ87blBcqqpNAM4Ku0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "^1.0.27-1"
+      }
+    },
+    "node_modules/stream-combiner2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
+      "integrity": "sha512-7DO1SfBVnyIyo9ytUjSyVojT5bp1ZY6h3pj7HUs6PwcRSd/r8mBOHbRwYC7nbHRakKzMKyNp5HWJRv4GgVherA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer2": "~0.0.2",
+        "through2": "~0.5.1"
+      }
+    },
+    "node_modules/stream-combiner2/node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/stream-combiner2/node_modules/through2": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+      "integrity": "sha512-zexCrAOTbjkBCXGyozn7hhS3aEaqdrc59mAD2E3dKYzV1vFuEGQ1hEDJN2oQMQFwy4he2zyLqPZV+AlfS8ZWJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~1.0.17",
+        "xtend": "~3.0.0"
+      }
+    },
+    "node_modules/stream-combiner2/node_modules/xtend": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+      "integrity": "sha512-sp/sT9OALMjRW1fKDlPeuSZlDQpkqReA0pyJukniWbTGoEKefHxhGJynE3PNhUMlcM8qWIjPwecwCw4LArS5Eg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/stream-http": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.2.0.tgz",
+      "integrity": "sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "xtend": "^4.0.2"
+      }
+    },
+    "node_modules/stream-http/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/stream-http/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/stream-splicer": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
+      "integrity": "sha512-nmUMEbdm/sZYqe9dZs7mqJvTYpunsDbIWI5FiBCMc/hMVd6vwzy+ITmo7C3gcLYqrn+uQ1w+EJwooWvJ997JAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indexof": "0.0.1",
+        "inherits": "^2.0.1",
+        "isarray": "~0.0.1",
+        "readable-stream": "^1.1.13-1",
+        "readable-wrap": "^1.0.0",
+        "through2": "^1.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha512-AOPG8EBc5wAikaG1/7uFCNFJwnKOuQwFTpYBdTW6OvWHeZBQBrAA/amefHGrEiOnCPcLFZK6FUPtWVKpQVIRgg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "strip-json-comments": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/subarg": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+      "integrity": "sha512-RIrIdRY0X1xojthNcVtgT9sjpOGagEUKpZdgBUi054OEPFo282yg+zE+t1Rj3+RqKq2xStL7uUHhY+AjbC4BXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.1.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/syntax-error": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
+      "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn-node": "^1.2.0"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/through2": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+      "integrity": "sha512-zEbpaeSMHxczpTzO1KkMHjBC1enTA68ojeaZGG4toqdASpb9t4xUZaYFBq2/9OHo5nTGFVSYd4c910OR+6wxbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": ">=1.1.13-1 <1.2.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      }
+    },
+    "node_modules/timers-browserify": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+      "integrity": "sha512-PIxwAupJZiYU4JmVZYwXp9FKsHMXb5h0ZEFyuXTAn8WLHOlcij+FEcbrvDsom1o5dr1YggEtFbECvGCW2sT53Q==",
+      "dev": true,
+      "dependencies": {
+        "process": "~0.11.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/tiny-lr-fork": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/tiny-lr-fork/-/tiny-lr-fork-0.0.5.tgz",
+      "integrity": "sha512-vhcvny/8f46rrViKV0BOUjVl4c/rDTztnT1+kT7iyD/Igqb/uyiRsKLxMc2Z8CNvTE1Px1tuNrPM+BOUL+3vlQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "~0.7.0",
+        "faye-websocket": "~0.4.3",
+        "noptify": "~0.0.3",
+        "qs": "~0.5.2"
+      },
+      "bin": {
+        "tiny-lr-fork": "bin/tiny-lr"
+      }
+    },
+    "node_modules/tiny-lr-fork/node_modules/debug": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+      "integrity": "sha512-EohAb3+DSHSGx8carOSKJe8G0ayV5/i609OD0J2orCkuyae7SyZSz2aoLmQF2s0Pj5gITDebwPH7GFBlqOUQ1Q==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tldjs": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/tldjs/-/tldjs-1.8.0.tgz",
+      "integrity": "sha512-oJHVrNdgPYlU7vszbSBMYDykdnJ8DmjaGML5KysOn2MIYtnpl1Yn+bCSF/vNo8vZkd0U+eRGg1qkQjHDLD/Teg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^1.4.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.23.tgz",
+      "integrity": "sha512-zR0TtNGw3OoChmmzHNnMVh6LRY7fCkxXnHOEI9/CZE5zn6TzZbyMknZdmQZzD0EhcQVT/9rZHeg1KqiqfAC5jw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/to-buffer/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/to-regex/node_modules/extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/to-regex/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tty-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
+      "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/type-detect": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+      "integrity": "sha512-5rqszGVwYgBoDkIm2oUtvkfZMQ0vk29iDMU0W2qCa3rG0vPDNczCMT4hV/bLBgLg8k8ri6+u3Zbt+S/14eMzlA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.7.tgz",
+      "integrity": "sha512-ueeb9YybpjhivjbHP2LdFDAjbS948fGEPj+ACAMs4xCMmh72OCOMQWBQKlaN4ZNQ04yfLSDLSx1tGRIoWimObQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha512-qLq/4y2pjcU3vhlhseXGGJ7VbFO4pBANu0kwl8VCa9KEI0V8VfZIx2Fy3w01iSTA/pGwKZSmu/+I4etLNDdt5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "source-map": "~0.5.1",
+        "yargs": "~3.10.0"
+      },
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      },
+      "optionalDependencies": {
+        "uglify-to-browserify": "~1.0.0"
+      }
+    },
+    "node_modules/uglify-js/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha512-vb2s1lYx2xBtUgy+ta+b2J/GLVUR+wmpINwHePmPRhOsIVCG2wDzKJ0n14GslH1BifsqVzSOwQhRaCAsZ/nI4Q==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/umd": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.3.tgz",
+      "integrity": "sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "umd": "bin/cli.js"
+      }
+    },
+    "node_modules/undeclared-identifiers": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/undeclared-identifiers/-/undeclared-identifiers-1.1.3.tgz",
+      "integrity": "sha512-pJOW4nxjlmfwKApE4zvxLScM/njmwj/DiUBv7EabwE4O8kRUy+HIwxQtZLBPll/jx1LJyBcqNfB3/cpv9EZwOw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn-node": "^1.3.0",
+        "dash-ast": "^1.0.0",
+        "get-assigned-identifiers": "^1.2.0",
+        "simple-concat": "^1.0.0",
+        "xtend": "^4.0.1"
+      },
+      "bin": {
+        "undeclared-identifiers": "bin.js"
+      }
+    },
+    "node_modules/underscore": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "integrity": "sha512-cp0oQQyZhUM1kpJDLdGO1jPZHgS/MpzoWYfe9+CM2h/QGDZlqwT2T3YGukuBdaNJ/CAPoeyAZRRHz8JFo176vA==",
+      "dev": true
+    },
+    "node_modules/underscore.string": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+      "integrity": "sha512-3FVmhXqelrj6gfgp3Bn6tOavJvW0dNH2T+heTD38JRxIrAbiuzbqjknszoOYj3DyFB1nWiLj208Qt2no/L4cIA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/union-value": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha512-PcA2tsuGSF9cnySLHTLSh2qrQiJ70mn+r+Glzxv2TWZblxsxCC52BDlZoPCsz7STd9pN7EZetkWZBAvk4cgZdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unset-value/node_modules/has-value": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+      "integrity": "sha512-gpG936j8/MzaeID5Yif+577c17TxaDmhuyVgSwtnL/q8UUTySg8Mecb+8Cf1otgLoD7DDH75axp86ER7LFsf3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-value": "^2.0.3",
+        "has-values": "^0.1.4",
+        "isobject": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unset-value/node_modules/has-value/node_modules/isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unset-value/node_modules/has-values": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+      "integrity": "sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unset-value/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/upath": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "yarn": "*"
+      }
+    },
+    "node_modules/urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==",
+      "deprecated": "Please see https://github.com/lydell/urix#deprecated",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "node_modules/url/node_modules/punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/use": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "2.0.3"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/util/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/vm-browserify": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "integrity": "sha512-NyZNR3WDah+NPkjh/YmhuWSsT4a0mF0BJYgUmvrJ70zxjTXh5Y2Asobxlh0Nfs0PCFB5FVpRJft7NozAWFMwLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indexof": "0.0.1"
+      }
+    },
+    "node_modules/watchify": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/watchify/-/watchify-3.11.1.tgz",
+      "integrity": "sha512-WwnUClyFNRMB2NIiHgJU9RQPQNqVeFk7OmZaWf5dC5EnNa0Mgr7imBydbaJ7tGTuPM2hz1Cb4uiBvK9NVxMfog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "^2.0.0",
+        "browserify": "^16.1.0",
+        "chokidar": "^2.1.1",
+        "defined": "^1.0.0",
+        "outpipe": "^1.1.0",
+        "through2": "^2.0.0",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "watchify": "bin/cmd.js"
+      }
+    },
+    "node_modules/watchify/node_modules/assert": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.1.tgz",
+      "integrity": "sha512-zzw1uCAgLbsKwBfFc8CX78DDg+xZeBksSO3vwVIDDN5i94eOrPsSSyiVhmsSABFDM/OcpE2aagCat9dnWQLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object.assign": "^4.1.4",
+        "util": "^0.10.4"
+      }
+    },
+    "node_modules/watchify/node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/watchify/node_modules/browser-pack": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.1.0.tgz",
+      "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "combine-source-map": "~0.8.0",
+        "defined": "^1.0.0",
+        "JSONStream": "^1.0.3",
+        "safe-buffer": "^5.1.1",
+        "through2": "^2.0.0",
+        "umd": "^3.0.0"
+      },
+      "bin": {
+        "browser-pack": "bin/cmd.js"
+      }
+    },
+    "node_modules/watchify/node_modules/browser-resolve": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-2.0.0.tgz",
+      "integrity": "sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve": "^1.17.0"
+      }
+    },
+    "node_modules/watchify/node_modules/browserify": {
+      "version": "16.5.2",
+      "resolved": "https://registry.npmjs.org/browserify/-/browserify-16.5.2.tgz",
+      "integrity": "sha512-TkOR1cQGdmXU9zW4YukWzWVSJwrxmNdADFbqbE3HFgQWe5wqZmOawqZ7J/8MPCwk/W8yY7Y0h+7mOtcZxLP23g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert": "^1.4.0",
+        "browser-pack": "^6.0.1",
+        "browser-resolve": "^2.0.0",
+        "browserify-zlib": "~0.2.0",
+        "buffer": "~5.2.1",
+        "cached-path-relative": "^1.0.0",
+        "concat-stream": "^1.6.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "~1.0.0",
+        "crypto-browserify": "^3.0.0",
+        "defined": "^1.0.0",
+        "deps-sort": "^2.0.0",
+        "domain-browser": "^1.2.0",
+        "duplexer2": "~0.1.2",
+        "events": "^2.0.0",
+        "glob": "^7.1.0",
+        "has": "^1.0.0",
+        "htmlescape": "^1.1.0",
+        "https-browserify": "^1.0.0",
+        "inherits": "~2.0.1",
+        "insert-module-globals": "^7.0.0",
+        "JSONStream": "^1.0.3",
+        "labeled-stream-splicer": "^2.0.0",
+        "mkdirp-classic": "^0.5.2",
+        "module-deps": "^6.2.3",
+        "os-browserify": "~0.3.0",
+        "parents": "^1.0.1",
+        "path-browserify": "~0.0.0",
+        "process": "~0.11.0",
+        "punycode": "^1.3.2",
+        "querystring-es3": "~0.2.0",
+        "read-only-stream": "^2.0.0",
+        "readable-stream": "^2.0.2",
+        "resolve": "^1.1.4",
+        "shasum": "^1.0.0",
+        "shell-quote": "^1.6.1",
+        "stream-browserify": "^2.0.0",
+        "stream-http": "^3.0.0",
+        "string_decoder": "^1.1.1",
+        "subarg": "^1.0.0",
+        "syntax-error": "^1.1.1",
+        "through2": "^2.0.0",
+        "timers-browserify": "^1.0.1",
+        "tty-browserify": "0.0.1",
+        "url": "~0.11.0",
+        "util": "~0.10.1",
+        "vm-browserify": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "browserify": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/watchify/node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
+      }
+    },
+    "node_modules/watchify/node_modules/buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+      "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      }
+    },
+    "node_modules/watchify/node_modules/combine-source-map": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz",
+      "integrity": "sha512-UlxQ9Vw0b/Bt/KYwCFqdEwsQ1eL8d1gibiFb7lxQJFdvTgc2hIZi6ugsg+kyhzhPV+QEpUiEIwInIAIrgoEkrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "convert-source-map": "~1.1.0",
+        "inline-source-map": "~0.6.0",
+        "lodash.memoize": "~3.0.3",
+        "source-map": "~0.5.3"
+      }
+    },
+    "node_modules/watchify/node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/watchify/node_modules/constants-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "integrity": "sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/watchify/node_modules/convert-source-map": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+      "integrity": "sha512-Y8L5rp6jo+g9VEPgvqNfEopjTR4OTYct8lXlS8iVQdmnjDvbdbzYe9rjtFCB9egC86JoNCU61WRY+ScjkZpnIg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/watchify/node_modules/deps-sort": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.1.tgz",
+      "integrity": "sha512-1orqXQr5po+3KI6kQb9A4jnXT1PBwggGl2d7Sq2xsnOeI9GPcE/tGcF9UiSZtZBM7MukY4cAh7MemS6tZYipfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "JSONStream": "^1.0.3",
+        "shasum-object": "^1.0.0",
+        "subarg": "^1.0.0",
+        "through2": "^2.0.0"
+      },
+      "bin": {
+        "deps-sort": "bin/cmd.js"
+      }
+    },
+    "node_modules/watchify/node_modules/detective": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-5.2.1.tgz",
+      "integrity": "sha512-v9XE1zRnz1wRtgurGu0Bs8uHKFSTdteYZNbIPFVhUZ39L/S79ppMpdmVOZAnoz1jfEFodc48n6MX483Xo3t1yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn-node": "^1.8.2",
+        "defined": "^1.0.0",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "detective": "bin/detective.js"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/watchify/node_modules/domain-browser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4",
+        "npm": ">=1.2"
+      }
+    },
+    "node_modules/watchify/node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/watchify/node_modules/events": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-2.1.0.tgz",
+      "integrity": "sha512-3Zmiobend8P9DjmKAty0Era4jV8oJ0yGYe2nJJAxgymF9+N8F2m0hhZiMoWtcfepExzNKZumFU3ksdQbInGWCg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/watchify/node_modules/https-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+      "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/watchify/node_modules/inline-source-map": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.3.tgz",
+      "integrity": "sha512-1aVsPEsJWMJq/pdMU61CDlm1URcW702MTB4w9/zUjMus6H/Py8o7g68Pr9D4I6QluWGt/KdmswuRhaA05xVR1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "~0.5.3"
+      }
+    },
+    "node_modules/watchify/node_modules/insert-module-globals": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.2.1.tgz",
+      "integrity": "sha512-ufS5Qq9RZN+Bu899eA9QCAYThY+gGW7oRkmb0vC93Vlyu/CFGcH0OYPEjVkDXA5FEbTt1+VWzdoOD3Ny9N+8tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn-node": "^1.5.2",
+        "combine-source-map": "^0.8.0",
+        "concat-stream": "^1.6.1",
+        "is-buffer": "^1.1.0",
+        "JSONStream": "^1.0.3",
+        "path-is-absolute": "^1.0.1",
+        "process": "~0.11.0",
+        "through2": "^2.0.0",
+        "undeclared-identifiers": "^1.1.2",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "insert-module-globals": "bin/cmd.js"
+      }
+    },
+    "node_modules/watchify/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/watchify/node_modules/labeled-stream-splicer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.2.tgz",
+      "integrity": "sha512-Ca4LSXFFZUjPScRaqOcFxneA0VpKZr4MMYCljyQr4LIewTLb3Y0IUTIsnBBsVubIeEfxeSZpSjSsRM8APEQaAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "stream-splicer": "^2.0.0"
+      }
+    },
+    "node_modules/watchify/node_modules/module-deps": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-6.2.3.tgz",
+      "integrity": "sha512-fg7OZaQBcL4/L+AK5f4iVqf9OMbCclXfy/znXRxTVhJSeW5AIlS9AwheYwDaXM3lVW7OBeaeUEY3gbaC6cLlSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browser-resolve": "^2.0.0",
+        "cached-path-relative": "^1.0.2",
+        "concat-stream": "~1.6.0",
+        "defined": "^1.0.0",
+        "detective": "^5.2.0",
+        "duplexer2": "^0.1.2",
+        "inherits": "^2.0.1",
+        "JSONStream": "^1.0.3",
+        "parents": "^1.0.0",
+        "readable-stream": "^2.0.2",
+        "resolve": "^1.4.0",
+        "stream-combiner2": "^1.1.1",
+        "subarg": "^1.0.0",
+        "through2": "^2.0.0",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "module-deps": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/watchify/node_modules/os-browserify": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+      "integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/watchify/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/watchify/node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/watchify/node_modules/read-only-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
+      "integrity": "sha512-3ALe0bjBVZtkdWKIcThYpQCLbBMd/+Tbh2CDSrAIDO3UsZ4Xs+tnyjv2MjCOMMgBG+AsUOeuP1cgtY1INISc8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/watchify/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/watchify/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/watchify/node_modules/readable-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/watchify/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/watchify/node_modules/shell-quote": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/watchify/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/watchify/node_modules/stream-browserify": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
+      "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/watchify/node_modules/stream-combiner2": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+      "integrity": "sha512-3PnJbYgS56AeWgtKF5jtJRT6uFJe56Z0Hc5Ngg/6sI6rIt8iiMBTa9cvdyFfpMQjaVHr8dusbNeFGIIonxOvKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer2": "~0.1.0",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/watchify/node_modules/stream-splicer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.1.tgz",
+      "integrity": "sha512-Xizh4/NPuYSyAXyT7g8IvdJ9HJpxIGL9PjyhtywCZvvP0OPIdqyrr4dMikeuvY8xahpdKEBlBTySe583totajg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/watchify/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/watchify/node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/watchify/node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/watchify/node_modules/url": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
+      "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^1.4.1",
+        "qs": "^6.12.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/watchify/node_modules/vm-browserify": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+      "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+      "integrity": "sha512-E87fdQ/eRJr9W1X4wTPejNy9zTW3FI2vpCZSJ/HAY+TkjKVC0TUm1jk6vn2Z7qay0DQy0+RBGdXxj+RmmiGZKQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha512-1pTPQDKTdd61ozlKGNCjhNRd+KPmgLSGa3mZTHoOliaGcESD8G1PXhh7c1fgiPjVbNVfgy2Faw4BI8/m0cC8Mg==",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/winston": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
+      "integrity": "sha512-fPoamsHq8leJ62D1M9V/f15mjQ1UHe4+7j1wpAT3fqgA5JqhJkk4aIfPEjfMTI9x6ZTjaLOpMAjluLtmgO5b6g==",
+      "dependencies": {
+        "async": "0.2.x",
+        "colors": "0.6.x",
+        "cycle": "1.0.x",
+        "eyes": "0.1.x",
+        "isstream": "0.1.x",
+        "pkginfo": "0.3.x",
+        "stack-trace": "0.0.x"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/winston/node_modules/async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ=="
+    },
+    "node_modules/wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "integrity": "sha512-QFzUah88GAGy9lyDKGBqZdkYApt63rCXYBGYnEP4xDJPXNqXXnBDACnbrXnViV6jRSqAePwrATi2i8mfYm4L1A==",
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
+        "window-size": "0.1.0"
+      }
+    }
+  }
+}

--- a/omega-target-chromium-extension/package-lock.json
+++ b/omega-target-chromium-extension/package-lock.json
@@ -1,0 +1,7158 @@
+{
+  "name": "omega-target-chromium-extension",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "omega-target-chromium-extension",
+      "version": "0.0.1",
+      "dependencies": {
+        "heap": "^0.2.6",
+        "omega-pac": "../omega-pac",
+        "omega-target": "../omega-target",
+        "omega-web": "../omega-web",
+        "xhr": "^1.16.0"
+      },
+      "devDependencies": {
+        "chai": "~1.9.1",
+        "coffee-script": "^1.7.1",
+        "coffeeify": "^0.7.0",
+        "coffeelint": "^1.16.0",
+        "grunt": "^0.4.5",
+        "grunt-browserify": "^3.0.0",
+        "grunt-coffeelint": "^0.0.13",
+        "grunt-contrib-coffee": "^0.11.1",
+        "grunt-contrib-compress": "^0.12.0",
+        "grunt-contrib-copy": "^0.5.0",
+        "grunt-contrib-watch": "^0.6.1",
+        "grunt-mocha-test": "~0.11.0",
+        "load-grunt-config": "^0.13.1",
+        "minifyify": "^4.1.1",
+        "po2json": "^0.3.2"
+      }
+    },
+    "../omega-pac": {
+      "version": "0.0.1",
+      "dependencies": {
+        "ip-address": "^4.0.0",
+        "tldjs": "^1.5.2",
+        "uglify-js": "^2.4.15"
+      },
+      "devDependencies": {
+        "chai": "~1.9.1",
+        "coffee-script": "^1.7.1",
+        "coffeeify": "^0.7.0",
+        "coffeelint": "^1.16.0",
+        "grunt": "^0.4.5",
+        "grunt-browserify": "^3.0.0",
+        "grunt-coffeelint": "^0.0.13",
+        "grunt-contrib-coffee": "^0.11.1",
+        "grunt-contrib-watch": "^0.6.1",
+        "grunt-mocha-test": "~0.11.0",
+        "load-grunt-config": "^0.13.1",
+        "lolex": "^1.4.0",
+        "minifyify": "^4.1.1"
+      }
+    },
+    "../omega-target": {
+      "version": "0.0.1",
+      "dependencies": {
+        "bluebird": "^2.3.2",
+        "jsondiffpatch": "^0.1.8",
+        "limiter": "^1.0.5",
+        "omega-pac": "../omega-pac"
+      },
+      "devDependencies": {
+        "chai": "^1.10.0",
+        "coffee-script": "^1.8.0",
+        "coffeeify": "^0.7.0",
+        "coffeelint": "^1.16.0",
+        "grunt": "^0.4.5",
+        "grunt-browserify": "^3.0.0",
+        "grunt-coffeelint": "^0.0.13",
+        "grunt-contrib-coffee": "^0.11.1",
+        "grunt-contrib-watch": "^0.6.1",
+        "grunt-mocha-test": "~0.11.0",
+        "load-grunt-config": "^0.13.1",
+        "minifyify": "^4.1.1",
+        "sinon": "^1.12.2",
+        "sinon-chai": "^2.6.0"
+      }
+    },
+    "../omega-web": {
+      "version": "0.0.1",
+      "devDependencies": {
+        "chai": "~1.9.1",
+        "coffeelint": "^1.16.0",
+        "grunt": "^0.4.5",
+        "grunt-autoprefixer": "^1.0.1",
+        "grunt-bower-task": "^0.5.0",
+        "grunt-coffeelint": "^0.0.13",
+        "grunt-contrib-coffee": "^0.11.1",
+        "grunt-contrib-concat": "^0.5.0",
+        "grunt-contrib-copy": "^0.5.0",
+        "grunt-contrib-jade": "^0.12.0",
+        "grunt-contrib-less": "^0.11.4",
+        "grunt-contrib-watch": "^0.6.1",
+        "grunt-mocha-test": "~0.11.0",
+        "grunt-ng-annotate": "^0.3.2",
+        "load-grunt-config": "^0.13.1",
+        "omega-pac": "../omega-pac"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/acorn": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+      "integrity": "sha512-fu2ygVGuMmlzG8ZeRJ0bvR41nsAkxxhbyk8bZ1SS521Z7vmgJFTQQlfz/Mp/nJexGBz+v8sC9bM6+lNgskt4Ug==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-node": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
+      "integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^7.0.0",
+        "acorn-walk": "^7.0.0",
+        "xtend": "^4.0.2"
+      }
+    },
+    "node_modules/acorn-node/node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
+      "dev": true,
+      "license": "BSD-3-Clause OR MIT",
+      "engines": {
+        "node": ">=0.4.2"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
+      }
+    },
+    "node_modules/archiver": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-0.11.0.tgz",
+      "integrity": "sha512-Jew2vT04Dc2DSR7NrfTLDpwoGYVgl9MXJu/BBAwdM248v67ScIGezA8MqHVIa0B+af+b0S3mBPUD2HNP3tM2PQ==",
+      "dev": true,
+      "dependencies": {
+        "async": "~0.9.0",
+        "buffer-crc32": "~0.2.1",
+        "glob": "~3.2.6",
+        "lazystream": "~0.1.0",
+        "lodash": "~2.4.1",
+        "readable-stream": "~1.0.26",
+        "tar-stream": "~0.4.0",
+        "zip-stream": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/archiver/node_modules/async": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+      "integrity": "sha512-l6ToIJIotphWahxxHyzK9bnLR6kM4jJIIgLShZeqLY7iboHoGkdgFl7W2/Ivi4SkMJYGKqW8vSuk0uKUj6qsSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/archiver/node_modules/glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha512-hVb0zwEZwC1FXSKRPFTeOtN7AArJcJlI6ULGLtrstaswKNlrTJqAA+1lYlSUop4vjA423xlBzqfVS3iWGlqJ+g==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "inherits": "2",
+        "minimatch": "0.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/archiver/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/archiver/node_modules/minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha512-WFX1jI1AaxNTZVOHLBVazwTWKaQjoykSzCBNXB72vDTCzopQGtyP91tKdFK5cv1+qMwPyiTu1HqUriqplI8pcA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/archiver/node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+      "integrity": "sha512-LjmC2dNpdn2L4UzyoaIr11ELYoLn37ZFy9zObrQFHsSuOepeUEMKnM8w5KL4Tnrp2gy88rRuQt6Ky8Bjml+Baw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "underscore": "~1.7.0",
+        "underscore.string": "~2.4.0"
+      }
+    },
+    "node_modules/argparse/node_modules/underscore.string": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+      "integrity": "sha512-yxkabuCaIBnzfIvX3kBxQqCs0ar/bfJwDnFEHJUm/ZrRVhT3IItdRF5cZjARLzEnyQYtIUhsZ2LG2j3HidFOFQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/asn1.js": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/asn1.js/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/assert": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
+      "integrity": "sha512-5aKcpD+XnHpZ7EGxsuo6uoILNh0rvm0Ypa17GlkrF2CNSPhvdgi3ft9XsL2ajdVOI2I3xuGZnHvlXAeqTZYvXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "util": "0.10.3"
+      }
+    },
+    "node_modules/assert/node_modules/inherits": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+      "integrity": "sha512-8nWq2nLTAwd02jTqJExUYFSD/fKq6VH9Y/oG2accc/kdI0V98Bag8d5a4gi3XHz73rDWa2PvTtvcWYquKqSENA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/assert/node_modules/util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "integrity": "sha512-5KiHfsmkqacuKjkRkdV7SsfDJ2EGiPsK92s2MhNSY0craxjTdKTtqKsJaCWp4LW33ZZ0OPUv1WO/TFvNQRiQxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "2.0.1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
+      "integrity": "sha512-g/gZV+G476cnmtYI+Ko9d5khxSoCSoom/EaNmmCfwpOvBXEJ18qwFrxfP1/CsIqk2no1sAKKwxndV0tP7ROOFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/astw": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/astw/-/astw-2.2.0.tgz",
+      "integrity": "sha512-E/4z//dvN0lfr8zAx8hXeQ8o3nRoQaL/wqI7fAALEvh/40mnyUxfFB9MwyDHYKVDtS3cp3Pow5s96djZR5lkWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^4.0.3"
+      }
+    },
+    "node_modules/async": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+      "integrity": "sha512-2tEzliJmf5fHNafNwQLJXUasGzQCVctvsNkXmnlELHwypU0p08/rHohYvkqKIjyXpx+0rkrYv6QbhJ+UF4QkBg==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/async-each": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.6.tgz",
+      "integrity": "sha512-c646jH1avxr+aVpndVMeAfYw7wAa6idufrlN3LPA4PmKS0QEGp6PIC9nwz0WQkkvBGAMEki3pFdtxaF39J9vvg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true,
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/base/node_modules/define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+      "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/Base64": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
+      "integrity": "sha512-reGEWshDmTDQDsCec/HduOO9Wyj6yMOupMfhIf3ugN1TDlK2NQW4DDJSqNNtp380SNcvRfXtO8HSCQot0d0SMw==",
+      "dev": true
+    },
+    "node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+      "integrity": "sha512-njlCs8XLBIK7LCChTWfzWuIAxkpmmLXcL7/igCofFT1B039Sz0IPnAmosN5QaO22lU4qr8LcUz2ojUlE6pLkRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~1.0.26"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.5.tgz",
+      "integrity": "sha512-Vq886eXykuP5E6HcKSSStP3bJgrE6In5WKxVUvJ8XGpWWYs2xZHWqUwzCtGgEtBcxyd57KBFDPFoUfNzdaHCNg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/browser-pack": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-5.0.1.tgz",
+      "integrity": "sha512-BFMQuYXCcwr3Uvna1y1hikqd3r2dQpWIQBIN3m5YwE3ClfnXDeF3tqP6Wqjhs1LRUeBJpgHn8yD+fPX/YSEgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "combine-source-map": "~0.6.1",
+        "defined": "^1.0.0",
+        "JSONStream": "^1.0.3",
+        "through2": "^1.0.0",
+        "umd": "^3.0.0"
+      },
+      "bin": {
+        "browser-pack": "bin/cmd.js"
+      }
+    },
+    "node_modules/browser-resolve": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+      "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve": "1.1.7"
+      }
+    },
+    "node_modules/browser-resolve/node_modules/resolve": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+      "integrity": "sha512-9znBF0vBcaSN3W2j7wKvdERPwqTxSpCq+if5C0WoTCyV9n24rua28jeuQ2pL/HOf+yUe/Mef+H/5p60K0Id3bg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/browserify": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/browserify/-/browserify-10.2.6.tgz",
+      "integrity": "sha512-rhKmIuWDcE1ULm6lrd3kQdUTqFsLd/UJp3yYt4Ur5rDzk/Gj2AH6+ZTNqkaMqwMphkf8Rp83S1GfMxtu9QjGDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert": "~1.3.0",
+        "browser-pack": "^5.0.0",
+        "browser-resolve": "^1.7.1",
+        "browserify-zlib": "~0.1.2",
+        "buffer": "^3.0.0",
+        "builtins": "~0.0.3",
+        "commondir": "0.0.1",
+        "concat-stream": "~1.4.1",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "~0.0.1",
+        "crypto-browserify": "^3.0.0",
+        "defined": "^1.0.0",
+        "deps-sort": "^1.3.7",
+        "domain-browser": "~1.1.0",
+        "duplexer2": "~0.0.2",
+        "events": "~1.0.0",
+        "glob": "^4.0.5",
+        "has": "^1.0.0",
+        "htmlescape": "^1.1.0",
+        "http-browserify": "^1.4.0",
+        "https-browserify": "~0.0.0",
+        "inherits": "~2.0.1",
+        "insert-module-globals": "^6.4.1",
+        "isarray": "0.0.1",
+        "JSONStream": "^1.0.3",
+        "labeled-stream-splicer": "^1.0.0",
+        "module-deps": "^3.7.11",
+        "os-browserify": "~0.1.1",
+        "parents": "^1.0.1",
+        "path-browserify": "~0.0.0",
+        "process": "~0.11.0",
+        "punycode": "^1.3.2",
+        "querystring-es3": "~0.2.0",
+        "read-only-stream": "^1.1.1",
+        "readable-stream": "^1.1.13",
+        "resolve": "^1.1.4",
+        "shasum": "^1.0.0",
+        "shell-quote": "~0.0.1",
+        "stream-browserify": "^1.0.0",
+        "string_decoder": "~0.10.0",
+        "subarg": "^1.0.0",
+        "syntax-error": "^1.1.1",
+        "through2": "^1.0.0",
+        "timers-browserify": "^1.0.1",
+        "tty-browserify": "~0.0.0",
+        "url": "~0.10.1",
+        "util": "~0.10.1",
+        "vm-browserify": "~0.0.1",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "browserify": "bin/cmd.js"
+      }
+    },
+    "node_modules/browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/browserify-cipher": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      }
+    },
+    "node_modules/browserify-des": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/browserify-rsa": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
+      "integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^5.2.1",
+        "randombytes": "^2.1.0",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/browserify-sign": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.6.tgz",
+      "integrity": "sha512-sd+Q65fjlWCYWtZKXiKfrUc8d+4jtp/8f0W2NkwzLtoW4bI6UDnWusLWIurHnmurW0XShIRxpwiOX4EoPtXUAg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "bn.js": "^5.2.3",
+        "browserify-rsa": "^4.1.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.6.1",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.9",
+        "readable-stream": "^2.3.8",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/browserify-sign/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/browserify-sign/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/browserify-sign/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/browserify-sign/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/browserify-sign/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+      "integrity": "sha512-19OEpq7vWgsH6WkvkBJQDFvJS1uPcbFOQ4v9CU839dO+ZZXUZO6XpE6hNCqvlIIj+4fZvRiJ6DsAQ382GwiyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~0.2.0"
+      }
+    },
+    "node_modules/browserify/node_modules/glob": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+      "integrity": "sha512-I0rTWUKSZKxPSIAIaqhSXTM/DiII6wame+rEC3cFA5Lqmr9YmdL7z6Hj9+bdWtTvoY1Su4/OiMLmb37Y7JzvJQ==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^2.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/browserify/node_modules/minimatch": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+      "integrity": "sha512-jQo6o1qSVLEWaw3l+bwYA2X0uLuK2KjNh2wjgO7Q/9UJnXr1Q3yQKR8BI0/Bt/rPg75e6SMW4hW/6cBHVTZUjA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/browserify/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.2.tgz",
+      "integrity": "sha512-c3M77NkHJxS0zx/ErxXhDLr1v3y2MDXPeTJPvLNOaIYJ4ymHBUFQ9EXzt9HYuqAJllMoNb/EZ8hIiulnQFAUuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/buffer/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/builtin-status-codes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/builtins": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
+      "integrity": "sha512-T8uCGKc0/2aLVt6omt8JxDRBoWEMkku+wFesxnhxnt4NygVZG99zqxo7ciK8eebszceKamGoUiLdkXCgGQyrQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cached-path-relative": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.1.0.tgz",
+      "integrity": "sha512-WF0LihfemtesFcJgO7xfOoOcnWzY/QHR4qeDqV44jPU3HTI54+LnfXK3SA27AVVGCdZFgjjFFaqUA9Jx7dMJZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha512-wzLkDa4K/mzI1OSITC+DUyjgIl/ETNHE9QvYgy6J6Jvqyyz4C0Xfd+lQhb19sX2jMpZV4IssUn0VDVmglV+s4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/chai": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-1.9.2.tgz",
+      "integrity": "sha512-olRoaitftnzWHFEAza6MXR4w+FfZrOVyV7r7U/Z8ObJefCgL8IuWkAuASJjSXrpP9wvgoL8+1dB9RbMLc2FkNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "1.0.0",
+        "deep-eql": "0.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+      "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "^2.0.0",
+        "async-each": "^1.0.1",
+        "braces": "^2.3.2",
+        "glob-parent": "^3.1.0",
+        "inherits": "^2.0.3",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "normalize-path": "^3.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.2.1",
+        "upath": "^1.1.1"
+      },
+      "optionalDependencies": {
+        "fsevents": "^1.2.7"
+      }
+    },
+    "node_modules/chokidar/node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cipher-base": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
+      "integrity": "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/class-utils/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/class-utils/node_modules/is-descriptor": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.8.tgz",
+      "integrity": "sha512-SceYGWXvdqlWa/OnQ5FQuV+NxvNmMRhMw/w9AHkH71hTzveND4BTYgvp16g+oITK47qbOl/3D0bl0iygehWAWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.1",
+        "is-data-descriptor": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/coffee-script": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
+      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/coffeeify": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/coffeeify/-/coffeeify-0.7.0.tgz",
+      "integrity": "sha512-4TYM0xE8hO8sj0omU6Y7EE4H75V4cslt3PwcycL+rN1RGoYorvzLGXTJeIuyw90JBmMKQUatXWERuNQt3GhXvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "coffee-script": "^1.7.1",
+        "convert-source-map": "^0.3.5",
+        "through": "^2.3.4"
+      }
+    },
+    "node_modules/coffeelint": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/coffeelint/-/coffeelint-1.16.2.tgz",
+      "integrity": "sha512-6mzgOo4zb17WfdrSui/cSUEgQ0AQkW3gXDht+6lHkfkqGUtSYKwGdGcXsDfAyuScVzTlTtKdfwkAlJWfqul7zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "coffee-script": "~1.11.0",
+        "glob": "^7.0.6",
+        "ignore": "^3.0.9",
+        "optimist": "^0.6.1",
+        "resolve": "^0.6.3",
+        "strip-json-comments": "^1.0.2"
+      },
+      "bin": {
+        "coffeelint": "bin/coffeelint"
+      },
+      "engines": {
+        "node": ">=0.8.0",
+        "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/coffeelint-stylish": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/coffeelint-stylish/-/coffeelint-stylish-0.1.2.tgz",
+      "integrity": "sha512-VcuzfB0bC9lvdvwckLzh3njKce68VVmOOXp0igyNl50D/uRLbFb4HSjQtTNGFEYiQ9Z0hjhfTqKe4v8UQxnngA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^1.0.0",
+        "text-table": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/coffeelint/node_modules/coffee-script": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.11.1.tgz",
+      "integrity": "sha512-NIWm59Fh1zkXq6TS6PQvSO3AR9DbGq1IBNZHa1E3fUCNmJhIwLf1YKcWgaHqaU7zWGC/OE2V7K3GVAXFzcmu+A==",
+      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha512-lNkKvzEeMBBjUGHZ+q6z9pSJla0KWAQPvtzhEV9+iGyQYG+pBpl7xKDhxoNSOZH2hhv0v5k0y2yAM4o4SjoSkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/colors": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+      "integrity": "sha512-OsSVtHK8Ir8r3+Fxw/b4jS1ZLPXkV6ZxDRJQzeD7qo0SqMXWrHDM71DgYzPMHY8SFJ0Ao+nNU2p1MmwdzKqPrw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/combine-source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
+      "integrity": "sha512-XKRNtuZRlVDTuSGKsfZpXYz80y0XDbYS4a+FzafTgmYHy/ckruFBx7Nd6WaQnFHVI3O6IseWVdXUvZutMpjSkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "convert-source-map": "~1.1.0",
+        "inline-source-map": "~0.5.0",
+        "lodash.memoize": "~3.0.3",
+        "source-map": "~0.4.2"
+      }
+    },
+    "node_modules/combine-source-map/node_modules/convert-source-map": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+      "integrity": "sha512-Y8L5rp6jo+g9VEPgvqNfEopjTR4OTYct8lXlS8iVQdmnjDvbdbzYe9rjtFCB9egC86JoNCU61WRY+ScjkZpnIg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz",
+      "integrity": "sha512-qebjpyeaA/nJ4w3EO2cV2++/zEkccPnjWogzA2rff+Lk8ILI75vULeTmyd4wPxWdKwtP3J+G39IXVZadh0UHyw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.x"
+      }
+    },
+    "node_modules/commondir": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
+      "integrity": "sha512-Ghe1LmLv3G3c0XJYu+c88MCRIPqWQ67qaqKY1KvuN4uPAjfUj+y4hvcpZ2kCPrjpRNyklW4dpAZZ8a7vOh50tg==",
+      "dev": true,
+      "license": "MIT/X11",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/compress-commons": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-0.1.6.tgz",
+      "integrity": "sha512-TiSO1gzpHUM+UAKHK+THSSmqAFIx+6mq66jK55YS2kJ7RTiwO+1LwdHNcDzgEB2iB1KYf45aaOgjpY3PnAh1KA==",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.1",
+        "crc32-stream": "~0.3.1",
+        "readable-stream": "~1.0.26"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compress-commons/node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.11.tgz",
+      "integrity": "sha512-X3JMh8+4je3U1cQpG87+f9lXHDrqcb2MVLg9L7o8b1UZ0DzhRrUpdn65ttzu10PpJPPI3MQNkis+oha6TSA9Mw==",
+      "dev": true,
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "~1.1.9",
+        "typedarray": "~0.0.5"
+      }
+    },
+    "node_modules/console-browserify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+      "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
+      "dev": true
+    },
+    "node_modules/constants-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
+      "integrity": "sha512-FL+diDS9AKR5BAA2M+GNk8lnH64tRE3zepTG9hucxc7o04LgCRhkQZhF7u/OKHZT8LLRT+sZEi9qFzXUchq9pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
+      "integrity": "sha512-+4nRk0k3oEpwUB7/CalD7xE2z4VmtEnnq0GO2IPTkrooTrAhEsWvuLF5iWP1dXrwluki/azwXV1ve7gtYuPldg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/crc32-stream": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-0.3.4.tgz",
+      "integrity": "sha512-6hJjO1uXTBSnY14XjxDmK3xm9AG8KjwjJAFkVfjcR2IMu/hGz73e0KT2aEIhh9JR36jHUXuMv58xfNC8lwBJnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.1",
+        "readable-stream": "~1.0.24"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/crc32-stream/node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/create-ecdh": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.5.3"
+      }
+    },
+    "node_modules/create-ecdh/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "node_modules/create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/crypto-browserify": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.1.tgz",
+      "integrity": "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browserify-cipher": "^1.0.1",
+        "browserify-sign": "^4.2.3",
+        "create-ecdh": "^4.0.4",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "diffie-hellman": "^5.0.3",
+        "hash-base": "~3.0.4",
+        "inherits": "^2.0.4",
+        "pbkdf2": "^3.1.2",
+        "public-encrypt": "^4.0.3",
+        "randombytes": "^2.1.0",
+        "randomfill": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dash-ast": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dash-ast/-/dash-ast-1.0.0.tgz",
+      "integrity": "sha512-Vy4dx7gquTeMcQR/hDkYLGUnwVil6vk4FOOct+djUnHOUWt+zJPJAaRIXaAFkPXtJjvlY7o3rfRu0/3hpnwoUA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dateformat": {
+      "version": "1.0.2-1.2.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+      "integrity": "sha512-AXvW8g7tO4ilk5HgOWeDmPi/ZPaCnMJ+9Cg1I3p19w6mcvAAXBuuGEXAxybC+Djj1PSZUiHUcyoYu7WneCX8gQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decode-uri-component": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha512-6sEotTRGBFiNcqVoeHwnfopbSpi5NbH1VWJmYCVkmxMmaVTT0bUTrNaGyBwhgP4MZL012W/mkzIn3Da+iDYweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "0.1.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/defined": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.1.tgz",
+      "integrity": "sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/deps-sort": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
+      "integrity": "sha512-aEnmQuu/Hf5h8akL8QshYWzk9MVBg/JYMyNq/Lz68i69nR17tunjP6o/AC6Tn48c8ayzG6aeKs6OoFOtVCtvrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "JSONStream": "^1.0.3",
+        "shasum": "^1.0.0",
+        "subarg": "^1.0.0",
+        "through2": "^1.0.0"
+      },
+      "bin": {
+        "deps-sort": "bin/cmd.js"
+      }
+    },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/detective": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
+      "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^5.2.1",
+        "defined": "^1.0.0"
+      }
+    },
+    "node_modules/detective/node_modules/acorn": {
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/diff": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.7.tgz",
+      "integrity": "sha512-0bTLzyr1S59cPsgAD/lR+ivvHTbgPb+k/mUR6WGqma1J6QDU+kUegI8uQFuH/cMUNK7JGN3Tk1Y5Jf2MO85WrA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/diffie-hellman": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      }
+    },
+    "node_modules/diffie-hellman/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+    },
+    "node_modules/domain-browser": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+      "integrity": "sha512-fJ5MoHxe69h3E4/lJtFRhcWwLb04bhIBSfvCEMS1YDH+/9yEZTqBHTSTgch8nCP5tE5k2gdQEjodUqJzy7qJ9Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4",
+        "npm": ">=1.2"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexer2": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+      "integrity": "sha512-+AWBwjGadtksxjOQSFDhPNQbed7icNXApT4+2BNpsXzcCBiInq2H9XW0O8sfHFaPmnQRs7cg/P0fAr2IWQSW0g==",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "readable-stream": "~1.1.9"
+      }
+    },
+    "node_modules/elliptic": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/elliptic/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+      "integrity": "sha512-rp5dMKN8zEs9dfi9g0X1ClLmV//WRyk/R15mppFNICIFRG5P92VP7Z04p8pk++gABo9W2tY+kHyu6P1mEHgmTA==",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/eventemitter2": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "integrity": "sha512-K7J4xq5xAD5jHsGM5ReWXRTFa3JRGofHiMcVgQ8PRwgWxzjHpMWCIzsmyf60+mh8KLsqYPcjUMa0AC4hd6lPyQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/events": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz",
+      "integrity": "sha512-XK19KwlDJo8XsceooxNDK1pObtcT44+Xte6V/jQc4a+fHq1qEouThyyX2ePmS0hS8RcCulmRxzg+T8jiLKAFFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha512-w/ozOKR9Obk3qoWeY/WDi6MFta9AoMR+zud60mdnbniMcBxRuFJyDt2LdX/14A1UABeqk+Uk+LDfUpvoGKppZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expand-brackets/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/expand-brackets/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expand-brackets/node_modules/is-descriptor": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.8.tgz",
+      "integrity": "sha512-SceYGWXvdqlWa/OnQ5FQuV+NxvNmMRhMw/w9AHkH71hTzveND4BTYgvp16g+oITK47qbOl/3D0bl0iygehWAWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.1",
+        "is-data-descriptor": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/expand-brackets/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extglob/node_modules/define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+      "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/faye-websocket": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz",
+      "integrity": "sha512-78pqrJbvGZSe8i+PLsPd+aJqTyGqgyWLnMw5NOwtXCTVMzEFh1zQPwIuIL/ycTj4rkDy5zZ9B6frYPqVPJBzyQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+      "integrity": "sha512-yjftfYnF4ThYEvKEV/kEFR15dmtyXTAh3vQnzpJUoc7Naj5y1P0Ck7Zs1+Vroa00E3KT3IYsk756S+8WA5dNLw==",
+      "dev": true,
+      "dependencies": {
+        "glob": "~3.2.9",
+        "lodash": "~2.4.1"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha512-hVb0zwEZwC1FXSKRPFTeOtN7AArJcJlI6ULGLtrstaswKNlrTJqAA+1lYlSUop4vjA423xlBzqfVS3iWGlqJ+g==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "inherits": "2",
+        "minimatch": "0.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/findup-sync/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/findup-sync/node_modules/minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha512-WFX1jI1AaxNTZVOHLBVazwTWKaQjoykSzCBNXB72vDTCzopQGtyP91tKdFK5cv1+qMwPyiTu1HqUriqplI8pcA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "map-cache": "^0.2.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.9.1.tgz",
+      "integrity": "sha512-yctbTOCHGDktj3eorstAjY0Z8WtbzoHlKKiUZRbX25b34BnuIGsdI9HG2dYO72kimROUPRgJhdSxlBRhDtEZqw==",
+      "dev": true,
+      "dependencies": {
+        "jsonfile": "~1.1.0",
+        "mkdirp": "^0.5.0",
+        "ncp": "^0.5.1",
+        "rimraf": "^2.2.8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "deprecated": "Upgrade to fsevents v2 to mitigate potential security issues",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1"
+      },
+      "engines": {
+        "node": ">= 4.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaze": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
+      "integrity": "sha512-3IWbXGkDDHFX8zIlNdfnmhvlSMhpBO6tDr4InB8fGku6dh/gjFPGNqcdsXJajZg05x9jRzXbL6gCnCnuMap4tw==",
+      "dev": true,
+      "dependencies": {
+        "globule": "~0.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/get-assigned-identifiers": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
+      "integrity": "sha512-mBBwmeGTrxEMO4pMaaf/uUEFHnYtwr8FTe8Y/mer4rcV/bye0qGm6pw1bGZFGStxC5O76c5ZAVBGnqHmOaJpdQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/getobject": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+      "integrity": "sha512-hIGEBfnHcZpWkXPsAVeVmpYDvfy/matVl03yOY91FPmnpCC12Lm5izNxCjO3lHAeO6uaTwMxu7g450Siknlhig==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/gettext-parser": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-0.2.0.tgz",
+      "integrity": "sha512-DayCnmcHjMrQyzw9iYW242VSJT2oMjJNBvUufMAK05kb87VDeIdAr35Tra3qiV7Ct2hb9VzOcgBdOcM+aLqEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encoding": "~0.1"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
+      }
+    },
+    "node_modules/glob-parent/node_modules/is-glob": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+      "integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/global": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+      "integrity": "sha512-/4AybdwIDU4HkCUbJkZdWpe4P6vuw/CUtu+0I1YlLIPe7OlUO7KNJ+q/rO70CW2/NW6Jc6I62++Hzsf5Alu6rQ==",
+      "license": "MIT",
+      "dependencies": {
+        "min-document": "^2.19.0",
+        "process": "~0.5.1"
+      }
+    },
+    "node_modules/global/node_modules/process": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+      "integrity": "sha512-oNpcutj+nYX2FjdEW7PGltWhXulAnFlM0My/k48L90hARCOJtvBbQXc/6itV2jDvU5xAAtonP+r6wmQgCcbAUA==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/globule": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+      "integrity": "sha512-3eIcA2OjPCm4VvwIwZPzIxCVssA8HSpM2C6c6kK5ufJH4FGwWoyqL3In19uuX4oe+TwH3w2P1nQDmW56iehO4A==",
+      "dev": true,
+      "dependencies": {
+        "glob": "~3.1.21",
+        "lodash": "~1.0.1",
+        "minimatch": "~0.2.11"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/globule/node_modules/glob": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+      "integrity": "sha512-ANhy2V2+tFpRajE3wN4DhkNQ08KDr0Ir1qL12/cUe5+a7STEK8jkW4onUYuY8/06qAFuT5je7mjAqzx0eKI2tQ==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "graceful-fs": "~1.2.0",
+        "inherits": "1",
+        "minimatch": "~0.2.11"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/globule/node_modules/graceful-fs": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+      "integrity": "sha512-iiTUZ5vZ+2ZV+h71XAgwCSu6+NAizhFU3Yw8aC/hH5SQ3SnISqEqAek40imAFGtDcwJKNhXvSY+hzIolnLwcdQ==",
+      "deprecated": "please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js",
+      "dev": true,
+      "license": "BSD",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/globule/node_modules/inherits": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+      "integrity": "sha512-Al67oatbRSo3RV5hRqIoln6Y5yMVbJSIn4jEJNL7VCImzq/kLr7vvb6sFRJXqr8rpHc/2kJOM+y0sPKN47VdzA==",
+      "dev": true
+    },
+    "node_modules/globule/node_modules/lodash": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+      "integrity": "sha512-0VSEDVec/Me2eATuoiQd8IjyBMMX0fahob8YJ96V1go2RjvCk1m1GxmtfXn8RNSaLaTtop7fsuhhu9oLk3hUgA==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/globule/node_modules/minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha512-zZ+Jy8lVWlvqqeM8iZB7w7KmQkoJn8djM585z88rywrEbzoqawVa9FR5p2hwD+y74nfuKOjmNvi9gtWJNLqHvA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/growl": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz",
+      "integrity": "sha512-VWv7s1EI41AG2LiCr7uAuxWikLDN1SQOuEUc37d/P34NAIIYgkvWYngNw0d9d9iCrDFL0SYCE9UQpxhIjjtuLg==",
+      "dev": true
+    },
+    "node_modules/grunt": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+      "integrity": "sha512-1iq3ylLjzXqz/KSq1OAE2qhnpcbkF2WyhsQcavZt+YmgvHu0EbPMEhGhy2gr0FP67isHpRdfwjB5WVeXXcJemQ==",
+      "dev": true,
+      "dependencies": {
+        "async": "~0.1.22",
+        "coffee-script": "~1.3.3",
+        "colors": "~0.6.2",
+        "dateformat": "1.0.2-1.2.3",
+        "eventemitter2": "~0.4.13",
+        "exit": "~0.1.1",
+        "findup-sync": "~0.1.2",
+        "getobject": "~0.1.0",
+        "glob": "~3.1.21",
+        "grunt-legacy-log": "~0.1.0",
+        "grunt-legacy-util": "~0.2.0",
+        "hooker": "~0.2.3",
+        "iconv-lite": "~0.2.11",
+        "js-yaml": "~2.0.5",
+        "lodash": "~0.9.2",
+        "minimatch": "~0.2.12",
+        "nopt": "~1.0.10",
+        "rimraf": "~2.2.8",
+        "underscore.string": "~2.2.1",
+        "which": "~1.0.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/grunt-browserify": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/grunt-browserify/-/grunt-browserify-3.8.0.tgz",
+      "integrity": "sha512-0wnAp/xFi/BKSEVRGR7ktaEnCXsRW+yWjVrKj1x+dwWKjRFMQt2nl1Rh5rpwbDuOYATOpYkbuOv6fDi0avxV0Q==",
+      "dev": true,
+      "dependencies": {
+        "async": "^0.9.0",
+        "browserify": "^10.0.0",
+        "glob": "^5.0.5",
+        "lodash": "^3.8.0",
+        "resolve": "^1.1.6",
+        "watchify": "^3.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.x"
+      }
+    },
+    "node_modules/grunt-browserify/node_modules/async": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+      "integrity": "sha512-l6ToIJIotphWahxxHyzK9bnLR6kM4jJIIgLShZeqLY7iboHoGkdgFl7W2/Ivi4SkMJYGKqW8vSuk0uKUj6qsSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/grunt-browserify/node_modules/glob": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+      "integrity": "sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/grunt-browserify/node_modules/lodash": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "integrity": "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/grunt-browserify/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/grunt-coffeelint": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/grunt-coffeelint/-/grunt-coffeelint-0.0.13.tgz",
+      "integrity": "sha512-AjoY762pHh703irpowkm45FkrWlDuNAcEo6PdfCMPFClV0+vPeoipeuq/qCSEQmklXtuOpnWrH+lwatrTBzVYg==",
+      "dev": true,
+      "dependencies": {
+        "coffeelint-stylish": "~0.1.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "peerDependencies": {
+        "coffeelint": "^1",
+        "grunt": "~0.4"
+      }
+    },
+    "node_modules/grunt-contrib-coffee": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-coffee/-/grunt-contrib-coffee-0.11.1.tgz",
+      "integrity": "sha512-Gu8BMXbVns+Zfyy4DiGOnYpEd4Ac6YIZzA24FzxLbNQqupxgk6EKk8YibXXd3umn/1KXcrSNGXjDyAJPIAlhHw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "~0.5.0",
+        "coffee-script": "~1.7.0",
+        "lodash": "~2.4.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "peerDependencies": {
+        "grunt": "~0.4.0"
+      }
+    },
+    "node_modules/grunt-contrib-coffee/node_modules/ansi-regex": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+      "integrity": "sha512-sGwIGMjhYdW26/IhwK2gkWWI8DRCVO6uj3hYgHT+zD+QL1pa37tM3ujhyfcJIYSbsxp7Gxhy7zrRW/1AHm4BmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/grunt-contrib-coffee/node_modules/ansi-styles": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+      "integrity": "sha512-f2PKUkN5QngiSemowa6Mrk9MPCdtFiOSmibjZ+j1qhLGHHYsqZwmBMRF3IRMVXo8sybDqx2fJl2d/8OphBoWkA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/grunt-contrib-coffee/node_modules/chalk": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+      "integrity": "sha512-bIKA54hP8iZhyDT81TOsJiQvR1gW+ZYSXFaZUAvoD4wCHdbHY2actmpTE4x344ZlFqHbvoxKOaESULTZN2gstg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^1.1.0",
+        "escape-string-regexp": "^1.0.0",
+        "has-ansi": "^0.1.0",
+        "strip-ansi": "^0.3.0",
+        "supports-color": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/grunt-contrib-coffee/node_modules/coffee-script": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.7.1.tgz",
+      "integrity": "sha512-W3s+SROY73OmrSGtPTTW/2wp2rmW5vuh0/tUuCK1NvTuyzLOVPccIP9whmhZ4cYWcr2NJPNENZIFaAMkTD5G3w==",
+      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mkdirp": "~0.3.5"
+      },
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/grunt-contrib-coffee/node_modules/has-ansi": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+      "integrity": "sha512-1YsTg1fk2/6JToQhtZkArMkurq8UoWU1Qe0aR3VUHjgij4nOylSWLWAtBXoZ4/dXOmugfLGm1c+QhuD0JyedFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^0.2.0"
+      },
+      "bin": {
+        "has-ansi": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/grunt-contrib-coffee/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/grunt-contrib-coffee/node_modules/mkdirp": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+      "integrity": "sha512-8OCq0De/h9ZxseqzCH8Kw/Filf5pF/vMI6+BH7Lu0jXz2pqYCjTAQRolSxRIi+Ax+oCCjlxoJMP0YQ4XlrQNHg==",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/grunt-contrib-coffee/node_modules/strip-ansi": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+      "integrity": "sha512-DerhZL7j6i6/nEnVG0qViKXI0OKouvvpsAiaj7c+LfqZZZxdwZtv8+UiA/w4VUJpT8UzX0pR1dcHOii1GbmruQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^0.2.1"
+      },
+      "bin": {
+        "strip-ansi": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/grunt-contrib-coffee/node_modules/supports-color": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+      "integrity": "sha512-tdCZ28MnM7k7cJDJc7Eq80A9CsRFAAOZUy41npOZCs++qSjfIy7o5Rh46CBk+Dk5FbKJ33X3Tqg4YrV07N5RaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "supports-color": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/grunt-contrib-compress": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-compress/-/grunt-contrib-compress-0.12.0.tgz",
+      "integrity": "sha512-y8ouyXioQwFOYKQ00H8yKPeXrufZ5VRwgqjn0LFzMMu39cPIwEJ8z6ANqnVwfDtzEHaS/TTnXakrboyQby4oCA==",
+      "dev": true,
+      "dependencies": {
+        "archiver": "~0.11.0",
+        "chalk": "^0.5.1",
+        "prettysize": "~0.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "peerDependencies": {
+        "grunt": "~0.4.0"
+      }
+    },
+    "node_modules/grunt-contrib-compress/node_modules/ansi-regex": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+      "integrity": "sha512-sGwIGMjhYdW26/IhwK2gkWWI8DRCVO6uj3hYgHT+zD+QL1pa37tM3ujhyfcJIYSbsxp7Gxhy7zrRW/1AHm4BmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/grunt-contrib-compress/node_modules/ansi-styles": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+      "integrity": "sha512-f2PKUkN5QngiSemowa6Mrk9MPCdtFiOSmibjZ+j1qhLGHHYsqZwmBMRF3IRMVXo8sybDqx2fJl2d/8OphBoWkA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/grunt-contrib-compress/node_modules/chalk": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+      "integrity": "sha512-bIKA54hP8iZhyDT81TOsJiQvR1gW+ZYSXFaZUAvoD4wCHdbHY2actmpTE4x344ZlFqHbvoxKOaESULTZN2gstg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^1.1.0",
+        "escape-string-regexp": "^1.0.0",
+        "has-ansi": "^0.1.0",
+        "strip-ansi": "^0.3.0",
+        "supports-color": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/grunt-contrib-compress/node_modules/has-ansi": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+      "integrity": "sha512-1YsTg1fk2/6JToQhtZkArMkurq8UoWU1Qe0aR3VUHjgij4nOylSWLWAtBXoZ4/dXOmugfLGm1c+QhuD0JyedFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^0.2.0"
+      },
+      "bin": {
+        "has-ansi": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/grunt-contrib-compress/node_modules/strip-ansi": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+      "integrity": "sha512-DerhZL7j6i6/nEnVG0qViKXI0OKouvvpsAiaj7c+LfqZZZxdwZtv8+UiA/w4VUJpT8UzX0pR1dcHOii1GbmruQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^0.2.1"
+      },
+      "bin": {
+        "strip-ansi": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/grunt-contrib-compress/node_modules/supports-color": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+      "integrity": "sha512-tdCZ28MnM7k7cJDJc7Eq80A9CsRFAAOZUy41npOZCs++qSjfIy7o5Rh46CBk+Dk5FbKJ33X3Tqg4YrV07N5RaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "supports-color": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/grunt-contrib-copy": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-0.5.0.tgz",
+      "integrity": "sha512-qJkJqvttTuVV7hXaQ91ctB1Anha0z6pyZuBlz+Trw8O5tFJ5hpB5f3BNxMfSgO7ciSgw36FgAovLg992x3dqKw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "peerDependencies": {
+        "grunt": "~0.4.0"
+      }
+    },
+    "node_modules/grunt-contrib-watch": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-0.6.1.tgz",
+      "integrity": "sha512-Ea4f3anehA6G+S88vyTwewA/Mf6SbadTIxSgQClKbZYnHOcJ0PrGc2p+uzR6hS9gp7DG6ObvaxkmE8HKnLOsfA==",
+      "dev": true,
+      "dependencies": {
+        "async": "~0.2.9",
+        "gaze": "~0.5.1",
+        "lodash": "~2.4.1",
+        "tiny-lr-fork": "0.0.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "peerDependencies": {
+        "grunt": "~0.4.0"
+      }
+    },
+    "node_modules/grunt-contrib-watch/node_modules/async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ==",
+      "dev": true
+    },
+    "node_modules/grunt-contrib-watch/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/grunt-legacy-log": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
+      "integrity": "sha512-qYs/uM0ImdzwIXLhS4O5WLV5soAM+PEqqHI/hzSxlo450ERSccEhnXqoeDA9ZozOdaWuYnzTOTwRcVRogleMxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colors": "~0.6.2",
+        "grunt-legacy-log-utils": "~0.1.1",
+        "hooker": "~0.2.3",
+        "lodash": "~2.4.1",
+        "underscore.string": "~2.3.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/grunt-legacy-log-utils": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
+      "integrity": "sha512-D0vbUX00TFYCKNZtcZzemMpwT8TR/FdRs1pmfiBw6qnUw80PfsjV+lhIozY/3eJ3PSG2zj89wd2mH/7f4tNAlw==",
+      "dev": true,
+      "dependencies": {
+        "colors": "~0.6.2",
+        "lodash": "~2.4.1",
+        "underscore.string": "~2.3.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/grunt-legacy-log-utils/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/grunt-legacy-log-utils/node_modules/underscore.string": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+      "integrity": "sha512-hbD5MibthuDAu4yA5wxes5bzFgqd3PpBJuClbRxaNddxfdsz+qf+1kHwrGQFrmchmDHb9iNU+6EHDn8uj0xDJg==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/grunt-legacy-log/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/grunt-legacy-log/node_modules/underscore.string": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+      "integrity": "sha512-hbD5MibthuDAu4yA5wxes5bzFgqd3PpBJuClbRxaNddxfdsz+qf+1kHwrGQFrmchmDHb9iNU+6EHDn8uj0xDJg==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/grunt-legacy-util": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+      "integrity": "sha512-cXPbfF8aM+pvveQeN1K872D5fRm30xfJWZiS63Y8W8oyIPLClCsmI8bW96Txqzac9cyL4lRqEBhbhJ3n5EzUUQ==",
+      "dev": true,
+      "dependencies": {
+        "async": "~0.1.22",
+        "exit": "~0.1.1",
+        "getobject": "~0.1.0",
+        "hooker": "~0.2.3",
+        "lodash": "~0.9.2",
+        "underscore.string": "~2.2.1",
+        "which": "~1.0.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/grunt-mocha-test": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/grunt-mocha-test/-/grunt-mocha-test-0.11.0.tgz",
+      "integrity": "sha512-BDffDt8Y724rbeUhSg3GZdhTx918hJ5WoHRdW3uXCIYNxeySoECjkmTiAEf2tHp6GYwW5sMKXk2jTqCU/LbajA==",
+      "dev": true,
+      "dependencies": {
+        "fs-extra": "~0.9.1",
+        "hooker": "~0.2.3",
+        "mocha": "~1.20.0"
+      },
+      "engines": {
+        "node": ">= 0.10.4"
+      }
+    },
+    "node_modules/grunt/node_modules/coffee-script": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+      "integrity": "sha512-QjQ1T4BqyHv19k6XSfdhy/QLlIOhywz0ekBUCa9h71zYMJlfDTGan/Z1JXzYkZ6v8R+GhvL/p4FZPbPW8WNXlg==",
+      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
+      "dev": true,
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/grunt/node_modules/glob": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+      "integrity": "sha512-ANhy2V2+tFpRajE3wN4DhkNQ08KDr0Ir1qL12/cUe5+a7STEK8jkW4onUYuY8/06qAFuT5je7mjAqzx0eKI2tQ==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "graceful-fs": "~1.2.0",
+        "inherits": "1",
+        "minimatch": "~0.2.11"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/grunt/node_modules/graceful-fs": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+      "integrity": "sha512-iiTUZ5vZ+2ZV+h71XAgwCSu6+NAizhFU3Yw8aC/hH5SQ3SnISqEqAek40imAFGtDcwJKNhXvSY+hzIolnLwcdQ==",
+      "deprecated": "please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js",
+      "dev": true,
+      "license": "BSD",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/grunt/node_modules/inherits": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+      "integrity": "sha512-Al67oatbRSo3RV5hRqIoln6Y5yMVbJSIn4jEJNL7VCImzq/kLr7vvb6sFRJXqr8rpHc/2kJOM+y0sPKN47VdzA==",
+      "dev": true
+    },
+    "node_modules/grunt/node_modules/minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha512-zZ+Jy8lVWlvqqeM8iZB7w7KmQkoJn8djM585z88rywrEbzoqawVa9FR5p2hwD+y74nfuKOjmNvi9gtWJNLqHvA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
+      "integrity": "sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-color": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+      "integrity": "sha512-kaNz5OTAYYmt646Hkqw50/qyxP2vFnTVu5AQ1Zmk22Kk5+4Qx6BpO8+u7IKsML5fOsFk0ZT0AcCJNYwcvaLBvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha512-IBXk4GTsLYdQ7Rvt+GRBrFSVEkmuOUy4re0Xjd9kJSUQpnTrWR4/y9RpfexN9vkAPMFuQoeWKwqzPozRTlasGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha512-ODYZC64uqzmtfGMEAX/FvZiRyWLpAC3vYnNunURUnkGVTS+mI0smVsWaPydRBsE3g+ok7h960jChO8mFcWlHaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-values/node_modules/kind-of": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+      "integrity": "sha512-24XsCxmEbRwEDbz/qz3stgin8TTzZ1ESR56OMCN0ujYg+vRutNSiOj9bHH9u85DKgXguraugV5sFuvbD4FW/hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/hash-base": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.5.tgz",
+      "integrity": "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/heap": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.7.tgz",
+      "integrity": "sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==",
+      "license": "MIT"
+    },
+    "node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/hooker": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+      "integrity": "sha512-t+UerCsQviSymAInD01Pw+Dn/usmz1sRO+3Zk1+lx8eg+WKpD2ulcwWqHHL0+aseRBr+3+vIhiG1K1JTwaIcTA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/htmlescape": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
+      "integrity": "sha512-eVcrzgbR4tim7c7soKQKtxa/kQM4TzjnlU83rcZ9bHU6t31ehfV7SktN6McWgwPWg+JYMA/O3qpGxBvFq1z2Jg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/http-browserify": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
+      "integrity": "sha512-Irf/LJXmE3cBzU1eaR4+NEX6bmVLqt1wkmDiA7kBwH7zmb0D8kBAXsDmQ88hhj/qv9iEZKlyGx/hrMcFi8sOHw==",
+      "dev": true,
+      "license": "MIT/X11",
+      "dependencies": {
+        "Base64": "~0.2.0",
+        "inherits": "~2.0.1"
+      }
+    },
+    "node_modules/https-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
+      "integrity": "sha512-EjDQFbgJr1vDD/175UJeSX3ncQ3+RUnCL5NkthQGHvF4VNHlzTy8ifJfTqz47qiPRqaFH58+CbuG3x51WuB1XQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+      "integrity": "sha512-KhmFWgaQZY83Cbhi+ADInoUQ8Etn6BG5fikM9syeOjQltvR45h7cRKJ/9uvQEuD61I3Uju77yYce0/LhKVClQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg==",
+      "dev": true
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/inline-source-map": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz",
+      "integrity": "sha512-2WtHG0qX9OH9TVcxsLVfq3Tzr+qtL6PtWgoh0XAAKe4KkdA/57Q+OGJuRJHA4mZ2OZnkJ/ZAaXf9krLB12/nIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "~0.4.0"
+      }
+    },
+    "node_modules/insert-module-globals": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.3.tgz",
+      "integrity": "sha512-ryk8hTKUZCc300SPOOwx30WhE5oRUssPDVlIoO8vtoMNBy5HGeesVRl3HF7ra4ll42T0IdnwD9XR9svh6+RRhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "combine-source-map": "~0.6.1",
+        "concat-stream": "~1.4.1",
+        "is-buffer": "^1.1.0",
+        "JSONStream": "^1.0.3",
+        "lexical-scope": "^1.2.0",
+        "process": "~0.11.0",
+        "through2": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "insert-module-globals": "bin/cmd.js"
+      }
+    },
+    "node_modules/is-accessor-descriptor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.2.tgz",
+      "integrity": "sha512-AIbwAcazqP3R65dGvqk1V+a+vE5Fg1yu/ZKMOiBWSUIXXiwQkYmXQcVa2O0nh0tSDKDFKxG2mY7dB1Sr4hEP1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "integrity": "sha512-9fRVlXc0uCxEDj1nQzaWONSpbTfx0FmJfzHF7pwlI8DkWGoHBBea4Pg5Ky0ojwwxQmnSifgbKkI06Qv0Ljgj+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-descriptor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.1.tgz",
+      "integrity": "sha512-bc4NlCDiCr28U4aEsQ3Qs2491gVq4V8G7MQyws968ImqjKuYtTJXrl7Vq7jsN7Ly/C3xj5KWFrY7sHNeDkAzXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-descriptor": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.4.tgz",
+      "integrity": "sha512-bv5z95W0dDtLfKwDfkTNxaRxmISBD3eQBKJeVxv2AQ7MjuUnDNG7cIQqvFtMOUYhsILWHhMayWdoGqNqYYYjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.2",
+        "is-data-descriptor": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha512-mkk3vzUHFjzKjpCXeu+IjXeZD+QOTjUUdubgmHtHTDwvAO2ZTkMTTVrapts5CWz3JvJryh/4KWZpjeZrCepZ3A==",
+      "deprecated": "Jade has been renamed to pug, please install the latest version of pug instead of jade",
+      "dev": true,
+      "dependencies": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "bin": {
+        "jade": "bin/jade"
+      }
+    },
+    "node_modules/jade/node_modules/commander": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+      "integrity": "sha512-0fLycpl1UMTGX257hRsu/arL/cUbcvQM4zMKwvLvzXtfdezIV4yotPS2dYtknF+NmEfWSoCEF6+hj9XLm/6hEw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.x"
+      }
+    },
+    "node_modules/jade/node_modules/mkdirp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+      "integrity": "sha512-OHsdUcVAQ6pOtg5JYWpCBo9W/GySVuwvP9hueRMW7UqshC0tbfzLv8wjySTPm3tfUZ/21CE9E1pJagOA91Pxew==",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "dev": true,
+      "license": "MIT/X11",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/jit-grunt": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/jit-grunt/-/jit-grunt-0.8.0.tgz",
+      "integrity": "sha512-mJ80LXh3rDLhlLMhqZsLu38QZlUR2bKrnT993DnlcvKSECKdt3/1+MNoMaUV8jbKIw16EdxODMPTuLsC8rGg/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      },
+      "peerDependencies": {
+        "grunt": "~0.4.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+      "integrity": "sha512-VEKcIksckDBUhg2JS874xVouiPkywVUh4yyUmLCDe1Zg3bCd6M+F1eGPenPeHLc2XC8pp9G8bsuofK0NeEqRkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "~ 0.1.11",
+        "esprima": "~ 1.0.2"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/json-stable-stringify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+      "integrity": "sha512-nKtD/Qxm7tWdZqJoldEC7fF0S41v0mWbeaXG3637stOWfyGxTgWTYE2wtfKmjzpvxv2MA2xzxsXOIiwUpkX6Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsonify": "~0.0.0"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-1.1.1.tgz",
+      "integrity": "sha512-yrmo536TrJWDHNYlkCjtkPSqNnAkt6u1k89O5Xxr53zc4DkdikTHE+Fx6VF7syJd18xsdo24U4csedAkhLgxVQ==",
+      "dev": true
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      },
+      "bin": {
+        "JSONStream": "bin.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/labeled-stream-splicer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
+      "integrity": "sha512-3KBjPRnXrYC5h2jEf/d6hO7Lcl+38QzRVTOyHA2sFzZVMYwsUFuejlrOMwAjmz13hVBr9ruDS1RwE4YEz8P58w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "isarray": "~0.0.1",
+        "stream-splicer": "^1.1.0"
+      }
+    },
+    "node_modules/lazystream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz",
+      "integrity": "sha512-4CsO3TC1MtG8s7pCxvwn6oK0MhMbJ3iqOqgYNbfEkTl8EavjlAVL+1m3iGErKifc1M0+WJkKcI7wuqhsYmfYtw==",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "~1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/lexical-scope": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
+      "integrity": "sha512-ntJ8IcBCuKwudML7vAuT/L0aIMU0+9vO25K4CjLPYgzf1NZ0bAhJJBZrvkO+oUGgKcbdkH8UZdRsaEg+wULLRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "astw": "^2.0.0"
+      }
+    },
+    "node_modules/load-grunt-config": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/load-grunt-config/-/load-grunt-config-0.13.2.tgz",
+      "integrity": "sha512-8rtJvmyRxZwZ5+dYJChdOljF457OEEEIfv4JT8Qsp3TX0Pcoq2y8KRukbrC0bujyh8tv38cx0CrbSsEeFR9Xhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "~0.2.10",
+        "glob": "~3.2.6",
+        "jit-grunt": "~0.8.0",
+        "js-yaml": "~3.0.1",
+        "load-grunt-tasks": "~0.3.0",
+        "lodash-node": "~2.4.1"
+      }
+    },
+    "node_modules/load-grunt-config/node_modules/async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ==",
+      "dev": true
+    },
+    "node_modules/load-grunt-config/node_modules/glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha512-hVb0zwEZwC1FXSKRPFTeOtN7AArJcJlI6ULGLtrstaswKNlrTJqAA+1lYlSUop4vjA423xlBzqfVS3iWGlqJ+g==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "inherits": "2",
+        "minimatch": "0.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/load-grunt-config/node_modules/js-yaml": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.2.tgz",
+      "integrity": "sha512-8PVwV1480dnAPMj8FCW3I/mZZ+gvtOoMAZFWJKagkFq2eWv5kcyzWTR+6MloV0SY57t6jSIaKc7DIz86K9ZCfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "~ 0.1.11",
+        "esprima": "~ 1.0.2"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/load-grunt-config/node_modules/minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha512-WFX1jI1AaxNTZVOHLBVazwTWKaQjoykSzCBNXB72vDTCzopQGtyP91tKdFK5cv1+qMwPyiTu1HqUriqplI8pcA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/load-grunt-tasks": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-0.3.0.tgz",
+      "integrity": "sha512-bgZqR+scmG37RTcJbZgXbH6pfohQl2F7j5wVqNHXS35B280LQKvI5ftMik0Q5qMR8tTecWEtLVNLRdSQGtQeWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "findup-sync": "~0.1.2",
+        "globule": "~0.2.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/load-grunt-tasks/node_modules/glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha512-hVb0zwEZwC1FXSKRPFTeOtN7AArJcJlI6ULGLtrstaswKNlrTJqAA+1lYlSUop4vjA423xlBzqfVS3iWGlqJ+g==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "inherits": "2",
+        "minimatch": "0.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/load-grunt-tasks/node_modules/glob/node_modules/minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha512-WFX1jI1AaxNTZVOHLBVazwTWKaQjoykSzCBNXB72vDTCzopQGtyP91tKdFK5cv1+qMwPyiTu1HqUriqplI8pcA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/load-grunt-tasks/node_modules/globule": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-0.2.0.tgz",
+      "integrity": "sha512-mMhYxzb8wpE7VtHkJi+jk0yjlBLFetYMAnkcFutmDo4uSFAHu/1tLgVm9Y6HcaTaX1DZBJjZOM1KqqCZDvBLBw==",
+      "dev": true,
+      "dependencies": {
+        "glob": "~3.2.7",
+        "lodash": "~2.4.1",
+        "minimatch": "~0.2.11"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/load-grunt-tasks/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/load-grunt-tasks/node_modules/minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha512-zZ+Jy8lVWlvqqeM8iZB7w7KmQkoJn8djM585z88rywrEbzoqawVa9FR5p2hwD+y74nfuKOjmNvi9gtWJNLqHvA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+      "integrity": "sha512-LVbt/rjK62gSbhehDVKL0vlaime4Y1IBixL+bKeNfoY4L2zab/jGrxU6Ka05tMA/zBxkTk5t3ivtphdyYupczw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/lodash-node": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz",
+      "integrity": "sha512-egEt8eNQp2kZWRmngahiqMoDCDCENv3uM188S7Ed5t4k3v6RrLELXC+FqLNMUnhCo7gvQX3G1V8opK/Lcslahg==",
+      "deprecated": "This package is discontinued. Use lodash@^4.0.0.",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash._basebind": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz",
+      "integrity": "sha512-VGHm6DH+1UiuafQdE/DNMqxOcSyhRu0xO9+jPDq7xITRn5YOorGrHVQmavMVXCYmTm80YRTZZCn/jTW7MokwLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._basecreate": "~2.4.1",
+        "lodash._setbinddata": "~2.4.1",
+        "lodash._slice": "~2.4.1",
+        "lodash.isobject": "~2.4.1"
+      }
+    },
+    "node_modules/lodash._basecreate": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+      "integrity": "sha512-8JJ3FnMPm54t3BwPLk8q8mPyQKQXm/rt9df+awr4NGtyJrtcCXM3Of1I86S6jVy1b4yAyFBb8wbKPEauuqzRmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._isnative": "~2.4.1",
+        "lodash.isobject": "~2.4.1",
+        "lodash.noop": "~2.4.1"
+      }
+    },
+    "node_modules/lodash._basecreatecallback": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz",
+      "integrity": "sha512-SLczhg860fGW7AKlYcuOFstDtJuQhaANlJ4Y/jrOoRxhmVtK41vbJDH3OefVRSRkSCQo4HI82QVkAVsoGa5gSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._setbinddata": "~2.4.1",
+        "lodash.bind": "~2.4.1",
+        "lodash.identity": "~2.4.1",
+        "lodash.support": "~2.4.1"
+      }
+    },
+    "node_modules/lodash._basecreatewrapper": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz",
+      "integrity": "sha512-x2ja1fa/qmzbizuXgVM4QAP9svtMbdxjG8Anl9bCeDAwLOVQ1vLrA0hLb/NkpbGi9evjtkl0aWLTEoOlUdBPQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._basecreate": "~2.4.1",
+        "lodash._setbinddata": "~2.4.1",
+        "lodash._slice": "~2.4.1",
+        "lodash.isobject": "~2.4.1"
+      }
+    },
+    "node_modules/lodash._createwrapper": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz",
+      "integrity": "sha512-5TCfLt1haQpsa7bgLYRKNNE4yqhO4ZxIayN1btQmazMchO6Q8JYFRMqbJ3W+uNmMm4R0Jw7KGkZX5YfDDnywuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._basebind": "~2.4.1",
+        "lodash._basecreatewrapper": "~2.4.1",
+        "lodash._slice": "~2.4.1",
+        "lodash.isfunction": "~2.4.1"
+      }
+    },
+    "node_modules/lodash._isnative": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+      "integrity": "sha512-BOlKGKNHhCHswGOWtmVb5zBygyxN7EmTuzVOSQI6QSoGhG+kvv71gICFS1TBpnqvT1n53txK8CDK3u5D2/GZxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash._objecttypes": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+      "integrity": "sha512-XpqGh1e7hhkOzftBfWE7zt+Yn9mVHFkDhicVttvKLsoCMLVVL+xTQjfjB4X4vtznauxv0QZ5ZAeqjvat0dh62Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash._setbinddata": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
+      "integrity": "sha512-Vx0XKzpg2DFbQw4wrp1xSWd2sfl3W/BG6bucSRZmftS1AzbWRemCmBQDxyQTNhlLNec428PXkuuja+VNBZgu2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._isnative": "~2.4.1",
+        "lodash.noop": "~2.4.1"
+      }
+    },
+    "node_modules/lodash._shimkeys": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+      "integrity": "sha512-lBrglYxLD/6KAJ8IEa5Lg+YHgNAL7FyKqXg4XOUI+Du/vtniLs1ZqS+yHNKPkK54waAgkdUnDOYaWf+rv4B+AA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._objecttypes": "~2.4.1"
+      }
+    },
+    "node_modules/lodash._slice": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz",
+      "integrity": "sha512-+odPJa4PE2UgYnQgJgkLs0UD03QU78R2ivhrFnG9GdtYOZdE6ObxOj7KiUEUlqOOgatFT+ZqSypFjDSduTigKg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.bind": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz",
+      "integrity": "sha512-hn2VWYZ+N9aYncRad4jORvlGgpFrn+axnPIWRvFxjk6CWcZH5b5alI8EymYsHITI23Z9wrW/+ORq+azrVFpOfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._createwrapper": "~2.4.1",
+        "lodash._slice": "~2.4.1"
+      }
+    },
+    "node_modules/lodash.defaults": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+      "integrity": "sha512-5wTIPWwGGr07JFysAZB8+7JB2NjJKXDIwogSaRX5zED85zyUAQwtOqUk8AsJkkigUcL3akbHYXd5+BPtTGQPZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._objecttypes": "~2.4.1",
+        "lodash.keys": "~2.4.1"
+      }
+    },
+    "node_modules/lodash.foreach": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-2.4.1.tgz",
+      "integrity": "sha512-AvOobAkE7qBtIiHU5QHQIfveWH5Usr9pIcFIzBv7u4S6bvb3FWpFrh9ltqBY7UeL5lw6e8d+SggiUXQVyh+FpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._basecreatecallback": "~2.4.1",
+        "lodash.forown": "~2.4.1"
+      }
+    },
+    "node_modules/lodash.forown": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.forown/-/lodash.forown-2.4.1.tgz",
+      "integrity": "sha512-VC+CKm/zSs5t3i/MHv71HZoQphuqOvez1xhjWBwHU5zAbsCYrqwHr+MyQyMk14HzA3hSRNA5lCqDMSw5G2Qscg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._basecreatecallback": "~2.4.1",
+        "lodash._objecttypes": "~2.4.1",
+        "lodash.keys": "~2.4.1"
+      }
+    },
+    "node_modules/lodash.identity": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz",
+      "integrity": "sha512-VRYX+8XipeLjorag5bz3YBBRJ+5kj8hVBzfnaHgXPZAVTYowBdY5l0M5ZnOmlAMCOXBFabQtm7f5VqjMKEji0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isfunction": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz",
+      "integrity": "sha512-6XcAB3izeQxPOQQNAJbbdjXbvWEt2Pn9ezPrjr4CwoLwmqsLVbsiEXD19cmmt4mbzOCOCdHzOQiUivUOJLra7w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isobject": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+      "integrity": "sha512-sTebg2a1PoicYEZXD5PBdQcTlIJ6hUslrlWr7iV0O7n+i4596s2NQ9I5CaZ5FbXSfya/9WQsrYLANUJv9paYVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._objecttypes": "~2.4.1"
+      }
+    },
+    "node_modules/lodash.keys": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+      "integrity": "sha512-ZpJhwvUXHSNL5wYd1RM6CUa2ZuqorG9ngoJ9Ix5Cce+uX7I5O/E06FCJdhSZ33b5dVyeQDnIlWH7B2s5uByZ7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._isnative": "~2.4.1",
+        "lodash._shimkeys": "~2.4.1",
+        "lodash.isobject": "~2.4.1"
+      }
+    },
+    "node_modules/lodash.memoize": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
+      "integrity": "sha512-eDn9kqrAmVUC1wmZvlQ6Uhde44n+tXpqPrN8olQJbttgh0oKclk+SF54P47VEGE9CEiMeRwAP8BaM7UHvBkz2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.noop": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
+      "integrity": "sha512-uNcV98/blRhInPUGQEnj9ekXXfG+q+rfoNSFZgl/eBfog9yBDW9gfUv2AHX/rAF7zZRlzWhbslGhbGQFZlCkZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.support": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.4.1.tgz",
+      "integrity": "sha512-6SwqWwGFHhTXEiqB/yQgu8FYd//tm786d49y7kizHVCJH7zdzs191UQn3ES3tkkDbUddNRfkCRYqJFHtbLnbCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._isnative": "~2.4.1"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-visit": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/micromatch/node_modules/extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/micromatch/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/micromatch/node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/miller-rabin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
+      },
+      "bin": {
+        "miller-rabin": "bin/miller-rabin"
+      }
+    },
+    "node_modules/miller-rabin/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/min-document": {
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.2.tgz",
+      "integrity": "sha512-8S5I8db/uZN8r9HSLFVWPdJCvYOejMcEC82VIzNUc6Zkklf/d1gg2psfE79/vyhWOj4+J8MtwmoOz3TmvaGu5A==",
+      "license": "MIT",
+      "dependencies": {
+        "dom-walk": "^0.1.0"
+      }
+    },
+    "node_modules/minifyify": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/minifyify/-/minifyify-4.4.0.tgz",
+      "integrity": "sha512-Btguwl72Z3WUAJoOPWV599R30/VwIHqs2IlCKZSHlFTftFaoyfJoDfcTS66cqbsEhHSdXy4+PGEgjrI4QRYE6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "concat-stream": "1.4.x",
+        "convert-source-map": "^0.4.0",
+        "lodash.bind": "2.4.x",
+        "lodash.defaults": "2.4.x",
+        "lodash.foreach": "2.4.x",
+        "mkdirp": "^0.5.0",
+        "source-map": "0.1.34",
+        "through": "2.3.x",
+        "tmp": "0.0.23",
+        "uglify-js": "2.4.x"
+      },
+      "engines": {
+        "node": "0.10.x"
+      }
+    },
+    "node_modules/minifyify/node_modules/convert-source-map": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.4.1.tgz",
+      "integrity": "sha512-yFU/yTFbnlUH0wnu33o7hZwbcGmmnKw2uLAxLPnWW8zh+o7+xq7LmB4DMqKo5IniPcRs6quLHZ/A5ogSYhU1qw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minifyify/node_modules/source-map": {
+      "version": "0.1.34",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+      "integrity": "sha512-yfCwDj0vR9RTwt3pEzglgb3ZgmcXHt6DjG3bjJvzPwTL+5zDQ2MhmSzAcTy0GTiQuCiriSWXvWM1/NhKdXuoQA==",
+      "dev": true,
+      "dependencies": {
+        "amdefine": ">=0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mixin-deep": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mixin-deep/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mocha": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.20.1.tgz",
+      "integrity": "sha512-25Nq3BuIYCy80uEix+hBlZcr/gnLzpcYqfsaPAxZm2qbMFmed8I3nP8N05KagK4BTkGYUvsRJ47istvRqFO8fw==",
+      "deprecated": "Mocha v1.x is no longer supported.",
+      "dev": true,
+      "dependencies": {
+        "commander": "2.0.0",
+        "debug": "*",
+        "diff": "1.0.7",
+        "glob": "3.2.3",
+        "growl": "1.7.x",
+        "jade": "0.26.3",
+        "mkdirp": "0.3.5"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 0.4.x"
+      }
+    },
+    "node_modules/mocha/node_modules/glob": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+      "integrity": "sha512-WPaLsMHD1lYEqAmIQI6VOJSPwuBdGShDWnj1yUo0vQqEO809R8W3LM9OVU13CnnDhyv/EiNwOtxEW74SmrzS6w==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "graceful-fs": "~2.0.0",
+        "inherits": "2",
+        "minimatch": "~0.2.11"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mocha/node_modules/graceful-fs": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+      "integrity": "sha512-hcj/NTUWv+C3MbqrVb9F+aH6lvTwEHJdx2foBxlrVq5h6zE8Bfu4pv4CAAqbDcZrw/9Ak5lsRXlY9Ao8/F0Tuw==",
+      "deprecated": "please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js",
+      "dev": true,
+      "license": "BSD",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha512-zZ+Jy8lVWlvqqeM8iZB7w7KmQkoJn8djM585z88rywrEbzoqawVa9FR5p2hwD+y74nfuKOjmNvi9gtWJNLqHvA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mocha/node_modules/mkdirp": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+      "integrity": "sha512-8OCq0De/h9ZxseqzCH8Kw/Filf5pF/vMI6+BH7Lu0jXz2pqYCjTAQRolSxRIi+Ax+oCCjlxoJMP0YQ4XlrQNHg==",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/module-deps": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
+      "integrity": "sha512-EbWWlSGaCVidEsLsSzkY6l/jm0IcGDSQ8tGwtjM8joTrxqxP0om02Px9Np8D7FMZ/vZFdsOGbio+WqkKQxYuTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browser-resolve": "^1.7.0",
+        "concat-stream": "~1.4.5",
+        "defined": "^1.0.0",
+        "detective": "^4.0.0",
+        "duplexer2": "0.0.2",
+        "inherits": "^2.0.1",
+        "JSONStream": "^1.0.3",
+        "parents": "^1.0.0",
+        "readable-stream": "^1.1.13",
+        "resolve": "^1.1.3",
+        "stream-combiner2": "~1.0.0",
+        "subarg": "^1.0.0",
+        "through2": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "module-deps": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/module-deps/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nan": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+      "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nanomatch/node_modules/extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nanomatch/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nanomatch/node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ncp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.5.1.tgz",
+      "integrity": "sha512-l+pJxuLlzwp11Dy72MJgCPNwIbXdv6imaACLiEMb2TIDyr54qz+nAZeD5qDlJefveaJ+R9Ug6KuozCxRpQXO0Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "ncp": "bin/ncp"
+      }
+    },
+    "node_modules/nomnom": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.0.tgz",
+      "integrity": "sha512-RlJzWaD7QE63jZeqHu7LgBFFwZ4XLkhdULsF3MZw20ZS0nJ9UunU7dmXHLQ6IQaDDwOg6qVFpgrjYMkERTbxlw==",
+      "deprecated": "Package no longer supported. Contact support@npmjs.com for more info.",
+      "dev": true,
+      "dependencies": {
+        "chalk": "~0.4.0",
+        "underscore": "~1.6.0"
+      }
+    },
+    "node_modules/nomnom/node_modules/ansi-styles": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+      "integrity": "sha512-3iF4FIKdxaVYT3JqQuY3Wat/T2t7TRbbQ94Fu50ZUCbLy4TFbTzr90NOHQodQkNqmeEGCw8WbeP78WNi6SKYUA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/nomnom/node_modules/chalk": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+      "integrity": "sha512-sQfYDlfv2DGVtjdoQqxS0cEZDroyG8h6TamA6rvxwlrU5BaSLDx9xhatBYl2pxZ7gmpNaPFVwBtdGdu5rQ+tYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "~1.0.0",
+        "has-color": "~0.1.0",
+        "strip-ansi": "~0.1.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/nomnom/node_modules/strip-ansi": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+      "integrity": "sha512-behete+3uqxecWlDAm5lmskaSaISA+ThQ4oNNBDTBJt0x2ppR6IPqfZNuj6BLaLJ/Sji4TPZlcRyOis8wXQTLg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "strip-ansi": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/nomnom/node_modules/underscore": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+      "integrity": "sha512-z4o1fvKUojIWh9XuaVLUDdf86RQiq13AC1dmHbTpoyuu+bquHms76v16CjycCbec87J7z0k//SiQVk0sMdFmpQ==",
+      "dev": true
+    },
+    "node_modules/nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/noptify": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
+      "integrity": "sha512-EZT35r9AuK+hig+iYv4144kwfDEDhlj3zncVHw9b9d86TUYk/67BtBApkfPD1kslAT/8TTD262xdsVbV+iCSTw==",
+      "dev": true,
+      "dependencies": {
+        "nopt": "~2.0.0"
+      }
+    },
+    "node_modules/noptify/node_modules/nopt": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
+      "integrity": "sha512-uVTsuT8Hm3aN3VttY+BPKw4KU9lVpI0F22UAr/I1r6+kugMr3oyhMALkycikLcdfvGRsgzCYN48DYLBFcJEUVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "remove-trailing-separator": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha512-79LYn6VAb63zgtmAteVOWo9Vdj71ZVBy3Pbse+VqxDpEP83XuujMrGqHIwAXJ5I/aM0zU7dIyIAhifVTPrNItQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-copy/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-copy/node_modules/is-descriptor": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.8.tgz",
+      "integrity": "sha512-SceYGWXvdqlWa/OnQ5FQuV+NxvNmMRhMw/w9AHkH71hTzveND4BTYgvp16g+oITK47qbOl/3D0bl0iygehWAWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.1",
+        "is-data-descriptor": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha512-GBaMwwAVK9qbQN3Scdo0OyvgPW7l3lnaVMj84uTOZlswkX0KpF6fyDBJhtTthf7pymztoN36/KEr1DyhF96zEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/omega-pac": {
+      "resolved": "../omega-pac",
+      "link": true
+    },
+    "node_modules/omega-target": {
+      "resolved": "../omega-target",
+      "link": true
+    },
+    "node_modules/omega-web": {
+      "resolved": "../omega-web",
+      "link": true
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha512-snN4O4TkigujZphWLN0E//nQmm7790RYaE53DdL7ZYwee2D8DDo9/EyYiKUfN3rneWUjhJnueija3G9I2i0h3g==",
+      "dev": true,
+      "license": "MIT/X11",
+      "dependencies": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      }
+    },
+    "node_modules/optimist/node_modules/minimist": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+      "integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/os-browserify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+      "integrity": "sha512-aZicJZccvxWOZ0Bja2eAch2L8RIJWBuRYmM8Gwl/JjNtRltH0Itcz4eH/ESyuIWfse8cc93ZCf0XrzhXK2HEDA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/outpipe": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz",
+      "integrity": "sha512-BnNY/RwnDrkmQdUa9U+OfN/Y7AWmKuUPCCd+hbRclZnnANvYpO72zp/a6Q4n829hPbdqEac31XCcsvlEvb+rtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shell-quote": "^1.4.2"
+      }
+    },
+    "node_modules/outpipe/node_modules/shell-quote": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parents": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+      "integrity": "sha512-mXKF3xkoUt5td2DoxpLmtOmZvko9VfFpwRwkKDHSNvgmpLAeBo18YDhcPbBzJq+QLCHMbGOfzia2cX4U+0v9Mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-platform": "~0.11.15"
+      }
+    },
+    "node_modules/parse-asn1": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.9.tgz",
+      "integrity": "sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asn1.js": "^4.10.1",
+        "browserify-aes": "^1.2.0",
+        "evp_bytestokey": "^1.0.3",
+        "pbkdf2": "^3.1.5",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/parse-headers": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.6.tgz",
+      "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==",
+      "license": "MIT"
+    },
+    "node_modules/pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-platform": {
+      "version": "0.11.15",
+      "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+      "integrity": "sha512-Y30dB6rab1A/nfEKsZxmr01nUotHX0c/ZiIAsCTatEe1CmS5Pm5He7fZ195bPT7RdquoaL8lLxFCMQi/bS7IJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/pbkdf2": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.6.tgz",
+      "integrity": "sha512-BT6eelPB1EyGHo8pC0o9Bl6k6SYVhKO1jEbd3lcTrtr7XHdjP8BW1YpfCV3G9Kwkxgattk+S5q2/RvuttCsS1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "ripemd160": "^2.0.3",
+        "safe-buffer": "^5.2.1",
+        "sha.js": "^2.4.12",
+        "to-buffer": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/po2json": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/po2json/-/po2json-0.3.2.tgz",
+      "integrity": "sha512-3uL0Ul6+xmVVA3auYN6sLJ6sDSL9KFHi30afEfLSrWFuTQY//hI2zLEbkzvsfQ2XuDbHMmXl8tGQzrflVq6D/A==",
+      "dev": true,
+      "dependencies": {
+        "gettext-parser": "~0.2.0",
+        "lodash": "~2.4.1",
+        "nomnom": "1.8.0"
+      },
+      "bin": {
+        "po2json": "bin/po2json"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/po2json/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/prettysize": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/prettysize/-/prettysize-0.0.3.tgz",
+      "integrity": "sha512-EuL28yZw3GpVWuXCSj+cdVfBZbXXlfD+sbG+pL9BGuOKRFvU2hIvANcWicKbxRxJQw/niv3Vxx6fCVxkMSjEDQ==",
+      "dev": true
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/public-encrypt": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/public-encrypt/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz",
+      "integrity": "sha512-KbOrQrP5Ye+0gmq+hwxoJwAFRwExACWqwxj1IDFFgqOw9Poxy3wwSbafd9ZqP6T6ykMfnxM573kt/a4i9ybatQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/querystring-es3": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "integrity": "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/randomfill": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/read-only-stream": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-1.1.1.tgz",
+      "integrity": "sha512-CNGbvYZYr0b1F41aN7bYLHUBvvoynSS7ZTf2RLa5egnjZxKJPJUpUdWplD+jxQPijP/eL02IJxBhY8hwJlI3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^1.0.31",
+        "readable-wrap": "^1.0.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/readable-wrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
+      "integrity": "sha512-/8n0Mr10S+HGKFygQ42Z40JIXwafPH3A72pwmlNClThgsImV5LJJiCue5Je1asxwY082sYxq/+kTxH6nTn0w3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^1.1.13-1"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11",
+        "micromatch": "^3.1.10",
+        "readable-stream": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/readdirp/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readdirp/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readdirp/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readdirp/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/regex-not/node_modules/extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/regex-not/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/repeat-element": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
+      "integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz",
+      "integrity": "sha512-UHBY3viPlJKf85YijDUcikKX6tmF4SokIDp518ZDVT92JNDcG5uKIthaT/owt3Sar0lwtOafsQuwrg22/v2Dwg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==",
+      "deprecated": "https://github.com/lydell/resolve-url#deprecated",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+      "integrity": "sha512-R5KMKHnPAQaZMqLOsyuyUmcIjSeDm+73eoqQpaXA7AZ22BL+6C+1mcUscgOsNd8WVlJuvlgAPsegcx7pjlV0Dg==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ripemd160": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
+      "integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^3.1.2",
+        "inherits": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/ripemd160/node_modules/hash-base": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
+      "integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^2.3.8",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/ripemd160/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ripemd160/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/ripemd160/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ripemd160/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/ripemd160/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha512-aJXcif4xnaNUzvUuC5gcb46oTS7zvg4jpMTnuqtrEPlR3vFr4pxtdTwaF1Qs3Enjn9HK+ZlwQui+a7z0SywIzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.1.10"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-value": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "dev": true,
+      "license": "(MIT AND BSD-3-Clause)",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/shasum": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+      "integrity": "sha512-UTzHm/+AzKfO9RgPgRpDIuMSNie1ubXRaljjlhFMNGYoG7z+rm9AHLPMf70R7887xboDH9Q+5YQbWKObFHEAtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-stable-stringify": "~0.0.0",
+        "sha.js": "~2.4.4"
+      }
+    },
+    "node_modules/shasum-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/shasum-object/-/shasum-object-1.0.1.tgz",
+      "integrity": "sha512-SsC+1tW7XKQ/94D4k1JhLmjDFpVGET/Nf54jVDtbavbALf8Zhp0Td9zTlxScjMW6nbEIrpADtPWfLk9iCXzHDQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fast-safe-stringify": "^2.0.7"
+      },
+      "bin": {
+        "shasum-object": "bin.js"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz",
+      "integrity": "sha512-uEWz7wa9vnCi9w4mvKZMgbHFk3DCKjLQlZcy0tJxUH4NwZjRrPPHXAYIEt2TmJs600Dcgj0Z3fZLZKVPVdGNbQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon-node/node_modules/define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+      "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/snapdragon/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon/node_modules/is-descriptor": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.8.tgz",
+      "integrity": "sha512-SceYGWXvdqlWa/OnQ5FQuV+NxvNmMRhMw/w9AHkH71hTzveND4BTYgvp16g+oITK47qbOl/3D0bl0iygehWAWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.1",
+        "is-data-descriptor": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/snapdragon/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/snapdragon/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+      "integrity": "sha512-Y8nIfcb1s/7DcobUz1yOO1GSp7gyL+D9zLHDehT7iRESqGSxjJ448Sg7rvfgsRJCnKLdSl11uGf0s9X80cH0/A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "amdefine": ">=0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/source-map-resolve": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+      "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
+    },
+    "node_modules/source-map-url": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
+      "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
+      "deprecated": "See https://github.com/lydell/source-map-url#deprecated",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split-string/node_modules/extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split-string/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha512-72E9+uLc27Mt718pMHt9VMNiAL4LMsmDbBva8mxWUCkT07fSzEGMYUCk0XWY6lp0j6RBAG4cJ3mWuZv2OE3s0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/static-extend/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/static-extend/node_modules/is-descriptor": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.8.tgz",
+      "integrity": "sha512-SceYGWXvdqlWa/OnQ5FQuV+NxvNmMRhMw/w9AHkH71hTzveND4BTYgvp16g+oITK47qbOl/3D0bl0iygehWAWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.1",
+        "is-data-descriptor": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/stream-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
+      "integrity": "sha512-e+V5xc4LlkOiRr64kZTUdb11exsbpSnwb9uwmXaHeDXCpfHg7vaefMJOxi21Pe74ZOqjZ87blBcqqpNAM4Ku0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "^1.0.27-1"
+      }
+    },
+    "node_modules/stream-combiner2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
+      "integrity": "sha512-7DO1SfBVnyIyo9ytUjSyVojT5bp1ZY6h3pj7HUs6PwcRSd/r8mBOHbRwYC7nbHRakKzMKyNp5HWJRv4GgVherA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer2": "~0.0.2",
+        "through2": "~0.5.1"
+      }
+    },
+    "node_modules/stream-combiner2/node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/stream-combiner2/node_modules/through2": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+      "integrity": "sha512-zexCrAOTbjkBCXGyozn7hhS3aEaqdrc59mAD2E3dKYzV1vFuEGQ1hEDJN2oQMQFwy4he2zyLqPZV+AlfS8ZWJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~1.0.17",
+        "xtend": "~3.0.0"
+      }
+    },
+    "node_modules/stream-combiner2/node_modules/xtend": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+      "integrity": "sha512-sp/sT9OALMjRW1fKDlPeuSZlDQpkqReA0pyJukniWbTGoEKefHxhGJynE3PNhUMlcM8qWIjPwecwCw4LArS5Eg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/stream-http": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.2.0.tgz",
+      "integrity": "sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "xtend": "^4.0.2"
+      }
+    },
+    "node_modules/stream-http/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/stream-http/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/stream-splicer": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
+      "integrity": "sha512-nmUMEbdm/sZYqe9dZs7mqJvTYpunsDbIWI5FiBCMc/hMVd6vwzy+ITmo7C3gcLYqrn+uQ1w+EJwooWvJ997JAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indexof": "0.0.1",
+        "inherits": "^2.0.1",
+        "isarray": "~0.0.1",
+        "readable-stream": "^1.1.13-1",
+        "readable-wrap": "^1.0.0",
+        "through2": "^1.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha512-AOPG8EBc5wAikaG1/7uFCNFJwnKOuQwFTpYBdTW6OvWHeZBQBrAA/amefHGrEiOnCPcLFZK6FUPtWVKpQVIRgg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "strip-json-comments": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/subarg": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+      "integrity": "sha512-RIrIdRY0X1xojthNcVtgT9sjpOGagEUKpZdgBUi054OEPFo282yg+zE+t1Rj3+RqKq2xStL7uUHhY+AjbC4BXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.1.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/syntax-error": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
+      "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn-node": "^1.2.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-0.4.7.tgz",
+      "integrity": "sha512-8/A2iGloynV8Q0cb43ez+aK1PEYWueUr4yPrenbwOJR3Y63VjaIPIravWB6VcYAz4jQfzr4TLX8i3/tDhkzPRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^0.9.0",
+        "end-of-stream": "^1.0.0",
+        "readable-stream": "^1.0.27-1",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/through2": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+      "integrity": "sha512-zEbpaeSMHxczpTzO1KkMHjBC1enTA68ojeaZGG4toqdASpb9t4xUZaYFBq2/9OHo5nTGFVSYd4c910OR+6wxbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": ">=1.1.13-1 <1.2.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      }
+    },
+    "node_modules/timers-browserify": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+      "integrity": "sha512-PIxwAupJZiYU4JmVZYwXp9FKsHMXb5h0ZEFyuXTAn8WLHOlcij+FEcbrvDsom1o5dr1YggEtFbECvGCW2sT53Q==",
+      "dev": true,
+      "dependencies": {
+        "process": "~0.11.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/tiny-lr-fork": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/tiny-lr-fork/-/tiny-lr-fork-0.0.5.tgz",
+      "integrity": "sha512-vhcvny/8f46rrViKV0BOUjVl4c/rDTztnT1+kT7iyD/Igqb/uyiRsKLxMc2Z8CNvTE1Px1tuNrPM+BOUL+3vlQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "~0.7.0",
+        "faye-websocket": "~0.4.3",
+        "noptify": "~0.0.3",
+        "qs": "~0.5.2"
+      },
+      "bin": {
+        "tiny-lr-fork": "bin/tiny-lr"
+      }
+    },
+    "node_modules/tiny-lr-fork/node_modules/debug": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+      "integrity": "sha512-EohAb3+DSHSGx8carOSKJe8G0ayV5/i609OD0J2orCkuyae7SyZSz2aoLmQF2s0Pj5gITDebwPH7GFBlqOUQ1Q==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.23.tgz",
+      "integrity": "sha512-zR0TtNGw3OoChmmzHNnMVh6LRY7fCkxXnHOEI9/CZE5zn6TzZbyMknZdmQZzD0EhcQVT/9rZHeg1KqiqfAC5jw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/to-buffer/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/to-regex/node_modules/extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/to-regex/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tty-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
+      "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/type-detect": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+      "integrity": "sha512-5rqszGVwYgBoDkIm2oUtvkfZMQ0vk29iDMU0W2qCa3rG0vPDNczCMT4hV/bLBgLg8k8ri6+u3Zbt+S/14eMzlA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.7.tgz",
+      "integrity": "sha512-ueeb9YybpjhivjbHP2LdFDAjbS948fGEPj+ACAMs4xCMmh72OCOMQWBQKlaN4ZNQ04yfLSDLSx1tGRIoWimObQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "2.4.24",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
+      "integrity": "sha512-tktIjwackfZLd893KGJmXc1hrRHH1vH9Po3xFh1XBjjeGAnN02xJ3SuoA+n1L29/ZaCA18KzCFlckS+vfPugiA==",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "async": "~0.2.6",
+        "source-map": "0.1.34",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.5.4"
+      },
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/uglify-js/node_modules/async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ==",
+      "dev": true
+    },
+    "node_modules/uglify-js/node_modules/source-map": {
+      "version": "0.1.34",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+      "integrity": "sha512-yfCwDj0vR9RTwt3pEzglgb3ZgmcXHt6DjG3bjJvzPwTL+5zDQ2MhmSzAcTy0GTiQuCiriSWXvWM1/NhKdXuoQA==",
+      "dev": true,
+      "dependencies": {
+        "amdefine": ">=0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha512-vb2s1lYx2xBtUgy+ta+b2J/GLVUR+wmpINwHePmPRhOsIVCG2wDzKJ0n14GslH1BifsqVzSOwQhRaCAsZ/nI4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/umd": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.3.tgz",
+      "integrity": "sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "umd": "bin/cli.js"
+      }
+    },
+    "node_modules/undeclared-identifiers": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/undeclared-identifiers/-/undeclared-identifiers-1.1.3.tgz",
+      "integrity": "sha512-pJOW4nxjlmfwKApE4zvxLScM/njmwj/DiUBv7EabwE4O8kRUy+HIwxQtZLBPll/jx1LJyBcqNfB3/cpv9EZwOw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn-node": "^1.3.0",
+        "dash-ast": "^1.0.0",
+        "get-assigned-identifiers": "^1.2.0",
+        "simple-concat": "^1.0.0",
+        "xtend": "^4.0.1"
+      },
+      "bin": {
+        "undeclared-identifiers": "bin.js"
+      }
+    },
+    "node_modules/underscore": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "integrity": "sha512-cp0oQQyZhUM1kpJDLdGO1jPZHgS/MpzoWYfe9+CM2h/QGDZlqwT2T3YGukuBdaNJ/CAPoeyAZRRHz8JFo176vA==",
+      "dev": true
+    },
+    "node_modules/underscore.string": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+      "integrity": "sha512-3FVmhXqelrj6gfgp3Bn6tOavJvW0dNH2T+heTD38JRxIrAbiuzbqjknszoOYj3DyFB1nWiLj208Qt2no/L4cIA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/union-value": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha512-PcA2tsuGSF9cnySLHTLSh2qrQiJ70mn+r+Glzxv2TWZblxsxCC52BDlZoPCsz7STd9pN7EZetkWZBAvk4cgZdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unset-value/node_modules/has-value": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+      "integrity": "sha512-gpG936j8/MzaeID5Yif+577c17TxaDmhuyVgSwtnL/q8UUTySg8Mecb+8Cf1otgLoD7DDH75axp86ER7LFsf3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-value": "^2.0.3",
+        "has-values": "^0.1.4",
+        "isobject": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unset-value/node_modules/has-value/node_modules/isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unset-value/node_modules/has-values": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+      "integrity": "sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unset-value/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/upath": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "yarn": "*"
+      }
+    },
+    "node_modules/urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==",
+      "deprecated": "Please see https://github.com/lydell/urix#deprecated",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "node_modules/url/node_modules/punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/use": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "2.0.3"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/util/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/vm-browserify": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "integrity": "sha512-NyZNR3WDah+NPkjh/YmhuWSsT4a0mF0BJYgUmvrJ70zxjTXh5Y2Asobxlh0Nfs0PCFB5FVpRJft7NozAWFMwLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indexof": "0.0.1"
+      }
+    },
+    "node_modules/watchify": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/watchify/-/watchify-3.11.1.tgz",
+      "integrity": "sha512-WwnUClyFNRMB2NIiHgJU9RQPQNqVeFk7OmZaWf5dC5EnNa0Mgr7imBydbaJ7tGTuPM2hz1Cb4uiBvK9NVxMfog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "^2.0.0",
+        "browserify": "^16.1.0",
+        "chokidar": "^2.1.1",
+        "defined": "^1.0.0",
+        "outpipe": "^1.1.0",
+        "through2": "^2.0.0",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "watchify": "bin/cmd.js"
+      }
+    },
+    "node_modules/watchify/node_modules/assert": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.1.tgz",
+      "integrity": "sha512-zzw1uCAgLbsKwBfFc8CX78DDg+xZeBksSO3vwVIDDN5i94eOrPsSSyiVhmsSABFDM/OcpE2aagCat9dnWQLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object.assign": "^4.1.4",
+        "util": "^0.10.4"
+      }
+    },
+    "node_modules/watchify/node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/watchify/node_modules/browser-pack": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.1.0.tgz",
+      "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "combine-source-map": "~0.8.0",
+        "defined": "^1.0.0",
+        "JSONStream": "^1.0.3",
+        "safe-buffer": "^5.1.1",
+        "through2": "^2.0.0",
+        "umd": "^3.0.0"
+      },
+      "bin": {
+        "browser-pack": "bin/cmd.js"
+      }
+    },
+    "node_modules/watchify/node_modules/browser-resolve": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-2.0.0.tgz",
+      "integrity": "sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve": "^1.17.0"
+      }
+    },
+    "node_modules/watchify/node_modules/browserify": {
+      "version": "16.5.2",
+      "resolved": "https://registry.npmjs.org/browserify/-/browserify-16.5.2.tgz",
+      "integrity": "sha512-TkOR1cQGdmXU9zW4YukWzWVSJwrxmNdADFbqbE3HFgQWe5wqZmOawqZ7J/8MPCwk/W8yY7Y0h+7mOtcZxLP23g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert": "^1.4.0",
+        "browser-pack": "^6.0.1",
+        "browser-resolve": "^2.0.0",
+        "browserify-zlib": "~0.2.0",
+        "buffer": "~5.2.1",
+        "cached-path-relative": "^1.0.0",
+        "concat-stream": "^1.6.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "~1.0.0",
+        "crypto-browserify": "^3.0.0",
+        "defined": "^1.0.0",
+        "deps-sort": "^2.0.0",
+        "domain-browser": "^1.2.0",
+        "duplexer2": "~0.1.2",
+        "events": "^2.0.0",
+        "glob": "^7.1.0",
+        "has": "^1.0.0",
+        "htmlescape": "^1.1.0",
+        "https-browserify": "^1.0.0",
+        "inherits": "~2.0.1",
+        "insert-module-globals": "^7.0.0",
+        "JSONStream": "^1.0.3",
+        "labeled-stream-splicer": "^2.0.0",
+        "mkdirp-classic": "^0.5.2",
+        "module-deps": "^6.2.3",
+        "os-browserify": "~0.3.0",
+        "parents": "^1.0.1",
+        "path-browserify": "~0.0.0",
+        "process": "~0.11.0",
+        "punycode": "^1.3.2",
+        "querystring-es3": "~0.2.0",
+        "read-only-stream": "^2.0.0",
+        "readable-stream": "^2.0.2",
+        "resolve": "^1.1.4",
+        "shasum": "^1.0.0",
+        "shell-quote": "^1.6.1",
+        "stream-browserify": "^2.0.0",
+        "stream-http": "^3.0.0",
+        "string_decoder": "^1.1.1",
+        "subarg": "^1.0.0",
+        "syntax-error": "^1.1.1",
+        "through2": "^2.0.0",
+        "timers-browserify": "^1.0.1",
+        "tty-browserify": "0.0.1",
+        "url": "~0.11.0",
+        "util": "~0.10.1",
+        "vm-browserify": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "browserify": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/watchify/node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
+      }
+    },
+    "node_modules/watchify/node_modules/buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+      "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      }
+    },
+    "node_modules/watchify/node_modules/combine-source-map": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz",
+      "integrity": "sha512-UlxQ9Vw0b/Bt/KYwCFqdEwsQ1eL8d1gibiFb7lxQJFdvTgc2hIZi6ugsg+kyhzhPV+QEpUiEIwInIAIrgoEkrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "convert-source-map": "~1.1.0",
+        "inline-source-map": "~0.6.0",
+        "lodash.memoize": "~3.0.3",
+        "source-map": "~0.5.3"
+      }
+    },
+    "node_modules/watchify/node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/watchify/node_modules/constants-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "integrity": "sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/watchify/node_modules/convert-source-map": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+      "integrity": "sha512-Y8L5rp6jo+g9VEPgvqNfEopjTR4OTYct8lXlS8iVQdmnjDvbdbzYe9rjtFCB9egC86JoNCU61WRY+ScjkZpnIg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/watchify/node_modules/deps-sort": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.1.tgz",
+      "integrity": "sha512-1orqXQr5po+3KI6kQb9A4jnXT1PBwggGl2d7Sq2xsnOeI9GPcE/tGcF9UiSZtZBM7MukY4cAh7MemS6tZYipfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "JSONStream": "^1.0.3",
+        "shasum-object": "^1.0.0",
+        "subarg": "^1.0.0",
+        "through2": "^2.0.0"
+      },
+      "bin": {
+        "deps-sort": "bin/cmd.js"
+      }
+    },
+    "node_modules/watchify/node_modules/detective": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-5.2.1.tgz",
+      "integrity": "sha512-v9XE1zRnz1wRtgurGu0Bs8uHKFSTdteYZNbIPFVhUZ39L/S79ppMpdmVOZAnoz1jfEFodc48n6MX483Xo3t1yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn-node": "^1.8.2",
+        "defined": "^1.0.0",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "detective": "bin/detective.js"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/watchify/node_modules/domain-browser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4",
+        "npm": ">=1.2"
+      }
+    },
+    "node_modules/watchify/node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/watchify/node_modules/events": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-2.1.0.tgz",
+      "integrity": "sha512-3Zmiobend8P9DjmKAty0Era4jV8oJ0yGYe2nJJAxgymF9+N8F2m0hhZiMoWtcfepExzNKZumFU3ksdQbInGWCg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/watchify/node_modules/https-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+      "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/watchify/node_modules/inline-source-map": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.3.tgz",
+      "integrity": "sha512-1aVsPEsJWMJq/pdMU61CDlm1URcW702MTB4w9/zUjMus6H/Py8o7g68Pr9D4I6QluWGt/KdmswuRhaA05xVR1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "~0.5.3"
+      }
+    },
+    "node_modules/watchify/node_modules/insert-module-globals": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.2.1.tgz",
+      "integrity": "sha512-ufS5Qq9RZN+Bu899eA9QCAYThY+gGW7oRkmb0vC93Vlyu/CFGcH0OYPEjVkDXA5FEbTt1+VWzdoOD3Ny9N+8tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn-node": "^1.5.2",
+        "combine-source-map": "^0.8.0",
+        "concat-stream": "^1.6.1",
+        "is-buffer": "^1.1.0",
+        "JSONStream": "^1.0.3",
+        "path-is-absolute": "^1.0.1",
+        "process": "~0.11.0",
+        "through2": "^2.0.0",
+        "undeclared-identifiers": "^1.1.2",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "insert-module-globals": "bin/cmd.js"
+      }
+    },
+    "node_modules/watchify/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/watchify/node_modules/labeled-stream-splicer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.2.tgz",
+      "integrity": "sha512-Ca4LSXFFZUjPScRaqOcFxneA0VpKZr4MMYCljyQr4LIewTLb3Y0IUTIsnBBsVubIeEfxeSZpSjSsRM8APEQaAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "stream-splicer": "^2.0.0"
+      }
+    },
+    "node_modules/watchify/node_modules/module-deps": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-6.2.3.tgz",
+      "integrity": "sha512-fg7OZaQBcL4/L+AK5f4iVqf9OMbCclXfy/znXRxTVhJSeW5AIlS9AwheYwDaXM3lVW7OBeaeUEY3gbaC6cLlSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browser-resolve": "^2.0.0",
+        "cached-path-relative": "^1.0.2",
+        "concat-stream": "~1.6.0",
+        "defined": "^1.0.0",
+        "detective": "^5.2.0",
+        "duplexer2": "^0.1.2",
+        "inherits": "^2.0.1",
+        "JSONStream": "^1.0.3",
+        "parents": "^1.0.0",
+        "readable-stream": "^2.0.2",
+        "resolve": "^1.4.0",
+        "stream-combiner2": "^1.1.1",
+        "subarg": "^1.0.0",
+        "through2": "^2.0.0",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "module-deps": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/watchify/node_modules/os-browserify": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+      "integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/watchify/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/watchify/node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/watchify/node_modules/read-only-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
+      "integrity": "sha512-3ALe0bjBVZtkdWKIcThYpQCLbBMd/+Tbh2CDSrAIDO3UsZ4Xs+tnyjv2MjCOMMgBG+AsUOeuP1cgtY1INISc8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/watchify/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/watchify/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/watchify/node_modules/readable-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/watchify/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/watchify/node_modules/shell-quote": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/watchify/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/watchify/node_modules/stream-browserify": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
+      "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/watchify/node_modules/stream-combiner2": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+      "integrity": "sha512-3PnJbYgS56AeWgtKF5jtJRT6uFJe56Z0Hc5Ngg/6sI6rIt8iiMBTa9cvdyFfpMQjaVHr8dusbNeFGIIonxOvKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer2": "~0.1.0",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/watchify/node_modules/stream-splicer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.1.tgz",
+      "integrity": "sha512-Xizh4/NPuYSyAXyT7g8IvdJ9HJpxIGL9PjyhtywCZvvP0OPIdqyrr4dMikeuvY8xahpdKEBlBTySe583totajg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/watchify/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/watchify/node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/watchify/node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/watchify/node_modules/url": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
+      "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^1.4.1",
+        "qs": "^6.12.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/watchify/node_modules/vm-browserify": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+      "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+      "integrity": "sha512-E87fdQ/eRJr9W1X4wTPejNy9zTW3FI2vpCZSJ/HAY+TkjKVC0TUm1jk6vn2Z7qay0DQy0+RBGdXxj+RmmiGZKQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha512-1pTPQDKTdd61ozlKGNCjhNRd+KPmgLSGa3mZTHoOliaGcESD8G1PXhh7c1fgiPjVbNVfgy2Faw4BI8/m0cC8Mg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/xhr": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/xhr/-/xhr-1.17.1.tgz",
+      "integrity": "sha512-p5ef9y6Lsjq+mbGXp04zZBmPGomTcjT8wt3KGMyR2SrmX7d98ne6uN1su+YN9oshbapTkkCMa1xDHc9v9blhow==",
+      "dependencies": {
+        "global": "~4.3.0",
+        "once": "~1.1.1",
+        "parse-headers": "^2.0.0"
+      }
+    },
+    "node_modules/xhr/node_modules/once": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz",
+      "integrity": "sha512-frdJr++QKEg4+JylTX+NNLgSoO6M2pDNYOOXe4WGIYKKBADBI9nU3oa06y4D4FpAJ3obAsjExeBOnscYJB9Blw==",
+      "license": "BSD"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+      "integrity": "sha512-5j382E4xQSs71p/xZQsU1PtRA2HXPAjX0E0DkoGLxwNASMOKX6A9doV1NrZmj85u2Pjquz402qonBzz/yLPbPA==",
+      "dev": true,
+      "license": "MIT/X11",
+      "dependencies": {
+        "camelcase": "^1.0.2",
+        "decamelize": "^1.0.0",
+        "window-size": "0.1.0",
+        "wordwrap": "0.0.2"
+      }
+    },
+    "node_modules/yargs/node_modules/wordwrap": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+      "integrity": "sha512-xSBsCeh+g+dinoBv3GAOWM4LcVVO68wLXRanibtBSdUvkGWQRGeE9P7IwU9EmDDi4jA6L44lz15CGMwdw9N5+Q==",
+      "dev": true,
+      "license": "MIT/X11",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.4.1.tgz",
+      "integrity": "sha512-besxwBaXruvWoMXO44C5SKtmJ4XQUZGs9BoHW4E+FNtVkuGHqtUL69r0s6RKSA9a0zQs5XwQvGsD+JBaC9/2sg==",
+      "dev": true,
+      "dependencies": {
+        "compress-commons": "~0.1.0",
+        "lodash": "~2.4.1",
+        "readable-stream": "~1.0.26"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/zip-stream/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/zip-stream/node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    }
+  }
+}

--- a/omega-target/package-lock.json
+++ b/omega-target/package-lock.json
@@ -1,0 +1,6689 @@
+{
+  "name": "omega-target",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "omega-target",
+      "version": "0.0.1",
+      "dependencies": {
+        "bluebird": "^2.3.2",
+        "jsondiffpatch": "^0.1.8",
+        "limiter": "^1.0.5",
+        "omega-pac": "../omega-pac"
+      },
+      "devDependencies": {
+        "chai": "^1.10.0",
+        "coffee-script": "^1.8.0",
+        "coffeeify": "^0.7.0",
+        "coffeelint": "^1.16.0",
+        "grunt": "^0.4.5",
+        "grunt-browserify": "^3.0.0",
+        "grunt-coffeelint": "^0.0.13",
+        "grunt-contrib-coffee": "^0.11.1",
+        "grunt-contrib-watch": "^0.6.1",
+        "grunt-mocha-test": "~0.11.0",
+        "load-grunt-config": "^0.13.1",
+        "minifyify": "^4.1.1",
+        "sinon": "^1.12.2",
+        "sinon-chai": "^2.6.0"
+      }
+    },
+    "../omega-pac": {
+      "version": "0.0.1",
+      "dependencies": {
+        "ip-address": "^4.0.0",
+        "tldjs": "^1.5.2",
+        "uglify-js": "^2.4.15"
+      },
+      "devDependencies": {
+        "chai": "~1.9.1",
+        "coffee-script": "^1.7.1",
+        "coffeeify": "^0.7.0",
+        "coffeelint": "^1.16.0",
+        "grunt": "^0.4.5",
+        "grunt-browserify": "^3.0.0",
+        "grunt-coffeelint": "^0.0.13",
+        "grunt-contrib-coffee": "^0.11.1",
+        "grunt-contrib-watch": "^0.6.1",
+        "grunt-mocha-test": "~0.11.0",
+        "load-grunt-config": "^0.13.1",
+        "lolex": "^1.4.0",
+        "minifyify": "^4.1.1"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/acorn": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+      "integrity": "sha512-fu2ygVGuMmlzG8ZeRJ0bvR41nsAkxxhbyk8bZ1SS521Z7vmgJFTQQlfz/Mp/nJexGBz+v8sC9bM6+lNgskt4Ug==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-node": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
+      "integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^7.0.0",
+        "acorn-walk": "^7.0.0",
+        "xtend": "^4.0.2"
+      }
+    },
+    "node_modules/acorn-node/node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
+      "dev": true,
+      "license": "BSD-3-Clause OR MIT",
+      "engines": {
+        "node": ">=0.4.2"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+      "integrity": "sha512-LjmC2dNpdn2L4UzyoaIr11ELYoLn37ZFy9zObrQFHsSuOepeUEMKnM8w5KL4Tnrp2gy88rRuQt6Ky8Bjml+Baw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "underscore": "~1.7.0",
+        "underscore.string": "~2.4.0"
+      }
+    },
+    "node_modules/argparse/node_modules/underscore.string": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+      "integrity": "sha512-yxkabuCaIBnzfIvX3kBxQqCs0ar/bfJwDnFEHJUm/ZrRVhT3IItdRF5cZjARLzEnyQYtIUhsZ2LG2j3HidFOFQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/asn1.js": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/asn1.js/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/assert": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
+      "integrity": "sha512-5aKcpD+XnHpZ7EGxsuo6uoILNh0rvm0Ypa17GlkrF2CNSPhvdgi3ft9XsL2ajdVOI2I3xuGZnHvlXAeqTZYvXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "util": "0.10.3"
+      }
+    },
+    "node_modules/assert/node_modules/inherits": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+      "integrity": "sha512-8nWq2nLTAwd02jTqJExUYFSD/fKq6VH9Y/oG2accc/kdI0V98Bag8d5a4gi3XHz73rDWa2PvTtvcWYquKqSENA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/assert/node_modules/util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "integrity": "sha512-5KiHfsmkqacuKjkRkdV7SsfDJ2EGiPsK92s2MhNSY0craxjTdKTtqKsJaCWp4LW33ZZ0OPUv1WO/TFvNQRiQxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "2.0.1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
+      "integrity": "sha512-g/gZV+G476cnmtYI+Ko9d5khxSoCSoom/EaNmmCfwpOvBXEJ18qwFrxfP1/CsIqk2no1sAKKwxndV0tP7ROOFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/astw": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/astw/-/astw-2.2.0.tgz",
+      "integrity": "sha512-E/4z//dvN0lfr8zAx8hXeQ8o3nRoQaL/wqI7fAALEvh/40mnyUxfFB9MwyDHYKVDtS3cp3Pow5s96djZR5lkWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^4.0.3"
+      }
+    },
+    "node_modules/async": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+      "integrity": "sha512-2tEzliJmf5fHNafNwQLJXUasGzQCVctvsNkXmnlELHwypU0p08/rHohYvkqKIjyXpx+0rkrYv6QbhJ+UF4QkBg==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/async-each": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.6.tgz",
+      "integrity": "sha512-c646jH1avxr+aVpndVMeAfYw7wAa6idufrlN3LPA4PmKS0QEGp6PIC9nwz0WQkkvBGAMEki3pFdtxaF39J9vvg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true,
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/base/node_modules/define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+      "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/Base64": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
+      "integrity": "sha512-reGEWshDmTDQDsCec/HduOO9Wyj6yMOupMfhIf3ugN1TDlK2NQW4DDJSqNNtp380SNcvRfXtO8HSCQot0d0SMw==",
+      "dev": true
+    },
+    "node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+      "integrity": "sha512-UfFSr22dmHPQqPP9XWHRhq+gWnHCYguQGkXQlbyPtW5qTnhFWA8/iXg765tH0cAjy7l/zPJ1aBTO0g5XgA7kvQ==",
+      "license": "MIT"
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.5.tgz",
+      "integrity": "sha512-Vq886eXykuP5E6HcKSSStP3bJgrE6In5WKxVUvJ8XGpWWYs2xZHWqUwzCtGgEtBcxyd57KBFDPFoUfNzdaHCNg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/browser-pack": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-5.0.1.tgz",
+      "integrity": "sha512-BFMQuYXCcwr3Uvna1y1hikqd3r2dQpWIQBIN3m5YwE3ClfnXDeF3tqP6Wqjhs1LRUeBJpgHn8yD+fPX/YSEgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "combine-source-map": "~0.6.1",
+        "defined": "^1.0.0",
+        "JSONStream": "^1.0.3",
+        "through2": "^1.0.0",
+        "umd": "^3.0.0"
+      },
+      "bin": {
+        "browser-pack": "bin/cmd.js"
+      }
+    },
+    "node_modules/browser-resolve": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+      "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve": "1.1.7"
+      }
+    },
+    "node_modules/browser-resolve/node_modules/resolve": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+      "integrity": "sha512-9znBF0vBcaSN3W2j7wKvdERPwqTxSpCq+if5C0WoTCyV9n24rua28jeuQ2pL/HOf+yUe/Mef+H/5p60K0Id3bg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/browserify": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/browserify/-/browserify-10.2.6.tgz",
+      "integrity": "sha512-rhKmIuWDcE1ULm6lrd3kQdUTqFsLd/UJp3yYt4Ur5rDzk/Gj2AH6+ZTNqkaMqwMphkf8Rp83S1GfMxtu9QjGDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert": "~1.3.0",
+        "browser-pack": "^5.0.0",
+        "browser-resolve": "^1.7.1",
+        "browserify-zlib": "~0.1.2",
+        "buffer": "^3.0.0",
+        "builtins": "~0.0.3",
+        "commondir": "0.0.1",
+        "concat-stream": "~1.4.1",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "~0.0.1",
+        "crypto-browserify": "^3.0.0",
+        "defined": "^1.0.0",
+        "deps-sort": "^1.3.7",
+        "domain-browser": "~1.1.0",
+        "duplexer2": "~0.0.2",
+        "events": "~1.0.0",
+        "glob": "^4.0.5",
+        "has": "^1.0.0",
+        "htmlescape": "^1.1.0",
+        "http-browserify": "^1.4.0",
+        "https-browserify": "~0.0.0",
+        "inherits": "~2.0.1",
+        "insert-module-globals": "^6.4.1",
+        "isarray": "0.0.1",
+        "JSONStream": "^1.0.3",
+        "labeled-stream-splicer": "^1.0.0",
+        "module-deps": "^3.7.11",
+        "os-browserify": "~0.1.1",
+        "parents": "^1.0.1",
+        "path-browserify": "~0.0.0",
+        "process": "~0.11.0",
+        "punycode": "^1.3.2",
+        "querystring-es3": "~0.2.0",
+        "read-only-stream": "^1.1.1",
+        "readable-stream": "^1.1.13",
+        "resolve": "^1.1.4",
+        "shasum": "^1.0.0",
+        "shell-quote": "~0.0.1",
+        "stream-browserify": "^1.0.0",
+        "string_decoder": "~0.10.0",
+        "subarg": "^1.0.0",
+        "syntax-error": "^1.1.1",
+        "through2": "^1.0.0",
+        "timers-browserify": "^1.0.1",
+        "tty-browserify": "~0.0.0",
+        "url": "~0.10.1",
+        "util": "~0.10.1",
+        "vm-browserify": "~0.0.1",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "browserify": "bin/cmd.js"
+      }
+    },
+    "node_modules/browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/browserify-cipher": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      }
+    },
+    "node_modules/browserify-des": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/browserify-rsa": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
+      "integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^5.2.1",
+        "randombytes": "^2.1.0",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/browserify-sign": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.6.tgz",
+      "integrity": "sha512-sd+Q65fjlWCYWtZKXiKfrUc8d+4jtp/8f0W2NkwzLtoW4bI6UDnWusLWIurHnmurW0XShIRxpwiOX4EoPtXUAg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "bn.js": "^5.2.3",
+        "browserify-rsa": "^4.1.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.6.1",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.9",
+        "readable-stream": "^2.3.8",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/browserify-sign/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/browserify-sign/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/browserify-sign/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/browserify-sign/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/browserify-sign/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+      "integrity": "sha512-19OEpq7vWgsH6WkvkBJQDFvJS1uPcbFOQ4v9CU839dO+ZZXUZO6XpE6hNCqvlIIj+4fZvRiJ6DsAQ382GwiyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~0.2.0"
+      }
+    },
+    "node_modules/browserify/node_modules/glob": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+      "integrity": "sha512-I0rTWUKSZKxPSIAIaqhSXTM/DiII6wame+rEC3cFA5Lqmr9YmdL7z6Hj9+bdWtTvoY1Su4/OiMLmb37Y7JzvJQ==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^2.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/browserify/node_modules/minimatch": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+      "integrity": "sha512-jQo6o1qSVLEWaw3l+bwYA2X0uLuK2KjNh2wjgO7Q/9UJnXr1Q3yQKR8BI0/Bt/rPg75e6SMW4hW/6cBHVTZUjA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/browserify/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.2.tgz",
+      "integrity": "sha512-c3M77NkHJxS0zx/ErxXhDLr1v3y2MDXPeTJPvLNOaIYJ4ymHBUFQ9EXzt9HYuqAJllMoNb/EZ8hIiulnQFAUuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/buffer/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/builtin-status-codes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/builtins": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
+      "integrity": "sha512-T8uCGKc0/2aLVt6omt8JxDRBoWEMkku+wFesxnhxnt4NygVZG99zqxo7ciK8eebszceKamGoUiLdkXCgGQyrQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cached-path-relative": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.1.0.tgz",
+      "integrity": "sha512-WF0LihfemtesFcJgO7xfOoOcnWzY/QHR4qeDqV44jPU3HTI54+LnfXK3SA27AVVGCdZFgjjFFaqUA9Jx7dMJZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha512-wzLkDa4K/mzI1OSITC+DUyjgIl/ETNHE9QvYgy6J6Jvqyyz4C0Xfd+lQhb19sX2jMpZV4IssUn0VDVmglV+s4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/chai": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-1.10.0.tgz",
+      "integrity": "sha512-E3L9M2SeQU1XagJkE9KJyTAXXHKJkJ1EsKkFp0Rl53lYa3mro2PVgYHNiCb2YRa2nUeyg7aqmI1EIcSBayNd5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "1.0.0",
+        "deep-eql": "0.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+      "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "^2.0.0",
+        "async-each": "^1.0.1",
+        "braces": "^2.3.2",
+        "glob-parent": "^3.1.0",
+        "inherits": "^2.0.3",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "normalize-path": "^3.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.2.1",
+        "upath": "^1.1.1"
+      },
+      "optionalDependencies": {
+        "fsevents": "^1.2.7"
+      }
+    },
+    "node_modules/chokidar/node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cipher-base": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
+      "integrity": "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/class-utils/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/class-utils/node_modules/is-descriptor": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.8.tgz",
+      "integrity": "sha512-SceYGWXvdqlWa/OnQ5FQuV+NxvNmMRhMw/w9AHkH71hTzveND4BTYgvp16g+oITK47qbOl/3D0bl0iygehWAWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.1",
+        "is-data-descriptor": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/coffee-script": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
+      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/coffeeify": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/coffeeify/-/coffeeify-0.7.0.tgz",
+      "integrity": "sha512-4TYM0xE8hO8sj0omU6Y7EE4H75V4cslt3PwcycL+rN1RGoYorvzLGXTJeIuyw90JBmMKQUatXWERuNQt3GhXvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "coffee-script": "^1.7.1",
+        "convert-source-map": "^0.3.5",
+        "through": "^2.3.4"
+      }
+    },
+    "node_modules/coffeelint": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/coffeelint/-/coffeelint-1.16.2.tgz",
+      "integrity": "sha512-6mzgOo4zb17WfdrSui/cSUEgQ0AQkW3gXDht+6lHkfkqGUtSYKwGdGcXsDfAyuScVzTlTtKdfwkAlJWfqul7zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "coffee-script": "~1.11.0",
+        "glob": "^7.0.6",
+        "ignore": "^3.0.9",
+        "optimist": "^0.6.1",
+        "resolve": "^0.6.3",
+        "strip-json-comments": "^1.0.2"
+      },
+      "bin": {
+        "coffeelint": "bin/coffeelint"
+      },
+      "engines": {
+        "node": ">=0.8.0",
+        "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/coffeelint-stylish": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/coffeelint-stylish/-/coffeelint-stylish-0.1.2.tgz",
+      "integrity": "sha512-VcuzfB0bC9lvdvwckLzh3njKce68VVmOOXp0igyNl50D/uRLbFb4HSjQtTNGFEYiQ9Z0hjhfTqKe4v8UQxnngA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^1.0.0",
+        "text-table": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/coffeelint/node_modules/coffee-script": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.11.1.tgz",
+      "integrity": "sha512-NIWm59Fh1zkXq6TS6PQvSO3AR9DbGq1IBNZHa1E3fUCNmJhIwLf1YKcWgaHqaU7zWGC/OE2V7K3GVAXFzcmu+A==",
+      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha512-lNkKvzEeMBBjUGHZ+q6z9pSJla0KWAQPvtzhEV9+iGyQYG+pBpl7xKDhxoNSOZH2hhv0v5k0y2yAM4o4SjoSkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/colors": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+      "integrity": "sha512-OsSVtHK8Ir8r3+Fxw/b4jS1ZLPXkV6ZxDRJQzeD7qo0SqMXWrHDM71DgYzPMHY8SFJ0Ao+nNU2p1MmwdzKqPrw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/combine-source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
+      "integrity": "sha512-XKRNtuZRlVDTuSGKsfZpXYz80y0XDbYS4a+FzafTgmYHy/ckruFBx7Nd6WaQnFHVI3O6IseWVdXUvZutMpjSkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "convert-source-map": "~1.1.0",
+        "inline-source-map": "~0.5.0",
+        "lodash.memoize": "~3.0.3",
+        "source-map": "~0.4.2"
+      }
+    },
+    "node_modules/combine-source-map/node_modules/convert-source-map": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+      "integrity": "sha512-Y8L5rp6jo+g9VEPgvqNfEopjTR4OTYct8lXlS8iVQdmnjDvbdbzYe9rjtFCB9egC86JoNCU61WRY+ScjkZpnIg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz",
+      "integrity": "sha512-qebjpyeaA/nJ4w3EO2cV2++/zEkccPnjWogzA2rff+Lk8ILI75vULeTmyd4wPxWdKwtP3J+G39IXVZadh0UHyw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.x"
+      }
+    },
+    "node_modules/commondir": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
+      "integrity": "sha512-Ghe1LmLv3G3c0XJYu+c88MCRIPqWQ67qaqKY1KvuN4uPAjfUj+y4hvcpZ2kCPrjpRNyklW4dpAZZ8a7vOh50tg==",
+      "dev": true,
+      "license": "MIT/X11",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.11.tgz",
+      "integrity": "sha512-X3JMh8+4je3U1cQpG87+f9lXHDrqcb2MVLg9L7o8b1UZ0DzhRrUpdn65ttzu10PpJPPI3MQNkis+oha6TSA9Mw==",
+      "dev": true,
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "~1.1.9",
+        "typedarray": "~0.0.5"
+      }
+    },
+    "node_modules/console-browserify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+      "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
+      "dev": true
+    },
+    "node_modules/constants-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
+      "integrity": "sha512-FL+diDS9AKR5BAA2M+GNk8lnH64tRE3zepTG9hucxc7o04LgCRhkQZhF7u/OKHZT8LLRT+sZEi9qFzXUchq9pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
+      "integrity": "sha512-+4nRk0k3oEpwUB7/CalD7xE2z4VmtEnnq0GO2IPTkrooTrAhEsWvuLF5iWP1dXrwluki/azwXV1ve7gtYuPldg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-ecdh": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.5.3"
+      }
+    },
+    "node_modules/create-ecdh/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "node_modules/create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/crypto-browserify": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.1.tgz",
+      "integrity": "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browserify-cipher": "^1.0.1",
+        "browserify-sign": "^4.2.3",
+        "create-ecdh": "^4.0.4",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "diffie-hellman": "^5.0.3",
+        "hash-base": "~3.0.4",
+        "inherits": "^2.0.4",
+        "pbkdf2": "^3.1.2",
+        "public-encrypt": "^4.0.3",
+        "randombytes": "^2.1.0",
+        "randomfill": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dash-ast": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dash-ast/-/dash-ast-1.0.0.tgz",
+      "integrity": "sha512-Vy4dx7gquTeMcQR/hDkYLGUnwVil6vk4FOOct+djUnHOUWt+zJPJAaRIXaAFkPXtJjvlY7o3rfRu0/3hpnwoUA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dateformat": {
+      "version": "1.0.2-1.2.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+      "integrity": "sha512-AXvW8g7tO4ilk5HgOWeDmPi/ZPaCnMJ+9Cg1I3p19w6mcvAAXBuuGEXAxybC+Djj1PSZUiHUcyoYu7WneCX8gQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decode-uri-component": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha512-6sEotTRGBFiNcqVoeHwnfopbSpi5NbH1VWJmYCVkmxMmaVTT0bUTrNaGyBwhgP4MZL012W/mkzIn3Da+iDYweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "0.1.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/defined": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.1.tgz",
+      "integrity": "sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/deps-sort": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
+      "integrity": "sha512-aEnmQuu/Hf5h8akL8QshYWzk9MVBg/JYMyNq/Lz68i69nR17tunjP6o/AC6Tn48c8ayzG6aeKs6OoFOtVCtvrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "JSONStream": "^1.0.3",
+        "shasum": "^1.0.0",
+        "subarg": "^1.0.0",
+        "through2": "^1.0.0"
+      },
+      "bin": {
+        "deps-sort": "bin/cmd.js"
+      }
+    },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/detective": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
+      "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^5.2.1",
+        "defined": "^1.0.0"
+      }
+    },
+    "node_modules/detective/node_modules/acorn": {
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/diff": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.7.tgz",
+      "integrity": "sha512-0bTLzyr1S59cPsgAD/lR+ivvHTbgPb+k/mUR6WGqma1J6QDU+kUegI8uQFuH/cMUNK7JGN3Tk1Y5Jf2MO85WrA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/diffie-hellman": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      }
+    },
+    "node_modules/diffie-hellman/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/domain-browser": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+      "integrity": "sha512-fJ5MoHxe69h3E4/lJtFRhcWwLb04bhIBSfvCEMS1YDH+/9yEZTqBHTSTgch8nCP5tE5k2gdQEjodUqJzy7qJ9Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4",
+        "npm": ">=1.2"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexer2": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+      "integrity": "sha512-+AWBwjGadtksxjOQSFDhPNQbed7icNXApT4+2BNpsXzcCBiInq2H9XW0O8sfHFaPmnQRs7cg/P0fAr2IWQSW0g==",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "readable-stream": "~1.1.9"
+      }
+    },
+    "node_modules/elliptic": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/elliptic/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+      "integrity": "sha512-rp5dMKN8zEs9dfi9g0X1ClLmV//WRyk/R15mppFNICIFRG5P92VP7Z04p8pk++gABo9W2tY+kHyu6P1mEHgmTA==",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/eventemitter2": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "integrity": "sha512-K7J4xq5xAD5jHsGM5ReWXRTFa3JRGofHiMcVgQ8PRwgWxzjHpMWCIzsmyf60+mh8KLsqYPcjUMa0AC4hd6lPyQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/events": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz",
+      "integrity": "sha512-XK19KwlDJo8XsceooxNDK1pObtcT44+Xte6V/jQc4a+fHq1qEouThyyX2ePmS0hS8RcCulmRxzg+T8jiLKAFFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha512-w/ozOKR9Obk3qoWeY/WDi6MFta9AoMR+zud60mdnbniMcBxRuFJyDt2LdX/14A1UABeqk+Uk+LDfUpvoGKppZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expand-brackets/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/expand-brackets/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expand-brackets/node_modules/is-descriptor": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.8.tgz",
+      "integrity": "sha512-SceYGWXvdqlWa/OnQ5FQuV+NxvNmMRhMw/w9AHkH71hTzveND4BTYgvp16g+oITK47qbOl/3D0bl0iygehWAWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.1",
+        "is-data-descriptor": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/expand-brackets/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extglob/node_modules/define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+      "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/faye-websocket": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz",
+      "integrity": "sha512-78pqrJbvGZSe8i+PLsPd+aJqTyGqgyWLnMw5NOwtXCTVMzEFh1zQPwIuIL/ycTj4rkDy5zZ9B6frYPqVPJBzyQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+      "integrity": "sha512-yjftfYnF4ThYEvKEV/kEFR15dmtyXTAh3vQnzpJUoc7Naj5y1P0Ck7Zs1+Vroa00E3KT3IYsk756S+8WA5dNLw==",
+      "dev": true,
+      "dependencies": {
+        "glob": "~3.2.9",
+        "lodash": "~2.4.1"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha512-hVb0zwEZwC1FXSKRPFTeOtN7AArJcJlI6ULGLtrstaswKNlrTJqAA+1lYlSUop4vjA423xlBzqfVS3iWGlqJ+g==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "inherits": "2",
+        "minimatch": "0.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/findup-sync/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/findup-sync/node_modules/minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha512-WFX1jI1AaxNTZVOHLBVazwTWKaQjoykSzCBNXB72vDTCzopQGtyP91tKdFK5cv1+qMwPyiTu1HqUriqplI8pcA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/formatio": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+      "integrity": "sha512-cPh7is6k3d8tIUh+pnXXuAbD/uhSXGgqLPw0UrYpv5lfdJ+MMMSjx40JNpqP7Top9Nt25YomWEiRmkHbOvkCaA==",
+      "deprecated": "This package is unmaintained. Use @sinonjs/formatio instead",
+      "dev": true,
+      "dependencies": {
+        "samsam": "~1.1"
+      }
+    },
+    "node_modules/fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "map-cache": "^0.2.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.9.1.tgz",
+      "integrity": "sha512-yctbTOCHGDktj3eorstAjY0Z8WtbzoHlKKiUZRbX25b34BnuIGsdI9HG2dYO72kimROUPRgJhdSxlBRhDtEZqw==",
+      "dev": true,
+      "dependencies": {
+        "jsonfile": "~1.1.0",
+        "mkdirp": "^0.5.0",
+        "ncp": "^0.5.1",
+        "rimraf": "^2.2.8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "deprecated": "Upgrade to fsevents v2 to mitigate potential security issues",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1"
+      },
+      "engines": {
+        "node": ">= 4.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaze": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
+      "integrity": "sha512-3IWbXGkDDHFX8zIlNdfnmhvlSMhpBO6tDr4InB8fGku6dh/gjFPGNqcdsXJajZg05x9jRzXbL6gCnCnuMap4tw==",
+      "dev": true,
+      "dependencies": {
+        "globule": "~0.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/get-assigned-identifiers": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
+      "integrity": "sha512-mBBwmeGTrxEMO4pMaaf/uUEFHnYtwr8FTe8Y/mer4rcV/bye0qGm6pw1bGZFGStxC5O76c5ZAVBGnqHmOaJpdQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/getobject": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+      "integrity": "sha512-hIGEBfnHcZpWkXPsAVeVmpYDvfy/matVl03yOY91FPmnpCC12Lm5izNxCjO3lHAeO6uaTwMxu7g450Siknlhig==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
+      }
+    },
+    "node_modules/glob-parent/node_modules/is-glob": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+      "integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/globule": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+      "integrity": "sha512-3eIcA2OjPCm4VvwIwZPzIxCVssA8HSpM2C6c6kK5ufJH4FGwWoyqL3In19uuX4oe+TwH3w2P1nQDmW56iehO4A==",
+      "dev": true,
+      "dependencies": {
+        "glob": "~3.1.21",
+        "lodash": "~1.0.1",
+        "minimatch": "~0.2.11"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/globule/node_modules/glob": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+      "integrity": "sha512-ANhy2V2+tFpRajE3wN4DhkNQ08KDr0Ir1qL12/cUe5+a7STEK8jkW4onUYuY8/06qAFuT5je7mjAqzx0eKI2tQ==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "graceful-fs": "~1.2.0",
+        "inherits": "1",
+        "minimatch": "~0.2.11"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/globule/node_modules/graceful-fs": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+      "integrity": "sha512-iiTUZ5vZ+2ZV+h71XAgwCSu6+NAizhFU3Yw8aC/hH5SQ3SnISqEqAek40imAFGtDcwJKNhXvSY+hzIolnLwcdQ==",
+      "deprecated": "please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js",
+      "dev": true,
+      "license": "BSD",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/globule/node_modules/inherits": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+      "integrity": "sha512-Al67oatbRSo3RV5hRqIoln6Y5yMVbJSIn4jEJNL7VCImzq/kLr7vvb6sFRJXqr8rpHc/2kJOM+y0sPKN47VdzA==",
+      "dev": true
+    },
+    "node_modules/globule/node_modules/lodash": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+      "integrity": "sha512-0VSEDVec/Me2eATuoiQd8IjyBMMX0fahob8YJ96V1go2RjvCk1m1GxmtfXn8RNSaLaTtop7fsuhhu9oLk3hUgA==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/globule/node_modules/minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha512-zZ+Jy8lVWlvqqeM8iZB7w7KmQkoJn8djM585z88rywrEbzoqawVa9FR5p2hwD+y74nfuKOjmNvi9gtWJNLqHvA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/growl": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz",
+      "integrity": "sha512-VWv7s1EI41AG2LiCr7uAuxWikLDN1SQOuEUc37d/P34NAIIYgkvWYngNw0d9d9iCrDFL0SYCE9UQpxhIjjtuLg==",
+      "dev": true
+    },
+    "node_modules/grunt": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+      "integrity": "sha512-1iq3ylLjzXqz/KSq1OAE2qhnpcbkF2WyhsQcavZt+YmgvHu0EbPMEhGhy2gr0FP67isHpRdfwjB5WVeXXcJemQ==",
+      "dev": true,
+      "dependencies": {
+        "async": "~0.1.22",
+        "coffee-script": "~1.3.3",
+        "colors": "~0.6.2",
+        "dateformat": "1.0.2-1.2.3",
+        "eventemitter2": "~0.4.13",
+        "exit": "~0.1.1",
+        "findup-sync": "~0.1.2",
+        "getobject": "~0.1.0",
+        "glob": "~3.1.21",
+        "grunt-legacy-log": "~0.1.0",
+        "grunt-legacy-util": "~0.2.0",
+        "hooker": "~0.2.3",
+        "iconv-lite": "~0.2.11",
+        "js-yaml": "~2.0.5",
+        "lodash": "~0.9.2",
+        "minimatch": "~0.2.12",
+        "nopt": "~1.0.10",
+        "rimraf": "~2.2.8",
+        "underscore.string": "~2.2.1",
+        "which": "~1.0.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/grunt-browserify": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/grunt-browserify/-/grunt-browserify-3.8.0.tgz",
+      "integrity": "sha512-0wnAp/xFi/BKSEVRGR7ktaEnCXsRW+yWjVrKj1x+dwWKjRFMQt2nl1Rh5rpwbDuOYATOpYkbuOv6fDi0avxV0Q==",
+      "dev": true,
+      "dependencies": {
+        "async": "^0.9.0",
+        "browserify": "^10.0.0",
+        "glob": "^5.0.5",
+        "lodash": "^3.8.0",
+        "resolve": "^1.1.6",
+        "watchify": "^3.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.x"
+      }
+    },
+    "node_modules/grunt-browserify/node_modules/async": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+      "integrity": "sha512-l6ToIJIotphWahxxHyzK9bnLR6kM4jJIIgLShZeqLY7iboHoGkdgFl7W2/Ivi4SkMJYGKqW8vSuk0uKUj6qsSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/grunt-browserify/node_modules/glob": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+      "integrity": "sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/grunt-browserify/node_modules/lodash": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "integrity": "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/grunt-browserify/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/grunt-coffeelint": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/grunt-coffeelint/-/grunt-coffeelint-0.0.13.tgz",
+      "integrity": "sha512-AjoY762pHh703irpowkm45FkrWlDuNAcEo6PdfCMPFClV0+vPeoipeuq/qCSEQmklXtuOpnWrH+lwatrTBzVYg==",
+      "dev": true,
+      "dependencies": {
+        "coffeelint-stylish": "~0.1.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "peerDependencies": {
+        "coffeelint": "^1",
+        "grunt": "~0.4"
+      }
+    },
+    "node_modules/grunt-contrib-coffee": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-coffee/-/grunt-contrib-coffee-0.11.1.tgz",
+      "integrity": "sha512-Gu8BMXbVns+Zfyy4DiGOnYpEd4Ac6YIZzA24FzxLbNQqupxgk6EKk8YibXXd3umn/1KXcrSNGXjDyAJPIAlhHw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "~0.5.0",
+        "coffee-script": "~1.7.0",
+        "lodash": "~2.4.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "peerDependencies": {
+        "grunt": "~0.4.0"
+      }
+    },
+    "node_modules/grunt-contrib-coffee/node_modules/ansi-regex": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+      "integrity": "sha512-sGwIGMjhYdW26/IhwK2gkWWI8DRCVO6uj3hYgHT+zD+QL1pa37tM3ujhyfcJIYSbsxp7Gxhy7zrRW/1AHm4BmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/grunt-contrib-coffee/node_modules/ansi-styles": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+      "integrity": "sha512-f2PKUkN5QngiSemowa6Mrk9MPCdtFiOSmibjZ+j1qhLGHHYsqZwmBMRF3IRMVXo8sybDqx2fJl2d/8OphBoWkA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/grunt-contrib-coffee/node_modules/chalk": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+      "integrity": "sha512-bIKA54hP8iZhyDT81TOsJiQvR1gW+ZYSXFaZUAvoD4wCHdbHY2actmpTE4x344ZlFqHbvoxKOaESULTZN2gstg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^1.1.0",
+        "escape-string-regexp": "^1.0.0",
+        "has-ansi": "^0.1.0",
+        "strip-ansi": "^0.3.0",
+        "supports-color": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/grunt-contrib-coffee/node_modules/coffee-script": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.7.1.tgz",
+      "integrity": "sha512-W3s+SROY73OmrSGtPTTW/2wp2rmW5vuh0/tUuCK1NvTuyzLOVPccIP9whmhZ4cYWcr2NJPNENZIFaAMkTD5G3w==",
+      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mkdirp": "~0.3.5"
+      },
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/grunt-contrib-coffee/node_modules/has-ansi": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+      "integrity": "sha512-1YsTg1fk2/6JToQhtZkArMkurq8UoWU1Qe0aR3VUHjgij4nOylSWLWAtBXoZ4/dXOmugfLGm1c+QhuD0JyedFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^0.2.0"
+      },
+      "bin": {
+        "has-ansi": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/grunt-contrib-coffee/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/grunt-contrib-coffee/node_modules/mkdirp": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+      "integrity": "sha512-8OCq0De/h9ZxseqzCH8Kw/Filf5pF/vMI6+BH7Lu0jXz2pqYCjTAQRolSxRIi+Ax+oCCjlxoJMP0YQ4XlrQNHg==",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/grunt-contrib-coffee/node_modules/strip-ansi": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+      "integrity": "sha512-DerhZL7j6i6/nEnVG0qViKXI0OKouvvpsAiaj7c+LfqZZZxdwZtv8+UiA/w4VUJpT8UzX0pR1dcHOii1GbmruQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^0.2.1"
+      },
+      "bin": {
+        "strip-ansi": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/grunt-contrib-coffee/node_modules/supports-color": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+      "integrity": "sha512-tdCZ28MnM7k7cJDJc7Eq80A9CsRFAAOZUy41npOZCs++qSjfIy7o5Rh46CBk+Dk5FbKJ33X3Tqg4YrV07N5RaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "supports-color": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/grunt-contrib-watch": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-0.6.1.tgz",
+      "integrity": "sha512-Ea4f3anehA6G+S88vyTwewA/Mf6SbadTIxSgQClKbZYnHOcJ0PrGc2p+uzR6hS9gp7DG6ObvaxkmE8HKnLOsfA==",
+      "dev": true,
+      "dependencies": {
+        "async": "~0.2.9",
+        "gaze": "~0.5.1",
+        "lodash": "~2.4.1",
+        "tiny-lr-fork": "0.0.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "peerDependencies": {
+        "grunt": "~0.4.0"
+      }
+    },
+    "node_modules/grunt-contrib-watch/node_modules/async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ==",
+      "dev": true
+    },
+    "node_modules/grunt-contrib-watch/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/grunt-legacy-log": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
+      "integrity": "sha512-qYs/uM0ImdzwIXLhS4O5WLV5soAM+PEqqHI/hzSxlo450ERSccEhnXqoeDA9ZozOdaWuYnzTOTwRcVRogleMxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colors": "~0.6.2",
+        "grunt-legacy-log-utils": "~0.1.1",
+        "hooker": "~0.2.3",
+        "lodash": "~2.4.1",
+        "underscore.string": "~2.3.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/grunt-legacy-log-utils": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
+      "integrity": "sha512-D0vbUX00TFYCKNZtcZzemMpwT8TR/FdRs1pmfiBw6qnUw80PfsjV+lhIozY/3eJ3PSG2zj89wd2mH/7f4tNAlw==",
+      "dev": true,
+      "dependencies": {
+        "colors": "~0.6.2",
+        "lodash": "~2.4.1",
+        "underscore.string": "~2.3.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/grunt-legacy-log-utils/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/grunt-legacy-log-utils/node_modules/underscore.string": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+      "integrity": "sha512-hbD5MibthuDAu4yA5wxes5bzFgqd3PpBJuClbRxaNddxfdsz+qf+1kHwrGQFrmchmDHb9iNU+6EHDn8uj0xDJg==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/grunt-legacy-log/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/grunt-legacy-log/node_modules/underscore.string": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+      "integrity": "sha512-hbD5MibthuDAu4yA5wxes5bzFgqd3PpBJuClbRxaNddxfdsz+qf+1kHwrGQFrmchmDHb9iNU+6EHDn8uj0xDJg==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/grunt-legacy-util": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+      "integrity": "sha512-cXPbfF8aM+pvveQeN1K872D5fRm30xfJWZiS63Y8W8oyIPLClCsmI8bW96Txqzac9cyL4lRqEBhbhJ3n5EzUUQ==",
+      "dev": true,
+      "dependencies": {
+        "async": "~0.1.22",
+        "exit": "~0.1.1",
+        "getobject": "~0.1.0",
+        "hooker": "~0.2.3",
+        "lodash": "~0.9.2",
+        "underscore.string": "~2.2.1",
+        "which": "~1.0.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/grunt-mocha-test": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/grunt-mocha-test/-/grunt-mocha-test-0.11.0.tgz",
+      "integrity": "sha512-BDffDt8Y724rbeUhSg3GZdhTx918hJ5WoHRdW3uXCIYNxeySoECjkmTiAEf2tHp6GYwW5sMKXk2jTqCU/LbajA==",
+      "dev": true,
+      "dependencies": {
+        "fs-extra": "~0.9.1",
+        "hooker": "~0.2.3",
+        "mocha": "~1.20.0"
+      },
+      "engines": {
+        "node": ">= 0.10.4"
+      }
+    },
+    "node_modules/grunt/node_modules/coffee-script": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+      "integrity": "sha512-QjQ1T4BqyHv19k6XSfdhy/QLlIOhywz0ekBUCa9h71zYMJlfDTGan/Z1JXzYkZ6v8R+GhvL/p4FZPbPW8WNXlg==",
+      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
+      "dev": true,
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/grunt/node_modules/glob": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+      "integrity": "sha512-ANhy2V2+tFpRajE3wN4DhkNQ08KDr0Ir1qL12/cUe5+a7STEK8jkW4onUYuY8/06qAFuT5je7mjAqzx0eKI2tQ==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "graceful-fs": "~1.2.0",
+        "inherits": "1",
+        "minimatch": "~0.2.11"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/grunt/node_modules/graceful-fs": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+      "integrity": "sha512-iiTUZ5vZ+2ZV+h71XAgwCSu6+NAizhFU3Yw8aC/hH5SQ3SnISqEqAek40imAFGtDcwJKNhXvSY+hzIolnLwcdQ==",
+      "deprecated": "please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js",
+      "dev": true,
+      "license": "BSD",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/grunt/node_modules/inherits": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+      "integrity": "sha512-Al67oatbRSo3RV5hRqIoln6Y5yMVbJSIn4jEJNL7VCImzq/kLr7vvb6sFRJXqr8rpHc/2kJOM+y0sPKN47VdzA==",
+      "dev": true
+    },
+    "node_modules/grunt/node_modules/minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha512-zZ+Jy8lVWlvqqeM8iZB7w7KmQkoJn8djM585z88rywrEbzoqawVa9FR5p2hwD+y74nfuKOjmNvi9gtWJNLqHvA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
+      "integrity": "sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha512-IBXk4GTsLYdQ7Rvt+GRBrFSVEkmuOUy4re0Xjd9kJSUQpnTrWR4/y9RpfexN9vkAPMFuQoeWKwqzPozRTlasGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha512-ODYZC64uqzmtfGMEAX/FvZiRyWLpAC3vYnNunURUnkGVTS+mI0smVsWaPydRBsE3g+ok7h960jChO8mFcWlHaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-values/node_modules/kind-of": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+      "integrity": "sha512-24XsCxmEbRwEDbz/qz3stgin8TTzZ1ESR56OMCN0ujYg+vRutNSiOj9bHH9u85DKgXguraugV5sFuvbD4FW/hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/hash-base": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.5.tgz",
+      "integrity": "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/hooker": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+      "integrity": "sha512-t+UerCsQviSymAInD01Pw+Dn/usmz1sRO+3Zk1+lx8eg+WKpD2ulcwWqHHL0+aseRBr+3+vIhiG1K1JTwaIcTA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/htmlescape": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
+      "integrity": "sha512-eVcrzgbR4tim7c7soKQKtxa/kQM4TzjnlU83rcZ9bHU6t31ehfV7SktN6McWgwPWg+JYMA/O3qpGxBvFq1z2Jg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/http-browserify": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
+      "integrity": "sha512-Irf/LJXmE3cBzU1eaR4+NEX6bmVLqt1wkmDiA7kBwH7zmb0D8kBAXsDmQ88hhj/qv9iEZKlyGx/hrMcFi8sOHw==",
+      "dev": true,
+      "license": "MIT/X11",
+      "dependencies": {
+        "Base64": "~0.2.0",
+        "inherits": "~2.0.1"
+      }
+    },
+    "node_modules/https-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
+      "integrity": "sha512-EjDQFbgJr1vDD/175UJeSX3ncQ3+RUnCL5NkthQGHvF4VNHlzTy8ifJfTqz47qiPRqaFH58+CbuG3x51WuB1XQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+      "integrity": "sha512-KhmFWgaQZY83Cbhi+ADInoUQ8Etn6BG5fikM9syeOjQltvR45h7cRKJ/9uvQEuD61I3Uju77yYce0/LhKVClQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg==",
+      "dev": true
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/inline-source-map": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz",
+      "integrity": "sha512-2WtHG0qX9OH9TVcxsLVfq3Tzr+qtL6PtWgoh0XAAKe4KkdA/57Q+OGJuRJHA4mZ2OZnkJ/ZAaXf9krLB12/nIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "~0.4.0"
+      }
+    },
+    "node_modules/insert-module-globals": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.3.tgz",
+      "integrity": "sha512-ryk8hTKUZCc300SPOOwx30WhE5oRUssPDVlIoO8vtoMNBy5HGeesVRl3HF7ra4ll42T0IdnwD9XR9svh6+RRhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "combine-source-map": "~0.6.1",
+        "concat-stream": "~1.4.1",
+        "is-buffer": "^1.1.0",
+        "JSONStream": "^1.0.3",
+        "lexical-scope": "^1.2.0",
+        "process": "~0.11.0",
+        "through2": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "insert-module-globals": "bin/cmd.js"
+      }
+    },
+    "node_modules/is-accessor-descriptor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.2.tgz",
+      "integrity": "sha512-AIbwAcazqP3R65dGvqk1V+a+vE5Fg1yu/ZKMOiBWSUIXXiwQkYmXQcVa2O0nh0tSDKDFKxG2mY7dB1Sr4hEP1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "integrity": "sha512-9fRVlXc0uCxEDj1nQzaWONSpbTfx0FmJfzHF7pwlI8DkWGoHBBea4Pg5Ky0ojwwxQmnSifgbKkI06Qv0Ljgj+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-descriptor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.1.tgz",
+      "integrity": "sha512-bc4NlCDiCr28U4aEsQ3Qs2491gVq4V8G7MQyws968ImqjKuYtTJXrl7Vq7jsN7Ly/C3xj5KWFrY7sHNeDkAzXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-descriptor": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.4.tgz",
+      "integrity": "sha512-bv5z95W0dDtLfKwDfkTNxaRxmISBD3eQBKJeVxv2AQ7MjuUnDNG7cIQqvFtMOUYhsILWHhMayWdoGqNqYYYjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.2",
+        "is-data-descriptor": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha512-mkk3vzUHFjzKjpCXeu+IjXeZD+QOTjUUdubgmHtHTDwvAO2ZTkMTTVrapts5CWz3JvJryh/4KWZpjeZrCepZ3A==",
+      "deprecated": "Jade has been renamed to pug, please install the latest version of pug instead of jade",
+      "dev": true,
+      "dependencies": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "bin": {
+        "jade": "bin/jade"
+      }
+    },
+    "node_modules/jade/node_modules/commander": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+      "integrity": "sha512-0fLycpl1UMTGX257hRsu/arL/cUbcvQM4zMKwvLvzXtfdezIV4yotPS2dYtknF+NmEfWSoCEF6+hj9XLm/6hEw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.x"
+      }
+    },
+    "node_modules/jade/node_modules/mkdirp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+      "integrity": "sha512-OHsdUcVAQ6pOtg5JYWpCBo9W/GySVuwvP9hueRMW7UqshC0tbfzLv8wjySTPm3tfUZ/21CE9E1pJagOA91Pxew==",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "dev": true,
+      "license": "MIT/X11",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/jit-grunt": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/jit-grunt/-/jit-grunt-0.8.0.tgz",
+      "integrity": "sha512-mJ80LXh3rDLhlLMhqZsLu38QZlUR2bKrnT993DnlcvKSECKdt3/1+MNoMaUV8jbKIw16EdxODMPTuLsC8rGg/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      },
+      "peerDependencies": {
+        "grunt": "~0.4.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+      "integrity": "sha512-VEKcIksckDBUhg2JS874xVouiPkywVUh4yyUmLCDe1Zg3bCd6M+F1eGPenPeHLc2XC8pp9G8bsuofK0NeEqRkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "~ 0.1.11",
+        "esprima": "~ 1.0.2"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/json-stable-stringify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+      "integrity": "sha512-nKtD/Qxm7tWdZqJoldEC7fF0S41v0mWbeaXG3637stOWfyGxTgWTYE2wtfKmjzpvxv2MA2xzxsXOIiwUpkX6Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsonify": "~0.0.0"
+      }
+    },
+    "node_modules/jsondiffpatch": {
+      "version": "0.1.43",
+      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.1.43.tgz",
+      "integrity": "sha512-lvOkGuk7gl9Rr4M/SfN530TslMb9QZG9PM5uznjb6oVwkkHNt7rgPNOBO59mwegJ/0Msx/yjwYzdiuoET6a87Q==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^0.5.1"
+      },
+      "bin": {
+        "jsondiffpatch": "bin/jsondiffpatch"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/jsondiffpatch/node_modules/ansi-regex": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+      "integrity": "sha512-sGwIGMjhYdW26/IhwK2gkWWI8DRCVO6uj3hYgHT+zD+QL1pa37tM3ujhyfcJIYSbsxp7Gxhy7zrRW/1AHm4BmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jsondiffpatch/node_modules/ansi-styles": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+      "integrity": "sha512-f2PKUkN5QngiSemowa6Mrk9MPCdtFiOSmibjZ+j1qhLGHHYsqZwmBMRF3IRMVXo8sybDqx2fJl2d/8OphBoWkA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jsondiffpatch/node_modules/chalk": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+      "integrity": "sha512-bIKA54hP8iZhyDT81TOsJiQvR1gW+ZYSXFaZUAvoD4wCHdbHY2actmpTE4x344ZlFqHbvoxKOaESULTZN2gstg==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^1.1.0",
+        "escape-string-regexp": "^1.0.0",
+        "has-ansi": "^0.1.0",
+        "strip-ansi": "^0.3.0",
+        "supports-color": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jsondiffpatch/node_modules/has-ansi": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+      "integrity": "sha512-1YsTg1fk2/6JToQhtZkArMkurq8UoWU1Qe0aR3VUHjgij4nOylSWLWAtBXoZ4/dXOmugfLGm1c+QhuD0JyedFA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^0.2.0"
+      },
+      "bin": {
+        "has-ansi": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jsondiffpatch/node_modules/strip-ansi": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+      "integrity": "sha512-DerhZL7j6i6/nEnVG0qViKXI0OKouvvpsAiaj7c+LfqZZZxdwZtv8+UiA/w4VUJpT8UzX0pR1dcHOii1GbmruQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^0.2.1"
+      },
+      "bin": {
+        "strip-ansi": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jsondiffpatch/node_modules/supports-color": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+      "integrity": "sha512-tdCZ28MnM7k7cJDJc7Eq80A9CsRFAAOZUy41npOZCs++qSjfIy7o5Rh46CBk+Dk5FbKJ33X3Tqg4YrV07N5RaA==",
+      "license": "MIT",
+      "bin": {
+        "supports-color": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-1.1.1.tgz",
+      "integrity": "sha512-yrmo536TrJWDHNYlkCjtkPSqNnAkt6u1k89O5Xxr53zc4DkdikTHE+Fx6VF7syJd18xsdo24U4csedAkhLgxVQ==",
+      "dev": true
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      },
+      "bin": {
+        "JSONStream": "bin.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/labeled-stream-splicer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
+      "integrity": "sha512-3KBjPRnXrYC5h2jEf/d6hO7Lcl+38QzRVTOyHA2sFzZVMYwsUFuejlrOMwAjmz13hVBr9ruDS1RwE4YEz8P58w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "isarray": "~0.0.1",
+        "stream-splicer": "^1.1.0"
+      }
+    },
+    "node_modules/lexical-scope": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
+      "integrity": "sha512-ntJ8IcBCuKwudML7vAuT/L0aIMU0+9vO25K4CjLPYgzf1NZ0bAhJJBZrvkO+oUGgKcbdkH8UZdRsaEg+wULLRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "astw": "^2.0.0"
+      }
+    },
+    "node_modules/limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+    },
+    "node_modules/load-grunt-config": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/load-grunt-config/-/load-grunt-config-0.13.2.tgz",
+      "integrity": "sha512-8rtJvmyRxZwZ5+dYJChdOljF457OEEEIfv4JT8Qsp3TX0Pcoq2y8KRukbrC0bujyh8tv38cx0CrbSsEeFR9Xhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "~0.2.10",
+        "glob": "~3.2.6",
+        "jit-grunt": "~0.8.0",
+        "js-yaml": "~3.0.1",
+        "load-grunt-tasks": "~0.3.0",
+        "lodash-node": "~2.4.1"
+      }
+    },
+    "node_modules/load-grunt-config/node_modules/async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ==",
+      "dev": true
+    },
+    "node_modules/load-grunt-config/node_modules/glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha512-hVb0zwEZwC1FXSKRPFTeOtN7AArJcJlI6ULGLtrstaswKNlrTJqAA+1lYlSUop4vjA423xlBzqfVS3iWGlqJ+g==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "inherits": "2",
+        "minimatch": "0.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/load-grunt-config/node_modules/js-yaml": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.2.tgz",
+      "integrity": "sha512-8PVwV1480dnAPMj8FCW3I/mZZ+gvtOoMAZFWJKagkFq2eWv5kcyzWTR+6MloV0SY57t6jSIaKc7DIz86K9ZCfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "~ 0.1.11",
+        "esprima": "~ 1.0.2"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/load-grunt-config/node_modules/minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha512-WFX1jI1AaxNTZVOHLBVazwTWKaQjoykSzCBNXB72vDTCzopQGtyP91tKdFK5cv1+qMwPyiTu1HqUriqplI8pcA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/load-grunt-tasks": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-0.3.0.tgz",
+      "integrity": "sha512-bgZqR+scmG37RTcJbZgXbH6pfohQl2F7j5wVqNHXS35B280LQKvI5ftMik0Q5qMR8tTecWEtLVNLRdSQGtQeWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "findup-sync": "~0.1.2",
+        "globule": "~0.2.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/load-grunt-tasks/node_modules/glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha512-hVb0zwEZwC1FXSKRPFTeOtN7AArJcJlI6ULGLtrstaswKNlrTJqAA+1lYlSUop4vjA423xlBzqfVS3iWGlqJ+g==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "inherits": "2",
+        "minimatch": "0.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/load-grunt-tasks/node_modules/glob/node_modules/minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha512-WFX1jI1AaxNTZVOHLBVazwTWKaQjoykSzCBNXB72vDTCzopQGtyP91tKdFK5cv1+qMwPyiTu1HqUriqplI8pcA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/load-grunt-tasks/node_modules/globule": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-0.2.0.tgz",
+      "integrity": "sha512-mMhYxzb8wpE7VtHkJi+jk0yjlBLFetYMAnkcFutmDo4uSFAHu/1tLgVm9Y6HcaTaX1DZBJjZOM1KqqCZDvBLBw==",
+      "dev": true,
+      "dependencies": {
+        "glob": "~3.2.7",
+        "lodash": "~2.4.1",
+        "minimatch": "~0.2.11"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/load-grunt-tasks/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/load-grunt-tasks/node_modules/minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha512-zZ+Jy8lVWlvqqeM8iZB7w7KmQkoJn8djM585z88rywrEbzoqawVa9FR5p2hwD+y74nfuKOjmNvi9gtWJNLqHvA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+      "integrity": "sha512-LVbt/rjK62gSbhehDVKL0vlaime4Y1IBixL+bKeNfoY4L2zab/jGrxU6Ka05tMA/zBxkTk5t3ivtphdyYupczw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/lodash-node": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz",
+      "integrity": "sha512-egEt8eNQp2kZWRmngahiqMoDCDCENv3uM188S7Ed5t4k3v6RrLELXC+FqLNMUnhCo7gvQX3G1V8opK/Lcslahg==",
+      "deprecated": "This package is discontinued. Use lodash@^4.0.0.",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash._basebind": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz",
+      "integrity": "sha512-VGHm6DH+1UiuafQdE/DNMqxOcSyhRu0xO9+jPDq7xITRn5YOorGrHVQmavMVXCYmTm80YRTZZCn/jTW7MokwLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._basecreate": "~2.4.1",
+        "lodash._setbinddata": "~2.4.1",
+        "lodash._slice": "~2.4.1",
+        "lodash.isobject": "~2.4.1"
+      }
+    },
+    "node_modules/lodash._basecreate": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+      "integrity": "sha512-8JJ3FnMPm54t3BwPLk8q8mPyQKQXm/rt9df+awr4NGtyJrtcCXM3Of1I86S6jVy1b4yAyFBb8wbKPEauuqzRmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._isnative": "~2.4.1",
+        "lodash.isobject": "~2.4.1",
+        "lodash.noop": "~2.4.1"
+      }
+    },
+    "node_modules/lodash._basecreatecallback": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz",
+      "integrity": "sha512-SLczhg860fGW7AKlYcuOFstDtJuQhaANlJ4Y/jrOoRxhmVtK41vbJDH3OefVRSRkSCQo4HI82QVkAVsoGa5gSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._setbinddata": "~2.4.1",
+        "lodash.bind": "~2.4.1",
+        "lodash.identity": "~2.4.1",
+        "lodash.support": "~2.4.1"
+      }
+    },
+    "node_modules/lodash._basecreatewrapper": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz",
+      "integrity": "sha512-x2ja1fa/qmzbizuXgVM4QAP9svtMbdxjG8Anl9bCeDAwLOVQ1vLrA0hLb/NkpbGi9evjtkl0aWLTEoOlUdBPQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._basecreate": "~2.4.1",
+        "lodash._setbinddata": "~2.4.1",
+        "lodash._slice": "~2.4.1",
+        "lodash.isobject": "~2.4.1"
+      }
+    },
+    "node_modules/lodash._createwrapper": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz",
+      "integrity": "sha512-5TCfLt1haQpsa7bgLYRKNNE4yqhO4ZxIayN1btQmazMchO6Q8JYFRMqbJ3W+uNmMm4R0Jw7KGkZX5YfDDnywuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._basebind": "~2.4.1",
+        "lodash._basecreatewrapper": "~2.4.1",
+        "lodash._slice": "~2.4.1",
+        "lodash.isfunction": "~2.4.1"
+      }
+    },
+    "node_modules/lodash._isnative": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+      "integrity": "sha512-BOlKGKNHhCHswGOWtmVb5zBygyxN7EmTuzVOSQI6QSoGhG+kvv71gICFS1TBpnqvT1n53txK8CDK3u5D2/GZxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash._objecttypes": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+      "integrity": "sha512-XpqGh1e7hhkOzftBfWE7zt+Yn9mVHFkDhicVttvKLsoCMLVVL+xTQjfjB4X4vtznauxv0QZ5ZAeqjvat0dh62Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash._setbinddata": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
+      "integrity": "sha512-Vx0XKzpg2DFbQw4wrp1xSWd2sfl3W/BG6bucSRZmftS1AzbWRemCmBQDxyQTNhlLNec428PXkuuja+VNBZgu2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._isnative": "~2.4.1",
+        "lodash.noop": "~2.4.1"
+      }
+    },
+    "node_modules/lodash._shimkeys": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+      "integrity": "sha512-lBrglYxLD/6KAJ8IEa5Lg+YHgNAL7FyKqXg4XOUI+Du/vtniLs1ZqS+yHNKPkK54waAgkdUnDOYaWf+rv4B+AA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._objecttypes": "~2.4.1"
+      }
+    },
+    "node_modules/lodash._slice": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz",
+      "integrity": "sha512-+odPJa4PE2UgYnQgJgkLs0UD03QU78R2ivhrFnG9GdtYOZdE6ObxOj7KiUEUlqOOgatFT+ZqSypFjDSduTigKg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.bind": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz",
+      "integrity": "sha512-hn2VWYZ+N9aYncRad4jORvlGgpFrn+axnPIWRvFxjk6CWcZH5b5alI8EymYsHITI23Z9wrW/+ORq+azrVFpOfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._createwrapper": "~2.4.1",
+        "lodash._slice": "~2.4.1"
+      }
+    },
+    "node_modules/lodash.defaults": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+      "integrity": "sha512-5wTIPWwGGr07JFysAZB8+7JB2NjJKXDIwogSaRX5zED85zyUAQwtOqUk8AsJkkigUcL3akbHYXd5+BPtTGQPZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._objecttypes": "~2.4.1",
+        "lodash.keys": "~2.4.1"
+      }
+    },
+    "node_modules/lodash.foreach": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-2.4.1.tgz",
+      "integrity": "sha512-AvOobAkE7qBtIiHU5QHQIfveWH5Usr9pIcFIzBv7u4S6bvb3FWpFrh9ltqBY7UeL5lw6e8d+SggiUXQVyh+FpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._basecreatecallback": "~2.4.1",
+        "lodash.forown": "~2.4.1"
+      }
+    },
+    "node_modules/lodash.forown": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.forown/-/lodash.forown-2.4.1.tgz",
+      "integrity": "sha512-VC+CKm/zSs5t3i/MHv71HZoQphuqOvez1xhjWBwHU5zAbsCYrqwHr+MyQyMk14HzA3hSRNA5lCqDMSw5G2Qscg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._basecreatecallback": "~2.4.1",
+        "lodash._objecttypes": "~2.4.1",
+        "lodash.keys": "~2.4.1"
+      }
+    },
+    "node_modules/lodash.identity": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz",
+      "integrity": "sha512-VRYX+8XipeLjorag5bz3YBBRJ+5kj8hVBzfnaHgXPZAVTYowBdY5l0M5ZnOmlAMCOXBFabQtm7f5VqjMKEji0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isfunction": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz",
+      "integrity": "sha512-6XcAB3izeQxPOQQNAJbbdjXbvWEt2Pn9ezPrjr4CwoLwmqsLVbsiEXD19cmmt4mbzOCOCdHzOQiUivUOJLra7w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isobject": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+      "integrity": "sha512-sTebg2a1PoicYEZXD5PBdQcTlIJ6hUslrlWr7iV0O7n+i4596s2NQ9I5CaZ5FbXSfya/9WQsrYLANUJv9paYVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._objecttypes": "~2.4.1"
+      }
+    },
+    "node_modules/lodash.keys": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+      "integrity": "sha512-ZpJhwvUXHSNL5wYd1RM6CUa2ZuqorG9ngoJ9Ix5Cce+uX7I5O/E06FCJdhSZ33b5dVyeQDnIlWH7B2s5uByZ7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._isnative": "~2.4.1",
+        "lodash._shimkeys": "~2.4.1",
+        "lodash.isobject": "~2.4.1"
+      }
+    },
+    "node_modules/lodash.memoize": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
+      "integrity": "sha512-eDn9kqrAmVUC1wmZvlQ6Uhde44n+tXpqPrN8olQJbttgh0oKclk+SF54P47VEGE9CEiMeRwAP8BaM7UHvBkz2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.noop": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
+      "integrity": "sha512-uNcV98/blRhInPUGQEnj9ekXXfG+q+rfoNSFZgl/eBfog9yBDW9gfUv2AHX/rAF7zZRlzWhbslGhbGQFZlCkZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.support": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.4.1.tgz",
+      "integrity": "sha512-6SwqWwGFHhTXEiqB/yQgu8FYd//tm786d49y7kizHVCJH7zdzs191UQn3ES3tkkDbUddNRfkCRYqJFHtbLnbCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._isnative": "~2.4.1"
+      }
+    },
+    "node_modules/lolex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
+      "integrity": "sha512-YYp8cqz7/8eruZ15L1mzcPkvLYxipfdsWIDESvNdNmQP9o7TsDitRhNuV2xb7aFu2ofZngao1jiVrVZ842x4BQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-visit": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/micromatch/node_modules/extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/micromatch/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/micromatch/node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/miller-rabin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
+      },
+      "bin": {
+        "miller-rabin": "bin/miller-rabin"
+      }
+    },
+    "node_modules/miller-rabin/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minifyify": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/minifyify/-/minifyify-4.4.0.tgz",
+      "integrity": "sha512-Btguwl72Z3WUAJoOPWV599R30/VwIHqs2IlCKZSHlFTftFaoyfJoDfcTS66cqbsEhHSdXy4+PGEgjrI4QRYE6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "concat-stream": "1.4.x",
+        "convert-source-map": "^0.4.0",
+        "lodash.bind": "2.4.x",
+        "lodash.defaults": "2.4.x",
+        "lodash.foreach": "2.4.x",
+        "mkdirp": "^0.5.0",
+        "source-map": "0.1.34",
+        "through": "2.3.x",
+        "tmp": "0.0.23",
+        "uglify-js": "2.4.x"
+      },
+      "engines": {
+        "node": "0.10.x"
+      }
+    },
+    "node_modules/minifyify/node_modules/convert-source-map": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.4.1.tgz",
+      "integrity": "sha512-yFU/yTFbnlUH0wnu33o7hZwbcGmmnKw2uLAxLPnWW8zh+o7+xq7LmB4DMqKo5IniPcRs6quLHZ/A5ogSYhU1qw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minifyify/node_modules/source-map": {
+      "version": "0.1.34",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+      "integrity": "sha512-yfCwDj0vR9RTwt3pEzglgb3ZgmcXHt6DjG3bjJvzPwTL+5zDQ2MhmSzAcTy0GTiQuCiriSWXvWM1/NhKdXuoQA==",
+      "dev": true,
+      "dependencies": {
+        "amdefine": ">=0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mixin-deep": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mixin-deep/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mocha": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.20.1.tgz",
+      "integrity": "sha512-25Nq3BuIYCy80uEix+hBlZcr/gnLzpcYqfsaPAxZm2qbMFmed8I3nP8N05KagK4BTkGYUvsRJ47istvRqFO8fw==",
+      "deprecated": "Mocha v1.x is no longer supported.",
+      "dev": true,
+      "dependencies": {
+        "commander": "2.0.0",
+        "debug": "*",
+        "diff": "1.0.7",
+        "glob": "3.2.3",
+        "growl": "1.7.x",
+        "jade": "0.26.3",
+        "mkdirp": "0.3.5"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 0.4.x"
+      }
+    },
+    "node_modules/mocha/node_modules/glob": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+      "integrity": "sha512-WPaLsMHD1lYEqAmIQI6VOJSPwuBdGShDWnj1yUo0vQqEO809R8W3LM9OVU13CnnDhyv/EiNwOtxEW74SmrzS6w==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "graceful-fs": "~2.0.0",
+        "inherits": "2",
+        "minimatch": "~0.2.11"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mocha/node_modules/graceful-fs": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+      "integrity": "sha512-hcj/NTUWv+C3MbqrVb9F+aH6lvTwEHJdx2foBxlrVq5h6zE8Bfu4pv4CAAqbDcZrw/9Ak5lsRXlY9Ao8/F0Tuw==",
+      "deprecated": "please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js",
+      "dev": true,
+      "license": "BSD",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha512-zZ+Jy8lVWlvqqeM8iZB7w7KmQkoJn8djM585z88rywrEbzoqawVa9FR5p2hwD+y74nfuKOjmNvi9gtWJNLqHvA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mocha/node_modules/mkdirp": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+      "integrity": "sha512-8OCq0De/h9ZxseqzCH8Kw/Filf5pF/vMI6+BH7Lu0jXz2pqYCjTAQRolSxRIi+Ax+oCCjlxoJMP0YQ4XlrQNHg==",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/module-deps": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
+      "integrity": "sha512-EbWWlSGaCVidEsLsSzkY6l/jm0IcGDSQ8tGwtjM8joTrxqxP0om02Px9Np8D7FMZ/vZFdsOGbio+WqkKQxYuTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browser-resolve": "^1.7.0",
+        "concat-stream": "~1.4.5",
+        "defined": "^1.0.0",
+        "detective": "^4.0.0",
+        "duplexer2": "0.0.2",
+        "inherits": "^2.0.1",
+        "JSONStream": "^1.0.3",
+        "parents": "^1.0.0",
+        "readable-stream": "^1.1.13",
+        "resolve": "^1.1.3",
+        "stream-combiner2": "~1.0.0",
+        "subarg": "^1.0.0",
+        "through2": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "module-deps": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/module-deps/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nan": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+      "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nanomatch/node_modules/extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nanomatch/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nanomatch/node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ncp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.5.1.tgz",
+      "integrity": "sha512-l+pJxuLlzwp11Dy72MJgCPNwIbXdv6imaACLiEMb2TIDyr54qz+nAZeD5qDlJefveaJ+R9Ug6KuozCxRpQXO0Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "ncp": "bin/ncp"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/noptify": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
+      "integrity": "sha512-EZT35r9AuK+hig+iYv4144kwfDEDhlj3zncVHw9b9d86TUYk/67BtBApkfPD1kslAT/8TTD262xdsVbV+iCSTw==",
+      "dev": true,
+      "dependencies": {
+        "nopt": "~2.0.0"
+      }
+    },
+    "node_modules/noptify/node_modules/nopt": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
+      "integrity": "sha512-uVTsuT8Hm3aN3VttY+BPKw4KU9lVpI0F22UAr/I1r6+kugMr3oyhMALkycikLcdfvGRsgzCYN48DYLBFcJEUVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "remove-trailing-separator": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha512-79LYn6VAb63zgtmAteVOWo9Vdj71ZVBy3Pbse+VqxDpEP83XuujMrGqHIwAXJ5I/aM0zU7dIyIAhifVTPrNItQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-copy/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-copy/node_modules/is-descriptor": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.8.tgz",
+      "integrity": "sha512-SceYGWXvdqlWa/OnQ5FQuV+NxvNmMRhMw/w9AHkH71hTzveND4BTYgvp16g+oITK47qbOl/3D0bl0iygehWAWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.1",
+        "is-data-descriptor": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha512-GBaMwwAVK9qbQN3Scdo0OyvgPW7l3lnaVMj84uTOZlswkX0KpF6fyDBJhtTthf7pymztoN36/KEr1DyhF96zEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/omega-pac": {
+      "resolved": "../omega-pac",
+      "link": true
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha512-snN4O4TkigujZphWLN0E//nQmm7790RYaE53DdL7ZYwee2D8DDo9/EyYiKUfN3rneWUjhJnueija3G9I2i0h3g==",
+      "dev": true,
+      "license": "MIT/X11",
+      "dependencies": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      }
+    },
+    "node_modules/optimist/node_modules/minimist": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+      "integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/os-browserify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+      "integrity": "sha512-aZicJZccvxWOZ0Bja2eAch2L8RIJWBuRYmM8Gwl/JjNtRltH0Itcz4eH/ESyuIWfse8cc93ZCf0XrzhXK2HEDA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/outpipe": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz",
+      "integrity": "sha512-BnNY/RwnDrkmQdUa9U+OfN/Y7AWmKuUPCCd+hbRclZnnANvYpO72zp/a6Q4n829hPbdqEac31XCcsvlEvb+rtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shell-quote": "^1.4.2"
+      }
+    },
+    "node_modules/outpipe/node_modules/shell-quote": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parents": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+      "integrity": "sha512-mXKF3xkoUt5td2DoxpLmtOmZvko9VfFpwRwkKDHSNvgmpLAeBo18YDhcPbBzJq+QLCHMbGOfzia2cX4U+0v9Mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-platform": "~0.11.15"
+      }
+    },
+    "node_modules/parse-asn1": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.9.tgz",
+      "integrity": "sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asn1.js": "^4.10.1",
+        "browserify-aes": "^1.2.0",
+        "evp_bytestokey": "^1.0.3",
+        "pbkdf2": "^3.1.5",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-platform": {
+      "version": "0.11.15",
+      "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+      "integrity": "sha512-Y30dB6rab1A/nfEKsZxmr01nUotHX0c/ZiIAsCTatEe1CmS5Pm5He7fZ195bPT7RdquoaL8lLxFCMQi/bS7IJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/pbkdf2": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.6.tgz",
+      "integrity": "sha512-BT6eelPB1EyGHo8pC0o9Bl6k6SYVhKO1jEbd3lcTrtr7XHdjP8BW1YpfCV3G9Kwkxgattk+S5q2/RvuttCsS1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "ripemd160": "^2.0.3",
+        "safe-buffer": "^5.2.1",
+        "sha.js": "^2.4.12",
+        "to-buffer": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/public-encrypt": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/public-encrypt/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz",
+      "integrity": "sha512-KbOrQrP5Ye+0gmq+hwxoJwAFRwExACWqwxj1IDFFgqOw9Poxy3wwSbafd9ZqP6T6ykMfnxM573kt/a4i9ybatQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/querystring-es3": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "integrity": "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/randomfill": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/read-only-stream": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-1.1.1.tgz",
+      "integrity": "sha512-CNGbvYZYr0b1F41aN7bYLHUBvvoynSS7ZTf2RLa5egnjZxKJPJUpUdWplD+jxQPijP/eL02IJxBhY8hwJlI3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^1.0.31",
+        "readable-wrap": "^1.0.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/readable-wrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
+      "integrity": "sha512-/8n0Mr10S+HGKFygQ42Z40JIXwafPH3A72pwmlNClThgsImV5LJJiCue5Je1asxwY082sYxq/+kTxH6nTn0w3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^1.1.13-1"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11",
+        "micromatch": "^3.1.10",
+        "readable-stream": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/readdirp/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readdirp/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readdirp/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readdirp/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/regex-not/node_modules/extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/regex-not/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/repeat-element": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
+      "integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz",
+      "integrity": "sha512-UHBY3viPlJKf85YijDUcikKX6tmF4SokIDp518ZDVT92JNDcG5uKIthaT/owt3Sar0lwtOafsQuwrg22/v2Dwg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==",
+      "deprecated": "https://github.com/lydell/resolve-url#deprecated",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+      "integrity": "sha512-R5KMKHnPAQaZMqLOsyuyUmcIjSeDm+73eoqQpaXA7AZ22BL+6C+1mcUscgOsNd8WVlJuvlgAPsegcx7pjlV0Dg==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ripemd160": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
+      "integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^3.1.2",
+        "inherits": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/ripemd160/node_modules/hash-base": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
+      "integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^2.3.8",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/ripemd160/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ripemd160/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/ripemd160/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ripemd160/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/ripemd160/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha512-aJXcif4xnaNUzvUuC5gcb46oTS7zvg4jpMTnuqtrEPlR3vFr4pxtdTwaF1Qs3Enjn9HK+ZlwQui+a7z0SywIzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.1.10"
+      }
+    },
+    "node_modules/samsam": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+      "integrity": "sha512-iVL7LibpM3tl4rQPweOXXrmjGegxx27flTOjQEZD3PXe4oZNFzuz6Si4mgleK/JWU/hyCvtV01RUovjvBEpDmw==",
+      "deprecated": "This package has been deprecated in favour of @sinonjs/samsam",
+      "dev": true
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-value": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "dev": true,
+      "license": "(MIT AND BSD-3-Clause)",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/shasum": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+      "integrity": "sha512-UTzHm/+AzKfO9RgPgRpDIuMSNie1ubXRaljjlhFMNGYoG7z+rm9AHLPMf70R7887xboDH9Q+5YQbWKObFHEAtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-stable-stringify": "~0.0.0",
+        "sha.js": "~2.4.4"
+      }
+    },
+    "node_modules/shasum-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/shasum-object/-/shasum-object-1.0.1.tgz",
+      "integrity": "sha512-SsC+1tW7XKQ/94D4k1JhLmjDFpVGET/Nf54jVDtbavbALf8Zhp0Td9zTlxScjMW6nbEIrpADtPWfLk9iCXzHDQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fast-safe-stringify": "^2.0.7"
+      },
+      "bin": {
+        "shasum-object": "bin.js"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz",
+      "integrity": "sha512-uEWz7wa9vnCi9w4mvKZMgbHFk3DCKjLQlZcy0tJxUH4NwZjRrPPHXAYIEt2TmJs600Dcgj0Z3fZLZKVPVdGNbQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/sinon": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
+      "integrity": "sha512-M9rtyQxKfcTTdB64rpPSRaTzOvunb+HHPv/3PxvNPrEDnFSny95Pi6/3VoD471ody0ay0IHyzT3BErfcLXj6NA==",
+      "deprecated": "16.1.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "formatio": "1.1.1",
+        "lolex": "1.3.2",
+        "samsam": "1.1.2",
+        "util": ">=0.10.3 <1"
+      },
+      "engines": {
+        "node": ">=0.1.103"
+      }
+    },
+    "node_modules/sinon-chai": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.14.0.tgz",
+      "integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR WTFPL)",
+      "peerDependencies": {
+        "chai": ">=1.9.2 <5",
+        "sinon": "^1.4.0 || ^2.1.0 || ^3.0.0 || ^4.0.0"
+      }
+    },
+    "node_modules/snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon-node/node_modules/define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+      "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/snapdragon/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon/node_modules/is-descriptor": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.8.tgz",
+      "integrity": "sha512-SceYGWXvdqlWa/OnQ5FQuV+NxvNmMRhMw/w9AHkH71hTzveND4BTYgvp16g+oITK47qbOl/3D0bl0iygehWAWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.1",
+        "is-data-descriptor": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/snapdragon/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/snapdragon/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+      "integrity": "sha512-Y8nIfcb1s/7DcobUz1yOO1GSp7gyL+D9zLHDehT7iRESqGSxjJ448Sg7rvfgsRJCnKLdSl11uGf0s9X80cH0/A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "amdefine": ">=0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/source-map-resolve": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+      "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
+    },
+    "node_modules/source-map-url": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
+      "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
+      "deprecated": "See https://github.com/lydell/source-map-url#deprecated",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split-string/node_modules/extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split-string/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha512-72E9+uLc27Mt718pMHt9VMNiAL4LMsmDbBva8mxWUCkT07fSzEGMYUCk0XWY6lp0j6RBAG4cJ3mWuZv2OE3s0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/static-extend/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/static-extend/node_modules/is-descriptor": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.8.tgz",
+      "integrity": "sha512-SceYGWXvdqlWa/OnQ5FQuV+NxvNmMRhMw/w9AHkH71hTzveND4BTYgvp16g+oITK47qbOl/3D0bl0iygehWAWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.1",
+        "is-data-descriptor": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/stream-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
+      "integrity": "sha512-e+V5xc4LlkOiRr64kZTUdb11exsbpSnwb9uwmXaHeDXCpfHg7vaefMJOxi21Pe74ZOqjZ87blBcqqpNAM4Ku0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "^1.0.27-1"
+      }
+    },
+    "node_modules/stream-combiner2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
+      "integrity": "sha512-7DO1SfBVnyIyo9ytUjSyVojT5bp1ZY6h3pj7HUs6PwcRSd/r8mBOHbRwYC7nbHRakKzMKyNp5HWJRv4GgVherA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer2": "~0.0.2",
+        "through2": "~0.5.1"
+      }
+    },
+    "node_modules/stream-combiner2/node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/stream-combiner2/node_modules/through2": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+      "integrity": "sha512-zexCrAOTbjkBCXGyozn7hhS3aEaqdrc59mAD2E3dKYzV1vFuEGQ1hEDJN2oQMQFwy4he2zyLqPZV+AlfS8ZWJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~1.0.17",
+        "xtend": "~3.0.0"
+      }
+    },
+    "node_modules/stream-combiner2/node_modules/xtend": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+      "integrity": "sha512-sp/sT9OALMjRW1fKDlPeuSZlDQpkqReA0pyJukniWbTGoEKefHxhGJynE3PNhUMlcM8qWIjPwecwCw4LArS5Eg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/stream-http": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.2.0.tgz",
+      "integrity": "sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "xtend": "^4.0.2"
+      }
+    },
+    "node_modules/stream-http/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/stream-http/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/stream-splicer": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
+      "integrity": "sha512-nmUMEbdm/sZYqe9dZs7mqJvTYpunsDbIWI5FiBCMc/hMVd6vwzy+ITmo7C3gcLYqrn+uQ1w+EJwooWvJ997JAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indexof": "0.0.1",
+        "inherits": "^2.0.1",
+        "isarray": "~0.0.1",
+        "readable-stream": "^1.1.13-1",
+        "readable-wrap": "^1.0.0",
+        "through2": "^1.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha512-AOPG8EBc5wAikaG1/7uFCNFJwnKOuQwFTpYBdTW6OvWHeZBQBrAA/amefHGrEiOnCPcLFZK6FUPtWVKpQVIRgg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "strip-json-comments": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/subarg": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+      "integrity": "sha512-RIrIdRY0X1xojthNcVtgT9sjpOGagEUKpZdgBUi054OEPFo282yg+zE+t1Rj3+RqKq2xStL7uUHhY+AjbC4BXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.1.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/syntax-error": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
+      "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn-node": "^1.2.0"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/through2": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+      "integrity": "sha512-zEbpaeSMHxczpTzO1KkMHjBC1enTA68ojeaZGG4toqdASpb9t4xUZaYFBq2/9OHo5nTGFVSYd4c910OR+6wxbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": ">=1.1.13-1 <1.2.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      }
+    },
+    "node_modules/timers-browserify": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+      "integrity": "sha512-PIxwAupJZiYU4JmVZYwXp9FKsHMXb5h0ZEFyuXTAn8WLHOlcij+FEcbrvDsom1o5dr1YggEtFbECvGCW2sT53Q==",
+      "dev": true,
+      "dependencies": {
+        "process": "~0.11.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/tiny-lr-fork": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/tiny-lr-fork/-/tiny-lr-fork-0.0.5.tgz",
+      "integrity": "sha512-vhcvny/8f46rrViKV0BOUjVl4c/rDTztnT1+kT7iyD/Igqb/uyiRsKLxMc2Z8CNvTE1Px1tuNrPM+BOUL+3vlQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "~0.7.0",
+        "faye-websocket": "~0.4.3",
+        "noptify": "~0.0.3",
+        "qs": "~0.5.2"
+      },
+      "bin": {
+        "tiny-lr-fork": "bin/tiny-lr"
+      }
+    },
+    "node_modules/tiny-lr-fork/node_modules/debug": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+      "integrity": "sha512-EohAb3+DSHSGx8carOSKJe8G0ayV5/i609OD0J2orCkuyae7SyZSz2aoLmQF2s0Pj5gITDebwPH7GFBlqOUQ1Q==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.23.tgz",
+      "integrity": "sha512-zR0TtNGw3OoChmmzHNnMVh6LRY7fCkxXnHOEI9/CZE5zn6TzZbyMknZdmQZzD0EhcQVT/9rZHeg1KqiqfAC5jw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/to-buffer/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/to-regex/node_modules/extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/to-regex/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tty-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
+      "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/type-detect": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+      "integrity": "sha512-5rqszGVwYgBoDkIm2oUtvkfZMQ0vk29iDMU0W2qCa3rG0vPDNczCMT4hV/bLBgLg8k8ri6+u3Zbt+S/14eMzlA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.7.tgz",
+      "integrity": "sha512-ueeb9YybpjhivjbHP2LdFDAjbS948fGEPj+ACAMs4xCMmh72OCOMQWBQKlaN4ZNQ04yfLSDLSx1tGRIoWimObQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "2.4.24",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
+      "integrity": "sha512-tktIjwackfZLd893KGJmXc1hrRHH1vH9Po3xFh1XBjjeGAnN02xJ3SuoA+n1L29/ZaCA18KzCFlckS+vfPugiA==",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "async": "~0.2.6",
+        "source-map": "0.1.34",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.5.4"
+      },
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/uglify-js/node_modules/async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ==",
+      "dev": true
+    },
+    "node_modules/uglify-js/node_modules/source-map": {
+      "version": "0.1.34",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+      "integrity": "sha512-yfCwDj0vR9RTwt3pEzglgb3ZgmcXHt6DjG3bjJvzPwTL+5zDQ2MhmSzAcTy0GTiQuCiriSWXvWM1/NhKdXuoQA==",
+      "dev": true,
+      "dependencies": {
+        "amdefine": ">=0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha512-vb2s1lYx2xBtUgy+ta+b2J/GLVUR+wmpINwHePmPRhOsIVCG2wDzKJ0n14GslH1BifsqVzSOwQhRaCAsZ/nI4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/umd": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.3.tgz",
+      "integrity": "sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "umd": "bin/cli.js"
+      }
+    },
+    "node_modules/undeclared-identifiers": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/undeclared-identifiers/-/undeclared-identifiers-1.1.3.tgz",
+      "integrity": "sha512-pJOW4nxjlmfwKApE4zvxLScM/njmwj/DiUBv7EabwE4O8kRUy+HIwxQtZLBPll/jx1LJyBcqNfB3/cpv9EZwOw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn-node": "^1.3.0",
+        "dash-ast": "^1.0.0",
+        "get-assigned-identifiers": "^1.2.0",
+        "simple-concat": "^1.0.0",
+        "xtend": "^4.0.1"
+      },
+      "bin": {
+        "undeclared-identifiers": "bin.js"
+      }
+    },
+    "node_modules/underscore": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "integrity": "sha512-cp0oQQyZhUM1kpJDLdGO1jPZHgS/MpzoWYfe9+CM2h/QGDZlqwT2T3YGukuBdaNJ/CAPoeyAZRRHz8JFo176vA==",
+      "dev": true
+    },
+    "node_modules/underscore.string": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+      "integrity": "sha512-3FVmhXqelrj6gfgp3Bn6tOavJvW0dNH2T+heTD38JRxIrAbiuzbqjknszoOYj3DyFB1nWiLj208Qt2no/L4cIA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/union-value": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha512-PcA2tsuGSF9cnySLHTLSh2qrQiJ70mn+r+Glzxv2TWZblxsxCC52BDlZoPCsz7STd9pN7EZetkWZBAvk4cgZdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unset-value/node_modules/has-value": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+      "integrity": "sha512-gpG936j8/MzaeID5Yif+577c17TxaDmhuyVgSwtnL/q8UUTySg8Mecb+8Cf1otgLoD7DDH75axp86ER7LFsf3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-value": "^2.0.3",
+        "has-values": "^0.1.4",
+        "isobject": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unset-value/node_modules/has-value/node_modules/isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unset-value/node_modules/has-values": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+      "integrity": "sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unset-value/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/upath": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "yarn": "*"
+      }
+    },
+    "node_modules/urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==",
+      "deprecated": "Please see https://github.com/lydell/urix#deprecated",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "node_modules/url/node_modules/punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/use": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "2.0.3"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/util/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/vm-browserify": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "integrity": "sha512-NyZNR3WDah+NPkjh/YmhuWSsT4a0mF0BJYgUmvrJ70zxjTXh5Y2Asobxlh0Nfs0PCFB5FVpRJft7NozAWFMwLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indexof": "0.0.1"
+      }
+    },
+    "node_modules/watchify": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/watchify/-/watchify-3.11.1.tgz",
+      "integrity": "sha512-WwnUClyFNRMB2NIiHgJU9RQPQNqVeFk7OmZaWf5dC5EnNa0Mgr7imBydbaJ7tGTuPM2hz1Cb4uiBvK9NVxMfog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "^2.0.0",
+        "browserify": "^16.1.0",
+        "chokidar": "^2.1.1",
+        "defined": "^1.0.0",
+        "outpipe": "^1.1.0",
+        "through2": "^2.0.0",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "watchify": "bin/cmd.js"
+      }
+    },
+    "node_modules/watchify/node_modules/assert": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.1.tgz",
+      "integrity": "sha512-zzw1uCAgLbsKwBfFc8CX78DDg+xZeBksSO3vwVIDDN5i94eOrPsSSyiVhmsSABFDM/OcpE2aagCat9dnWQLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object.assign": "^4.1.4",
+        "util": "^0.10.4"
+      }
+    },
+    "node_modules/watchify/node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/watchify/node_modules/browser-pack": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.1.0.tgz",
+      "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "combine-source-map": "~0.8.0",
+        "defined": "^1.0.0",
+        "JSONStream": "^1.0.3",
+        "safe-buffer": "^5.1.1",
+        "through2": "^2.0.0",
+        "umd": "^3.0.0"
+      },
+      "bin": {
+        "browser-pack": "bin/cmd.js"
+      }
+    },
+    "node_modules/watchify/node_modules/browser-resolve": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-2.0.0.tgz",
+      "integrity": "sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve": "^1.17.0"
+      }
+    },
+    "node_modules/watchify/node_modules/browserify": {
+      "version": "16.5.2",
+      "resolved": "https://registry.npmjs.org/browserify/-/browserify-16.5.2.tgz",
+      "integrity": "sha512-TkOR1cQGdmXU9zW4YukWzWVSJwrxmNdADFbqbE3HFgQWe5wqZmOawqZ7J/8MPCwk/W8yY7Y0h+7mOtcZxLP23g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert": "^1.4.0",
+        "browser-pack": "^6.0.1",
+        "browser-resolve": "^2.0.0",
+        "browserify-zlib": "~0.2.0",
+        "buffer": "~5.2.1",
+        "cached-path-relative": "^1.0.0",
+        "concat-stream": "^1.6.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "~1.0.0",
+        "crypto-browserify": "^3.0.0",
+        "defined": "^1.0.0",
+        "deps-sort": "^2.0.0",
+        "domain-browser": "^1.2.0",
+        "duplexer2": "~0.1.2",
+        "events": "^2.0.0",
+        "glob": "^7.1.0",
+        "has": "^1.0.0",
+        "htmlescape": "^1.1.0",
+        "https-browserify": "^1.0.0",
+        "inherits": "~2.0.1",
+        "insert-module-globals": "^7.0.0",
+        "JSONStream": "^1.0.3",
+        "labeled-stream-splicer": "^2.0.0",
+        "mkdirp-classic": "^0.5.2",
+        "module-deps": "^6.2.3",
+        "os-browserify": "~0.3.0",
+        "parents": "^1.0.1",
+        "path-browserify": "~0.0.0",
+        "process": "~0.11.0",
+        "punycode": "^1.3.2",
+        "querystring-es3": "~0.2.0",
+        "read-only-stream": "^2.0.0",
+        "readable-stream": "^2.0.2",
+        "resolve": "^1.1.4",
+        "shasum": "^1.0.0",
+        "shell-quote": "^1.6.1",
+        "stream-browserify": "^2.0.0",
+        "stream-http": "^3.0.0",
+        "string_decoder": "^1.1.1",
+        "subarg": "^1.0.0",
+        "syntax-error": "^1.1.1",
+        "through2": "^2.0.0",
+        "timers-browserify": "^1.0.1",
+        "tty-browserify": "0.0.1",
+        "url": "~0.11.0",
+        "util": "~0.10.1",
+        "vm-browserify": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "browserify": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/watchify/node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
+      }
+    },
+    "node_modules/watchify/node_modules/buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+      "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      }
+    },
+    "node_modules/watchify/node_modules/combine-source-map": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz",
+      "integrity": "sha512-UlxQ9Vw0b/Bt/KYwCFqdEwsQ1eL8d1gibiFb7lxQJFdvTgc2hIZi6ugsg+kyhzhPV+QEpUiEIwInIAIrgoEkrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "convert-source-map": "~1.1.0",
+        "inline-source-map": "~0.6.0",
+        "lodash.memoize": "~3.0.3",
+        "source-map": "~0.5.3"
+      }
+    },
+    "node_modules/watchify/node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/watchify/node_modules/constants-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "integrity": "sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/watchify/node_modules/convert-source-map": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+      "integrity": "sha512-Y8L5rp6jo+g9VEPgvqNfEopjTR4OTYct8lXlS8iVQdmnjDvbdbzYe9rjtFCB9egC86JoNCU61WRY+ScjkZpnIg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/watchify/node_modules/deps-sort": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.1.tgz",
+      "integrity": "sha512-1orqXQr5po+3KI6kQb9A4jnXT1PBwggGl2d7Sq2xsnOeI9GPcE/tGcF9UiSZtZBM7MukY4cAh7MemS6tZYipfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "JSONStream": "^1.0.3",
+        "shasum-object": "^1.0.0",
+        "subarg": "^1.0.0",
+        "through2": "^2.0.0"
+      },
+      "bin": {
+        "deps-sort": "bin/cmd.js"
+      }
+    },
+    "node_modules/watchify/node_modules/detective": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-5.2.1.tgz",
+      "integrity": "sha512-v9XE1zRnz1wRtgurGu0Bs8uHKFSTdteYZNbIPFVhUZ39L/S79ppMpdmVOZAnoz1jfEFodc48n6MX483Xo3t1yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn-node": "^1.8.2",
+        "defined": "^1.0.0",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "detective": "bin/detective.js"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/watchify/node_modules/domain-browser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4",
+        "npm": ">=1.2"
+      }
+    },
+    "node_modules/watchify/node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/watchify/node_modules/events": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-2.1.0.tgz",
+      "integrity": "sha512-3Zmiobend8P9DjmKAty0Era4jV8oJ0yGYe2nJJAxgymF9+N8F2m0hhZiMoWtcfepExzNKZumFU3ksdQbInGWCg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/watchify/node_modules/https-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+      "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/watchify/node_modules/inline-source-map": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.3.tgz",
+      "integrity": "sha512-1aVsPEsJWMJq/pdMU61CDlm1URcW702MTB4w9/zUjMus6H/Py8o7g68Pr9D4I6QluWGt/KdmswuRhaA05xVR1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "~0.5.3"
+      }
+    },
+    "node_modules/watchify/node_modules/insert-module-globals": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.2.1.tgz",
+      "integrity": "sha512-ufS5Qq9RZN+Bu899eA9QCAYThY+gGW7oRkmb0vC93Vlyu/CFGcH0OYPEjVkDXA5FEbTt1+VWzdoOD3Ny9N+8tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn-node": "^1.5.2",
+        "combine-source-map": "^0.8.0",
+        "concat-stream": "^1.6.1",
+        "is-buffer": "^1.1.0",
+        "JSONStream": "^1.0.3",
+        "path-is-absolute": "^1.0.1",
+        "process": "~0.11.0",
+        "through2": "^2.0.0",
+        "undeclared-identifiers": "^1.1.2",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "insert-module-globals": "bin/cmd.js"
+      }
+    },
+    "node_modules/watchify/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/watchify/node_modules/labeled-stream-splicer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.2.tgz",
+      "integrity": "sha512-Ca4LSXFFZUjPScRaqOcFxneA0VpKZr4MMYCljyQr4LIewTLb3Y0IUTIsnBBsVubIeEfxeSZpSjSsRM8APEQaAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "stream-splicer": "^2.0.0"
+      }
+    },
+    "node_modules/watchify/node_modules/module-deps": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-6.2.3.tgz",
+      "integrity": "sha512-fg7OZaQBcL4/L+AK5f4iVqf9OMbCclXfy/znXRxTVhJSeW5AIlS9AwheYwDaXM3lVW7OBeaeUEY3gbaC6cLlSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browser-resolve": "^2.0.0",
+        "cached-path-relative": "^1.0.2",
+        "concat-stream": "~1.6.0",
+        "defined": "^1.0.0",
+        "detective": "^5.2.0",
+        "duplexer2": "^0.1.2",
+        "inherits": "^2.0.1",
+        "JSONStream": "^1.0.3",
+        "parents": "^1.0.0",
+        "readable-stream": "^2.0.2",
+        "resolve": "^1.4.0",
+        "stream-combiner2": "^1.1.1",
+        "subarg": "^1.0.0",
+        "through2": "^2.0.0",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "module-deps": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/watchify/node_modules/os-browserify": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+      "integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/watchify/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/watchify/node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/watchify/node_modules/read-only-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
+      "integrity": "sha512-3ALe0bjBVZtkdWKIcThYpQCLbBMd/+Tbh2CDSrAIDO3UsZ4Xs+tnyjv2MjCOMMgBG+AsUOeuP1cgtY1INISc8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/watchify/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/watchify/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/watchify/node_modules/readable-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/watchify/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/watchify/node_modules/shell-quote": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/watchify/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/watchify/node_modules/stream-browserify": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
+      "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/watchify/node_modules/stream-combiner2": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+      "integrity": "sha512-3PnJbYgS56AeWgtKF5jtJRT6uFJe56Z0Hc5Ngg/6sI6rIt8iiMBTa9cvdyFfpMQjaVHr8dusbNeFGIIonxOvKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer2": "~0.1.0",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/watchify/node_modules/stream-splicer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.1.tgz",
+      "integrity": "sha512-Xizh4/NPuYSyAXyT7g8IvdJ9HJpxIGL9PjyhtywCZvvP0OPIdqyrr4dMikeuvY8xahpdKEBlBTySe583totajg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/watchify/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/watchify/node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/watchify/node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/watchify/node_modules/url": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
+      "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^1.4.1",
+        "qs": "^6.12.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/watchify/node_modules/vm-browserify": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+      "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+      "integrity": "sha512-E87fdQ/eRJr9W1X4wTPejNy9zTW3FI2vpCZSJ/HAY+TkjKVC0TUm1jk6vn2Z7qay0DQy0+RBGdXxj+RmmiGZKQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha512-1pTPQDKTdd61ozlKGNCjhNRd+KPmgLSGa3mZTHoOliaGcESD8G1PXhh7c1fgiPjVbNVfgy2Faw4BI8/m0cC8Mg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+      "integrity": "sha512-5j382E4xQSs71p/xZQsU1PtRA2HXPAjX0E0DkoGLxwNASMOKX6A9doV1NrZmj85u2Pjquz402qonBzz/yLPbPA==",
+      "dev": true,
+      "license": "MIT/X11",
+      "dependencies": {
+        "camelcase": "^1.0.2",
+        "decamelize": "^1.0.0",
+        "window-size": "0.1.0",
+        "wordwrap": "0.0.2"
+      }
+    },
+    "node_modules/yargs/node_modules/wordwrap": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+      "integrity": "sha512-xSBsCeh+g+dinoBv3GAOWM4LcVVO68wLXRanibtBSdUvkGWQRGeE9P7IwU9EmDDi4jA6L44lz15CGMwdw9N5+Q==",
+      "dev": true,
+      "license": "MIT/X11",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    }
+  }
+}

--- a/omega-web/package-lock.json
+++ b/omega-web/package-lock.json
@@ -1,0 +1,3094 @@
+{
+  "name": "omega-web",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "omega-web",
+      "version": "0.0.1",
+      "devDependencies": {
+        "chai": "~1.9.1",
+        "coffeelint": "^1.16.0",
+        "grunt": "^0.4.5",
+        "grunt-autoprefixer": "^1.0.1",
+        "grunt-bower-task": "^0.5.0",
+        "grunt-coffeelint": "^0.0.13",
+        "grunt-contrib-coffee": "^0.11.1",
+        "grunt-contrib-concat": "^0.5.0",
+        "grunt-contrib-copy": "^0.5.0",
+        "grunt-contrib-jade": "^0.12.0",
+        "grunt-contrib-less": "^0.11.4",
+        "grunt-contrib-watch": "^0.6.1",
+        "grunt-mocha-test": "~0.11.0",
+        "grunt-ng-annotate": "^0.3.2",
+        "load-grunt-config": "^0.13.1",
+        "omega-pac": "../omega-pac"
+      }
+    },
+    "../omega-pac": {
+      "version": "0.0.1",
+      "dev": true,
+      "dependencies": {
+        "ip-address": "^4.0.0",
+        "tldjs": "^1.5.2",
+        "uglify-js": "^2.4.15"
+      },
+      "devDependencies": {
+        "chai": "~1.9.1",
+        "coffee-script": "^1.7.1",
+        "coffeeify": "^0.7.0",
+        "coffeelint": "^1.16.0",
+        "grunt": "^0.4.5",
+        "grunt-browserify": "^3.0.0",
+        "grunt-coffeelint": "^0.0.13",
+        "grunt-contrib-coffee": "^0.11.1",
+        "grunt-contrib-watch": "^0.6.1",
+        "grunt-mocha-test": "~0.11.0",
+        "load-grunt-config": "^0.13.1",
+        "lolex": "^1.4.0",
+        "minifyify": "^4.1.1"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/alter": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
+      "integrity": "sha512-Wuss6JIZ6h4j2+NgU2t+9mSwS7gBSZJbU4Dg8xETguAD2veJUSuCrvTIiC78QgZE7/zX7h6OnXw2PiiCBirEGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stable": "~0.1.3"
+      }
+    },
+    "node_modules/amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
+      "dev": true,
+      "license": "BSD-3-Clause OR MIT",
+      "engines": {
+        "node": ">=0.4.2"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+      "integrity": "sha512-sGwIGMjhYdW26/IhwK2gkWWI8DRCVO6uj3hYgHT+zD+QL1pa37tM3ujhyfcJIYSbsxp7Gxhy7zrRW/1AHm4BmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+      "integrity": "sha512-f2PKUkN5QngiSemowa6Mrk9MPCdtFiOSmibjZ+j1qhLGHHYsqZwmBMRF3IRMVXo8sybDqx2fJl2d/8OphBoWkA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+      "integrity": "sha512-LjmC2dNpdn2L4UzyoaIr11ELYoLn37ZFy9zObrQFHsSuOepeUEMKnM8w5KL4Tnrp2gy88rRuQt6Ky8Bjml+Baw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "underscore": "~1.7.0",
+        "underscore.string": "~2.4.0"
+      }
+    },
+    "node_modules/argparse/node_modules/underscore.string": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+      "integrity": "sha512-yxkabuCaIBnzfIvX3kBxQqCs0ar/bfJwDnFEHJUm/ZrRVhT3IItdRF5cZjARLzEnyQYtIUhsZ2LG2j3HidFOFQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/asn1": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+      "integrity": "sha512-Fh9zh3G2mZ8qM/kwsiKwL2U2FmXxVsboP4x1mXjnhKHv3SmzaBZoYvxEQJz/YS2gnCgd8xlAVWcZnQyC9qZBsA==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=0.4.9"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+      "integrity": "sha512-brU24g7ryhRwGCI2y+1dGQmQXiZF7TtIj583S96y0jjdajIe6wn8BuXyELYhvD22dtIxDQVFk04YTJwwdwOYJw==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
+      "integrity": "sha512-g/gZV+G476cnmtYI+Ko9d5khxSoCSoom/EaNmmCfwpOvBXEJ18qwFrxfP1/CsIqk2no1sAKKwxndV0tP7ROOFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/async": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+      "integrity": "sha512-2tEzliJmf5fHNafNwQLJXUasGzQCVctvsNkXmnlELHwypU0p08/rHohYvkqKIjyXpx+0rkrYv6QbhJ+UF4QkBg==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/autoprefixer-core": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-3.1.2.tgz",
+      "integrity": "sha512-zXBwCsV9nrVf2evKwUREELXvM0IL7bg9k17EVku57I+nSVKXTyH7IvL4Nqit6wZkrY9b3ca6umNxh9SY5lIsuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "caniuse-db": "^1.0.30000006",
+        "postcss": "~2.2.5"
+      }
+    },
+    "node_modules/aws-sign2": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+      "integrity": "sha512-oqUX0DM5j7aPWPCnpWebiyNIj2wiNI87ZxnOMoGv0aE4TGlBy2N+5iWc6dQ/NOKZaBD2W6PVz8jtOGkWzSC5EA==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/boom": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+      "integrity": "sha512-OvfN8y1oAxxphzkl2SnCS+ztV/uVKTATtgLjWYg/7KwcNyf3rzpHxNQJZCKtsZd4+MteKczhWbSjtEX4bGgU9g==",
+      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "hoek": "0.9.x"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/bower": {
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.14.tgz",
+      "integrity": "sha512-8Rq058FD91q9Nwthyhw0la9fzpBz0iwZTrt51LWl+w+PnJgZk9J+5wp3nibsJcIUPglMYXr4NRBaR+TUj0OkBQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "bower": "bin/bower"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/bower-json": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/bower-json/-/bower-json-0.8.4.tgz",
+      "integrity": "sha512-mMKghvq9ivbuzSsY5nrOLnDtZIJMUCpysqbGaGW3mj88JAcuSi8ZAzIt34vNZjohy0aR9VXLwgPTZGnBX2Vpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-extend": "^0.5.1",
+        "ends-with": "^0.2.0",
+        "ext-list": "^2.0.0",
+        "graceful-fs": "^4.1.3",
+        "intersect": "^1.0.1",
+        "sort-keys-length": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/camelcase": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha512-wzLkDa4K/mzI1OSITC+DUyjgIl/ETNHE9QvYgy6J6Jvqyyz4C0Xfd+lQhb19sX2jMpZV4IssUn0VDVmglV+s4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/caniuse-db": {
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001809.tgz",
+      "integrity": "sha512-KhbnKGfn5NxLmqvmGQGTYjMEyoT0hlma+U+0A09p3s70YAqLZVSgmFogrZkO8r6SMiZyjzshJzm1iTRb5RLGZA==",
+      "dev": true,
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-1.9.2.tgz",
+      "integrity": "sha512-olRoaitftnzWHFEAza6MXR4w+FfZrOVyV7r7U/Z8ObJefCgL8IuWkAuASJjSXrpP9wvgoL8+1dB9RbMLc2FkNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "1.0.0",
+        "deep-eql": "0.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+      "integrity": "sha512-bIKA54hP8iZhyDT81TOsJiQvR1gW+ZYSXFaZUAvoD4wCHdbHY2actmpTE4x344ZlFqHbvoxKOaESULTZN2gstg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^1.1.0",
+        "escape-string-regexp": "^1.0.0",
+        "has-ansi": "^0.1.0",
+        "strip-ansi": "^0.3.0",
+        "supports-color": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/character-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.2.0.tgz",
+      "integrity": "sha512-FtpaoJWMk2JsI8h/Qhc5cLQMMT8cbqxDJ/vP2t5a1TcjnSPHGj0dcovj5H6lR5gzMAgJbe5dlIfbx1rGufvHgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/clean-css": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-2.2.23.tgz",
+      "integrity": "sha512-4Ft5U6dNFqr++uztZJzaGXLTTI1aGYgOVAvGAwjp1eOPd4jT6HKjYE2CJ6qnAWZ3/H/U77iFeCZyhhBmOUaU1w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "commander": "2.2.x"
+      },
+      "bin": {
+        "cleancss": "bin/cleancss"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/clean-css/node_modules/commander": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.2.0.tgz",
+      "integrity": "sha512-U6hBkeIsoeE81B+yas9uVF4YYVcVoBCwb1e314VPyvVQubFwvnTAuc1oUQ6VuMPYUS4Rf1gzr0wTVLvs4sb5Pw==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.x"
+      }
+    },
+    "node_modules/coffee-script": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.11.1.tgz",
+      "integrity": "sha512-NIWm59Fh1zkXq6TS6PQvSO3AR9DbGq1IBNZHa1E3fUCNmJhIwLf1YKcWgaHqaU7zWGC/OE2V7K3GVAXFzcmu+A==",
+      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/coffeelint": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/coffeelint/-/coffeelint-1.16.2.tgz",
+      "integrity": "sha512-6mzgOo4zb17WfdrSui/cSUEgQ0AQkW3gXDht+6lHkfkqGUtSYKwGdGcXsDfAyuScVzTlTtKdfwkAlJWfqul7zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "coffee-script": "~1.11.0",
+        "glob": "^7.0.6",
+        "ignore": "^3.0.9",
+        "optimist": "^0.6.1",
+        "resolve": "^0.6.3",
+        "strip-json-comments": "^1.0.2"
+      },
+      "bin": {
+        "coffeelint": "bin/coffeelint"
+      },
+      "engines": {
+        "node": ">=0.8.0",
+        "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/coffeelint-stylish": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/coffeelint-stylish/-/coffeelint-stylish-0.1.2.tgz",
+      "integrity": "sha512-VcuzfB0bC9lvdvwckLzh3njKce68VVmOOXp0igyNl50D/uRLbFb4HSjQtTNGFEYiQ9Z0hjhfTqKe4v8UQxnngA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^1.0.0",
+        "text-table": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0",
+        "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/coffeelint-stylish/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/coffeelint-stylish/node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/coffeelint-stylish/node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/coffeelint-stylish/node_modules/has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/coffeelint-stylish/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/coffeelint-stylish/node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/colors": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+      "integrity": "sha512-OsSVtHK8Ir8r3+Fxw/b4jS1ZLPXkV6ZxDRJQzeD7qo0SqMXWrHDM71DgYzPMHY8SFJ0Ao+nNU2p1MmwdzKqPrw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+      "integrity": "sha512-qfexlmLp9MyrkajQVyjEDb0Vj+KhRgR/rxLiVhaihlT+ZkX0lReqtH6Ack40CvMDERR4b5eFp3CreskpBs1Pig==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "delayed-stream": "0.0.5"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+      "integrity": "sha512-J2wnb6TKniXNOtoHS8TSrG9IOQluPrsmyAJ8oCUJOBmv+uLBCyPYAZkD2jFvw2DCzIXNnISIM01NIvr35TkBMQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.x"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/constantinople": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-2.0.1.tgz",
+      "integrity": "sha512-ZF+ejGc/Gu8ucEaiTOgbptlCxKnzHtUaS7rwB/ZYjnoCZxZyuu82V6zQB/Ax/CS/rp/x2FI/x8gQxrtC4ekxlw==",
+      "deprecated": "Please update to at least constantinople 3.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uglify-js": "~2.4.0"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.4.1.tgz",
+      "integrity": "sha512-yFU/yTFbnlUH0wnu33o7hZwbcGmmnKw2uLAxLPnWW8zh+o7+xq7LmB4DMqKo5IniPcRs6quLHZ/A5ogSYhU1qw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cryptiles": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+      "integrity": "sha512-gvWSbgqP+569DdslUiCelxIv3IYK5Lgmq1UrRnk+s1WxQOQ16j3GPDcjdtgL5Au65DU/xQi6q3xPtf5Kta+3IQ==",
+      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "boom": "0.4.x"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/css": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
+      "integrity": "sha512-qmTYWhHk910nQWnGqMAiWWPQlB6tESiWgNebQJmiozOAGcBAQ1+U/UzUOkhdrcshlkSRRiKWodwmVvO0OmnIGg==",
+      "dev": true,
+      "dependencies": {
+        "css-parse": "1.0.4",
+        "css-stringify": "1.0.5"
+      }
+    },
+    "node_modules/css-parse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.0.4.tgz",
+      "integrity": "sha512-pfstzKVRZiHprDXdsmtfH1HYUEw22lzjuHdnpe1hscwoQvgW2C5zDQIBE0RKoALEReTn9W1ECdY8uaT/kO4VfA==",
+      "dev": true
+    },
+    "node_modules/css-stringify": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz",
+      "integrity": "sha512-aIThpcErhG5EyHorGqNlTh0TduNBqLrrXLO3x5rku3ZKBxuVfY+T7noyM2G2X/01iQANqJUb6d3+FLoa+N7Xwg==",
+      "dev": true
+    },
+    "node_modules/ctype": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+      "integrity": "sha512-T6CEkoSV4q50zW3TlTHMbzy1E5+zlnNcY+yb7tWVYlTwPhx9LpnfAkd4wecpWknDyptp4k97LUZeInlf6jdzBg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/dateformat": {
+      "version": "1.0.2-1.2.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+      "integrity": "sha512-AXvW8g7tO4ilk5HgOWeDmPi/ZPaCnMJ+9Cg1I3p19w6mcvAAXBuuGEXAxybC+Djj1PSZUiHUcyoYu7WneCX8gQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha512-6sEotTRGBFiNcqVoeHwnfopbSpi5NbH1VWJmYCVkmxMmaVTT0bUTrNaGyBwhgP4MZL012W/mkzIn3Da+iDYweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "0.1.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/deep-equal": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz",
+      "integrity": "sha512-p1bI/kkDPT6auUI0U+WLuIIrzmDIDo80I406J8tT4y6I4ZGtBuMeTudrKDtBdMJFAcxqrQdx27gosqPVyY3IvQ==",
+      "dev": true,
+      "license": "MIT/X11",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+      "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/defined": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
+      "integrity": "sha512-zpqiCT8bODLu3QSmLLic8xJnYWBFjOSu/fBCm189oAiTtPq/PSanNACKZDS7kgSyCJY7P+IcODzlIogBK/9RBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+      "integrity": "sha512-v+7uBd1pqe5YtgPacIIbZ8HuHeLFVNe4mUEyFDXL6KiqzEykjbw+5mXZXpGFgNVasdL4jWKgaKIXrEHiynN1LA==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/diff": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
+      "integrity": "sha512-1zEb73vemXFpUmfh3fsta4YHz3lwebxXvaWmPbFv9apujQBWDnkrPDLXLQs1gZo4RCWMDsT89r0Pf/z8/02TGA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/ends-with": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ends-with/-/ends-with-0.2.0.tgz",
+      "integrity": "sha512-lRppY4dK3VkqBdR242sKcAJeYc8Gf/DhoX9AWvWI2RzccmLnqBQfwm2k4oSDv5MPDjUqawCauXhZkyWxkVhRsg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+      "integrity": "sha512-rp5dMKN8zEs9dfi9g0X1ClLmV//WRyk/R15mppFNICIFRG5P92VP7Z04p8pk++gABo9W2tY+kHyu6P1mEHgmTA==",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/eventemitter2": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "integrity": "sha512-K7J4xq5xAD5jHsGM5ReWXRTFa3JRGofHiMcVgQ8PRwgWxzjHpMWCIzsmyf60+mh8KLsqYPcjUMa0AC4hd6lPyQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/ext-list": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
+      "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.28.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/faye-websocket": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz",
+      "integrity": "sha512-78pqrJbvGZSe8i+PLsPd+aJqTyGqgyWLnMw5NOwtXCTVMzEFh1zQPwIuIL/ycTj4rkDy5zZ9B6frYPqVPJBzyQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/findup-sync": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+      "integrity": "sha512-yjftfYnF4ThYEvKEV/kEFR15dmtyXTAh3vQnzpJUoc7Naj5y1P0Ck7Zs1+Vroa00E3KT3IYsk756S+8WA5dNLw==",
+      "dev": true,
+      "dependencies": {
+        "glob": "~3.2.9",
+        "lodash": "~2.4.1"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha512-hVb0zwEZwC1FXSKRPFTeOtN7AArJcJlI6ULGLtrstaswKNlrTJqAA+1lYlSUop4vjA423xlBzqfVS3iWGlqJ+g==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "inherits": "2",
+        "minimatch": "0.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/findup-sync/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/findup-sync/node_modules/minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha512-WFX1jI1AaxNTZVOHLBVazwTWKaQjoykSzCBNXB72vDTCzopQGtyP91tKdFK5cv1+qMwPyiTu1HqUriqplI8pcA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/forever-agent": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+      "integrity": "sha512-PDG5Ef0Dob/JsZUxUltJOhm/Y9mlteAE+46y3M9RBz/Rd3QVENJ75aGRhN56yekTUboaBIkd8KVWX2NjF6+91A==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+      "integrity": "sha512-x8eE+nzFtAMA0YYlSxf/Qhq6vP1f8wSoZ7Aw1GuctBcmudCNuTUmmx45TfEplyb6cjsZO/jvh6+1VpZn24ez+w==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "async": "~0.9.0",
+        "combined-stream": "~0.0.4",
+        "mime": "~1.2.11"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/form-data/node_modules/async": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+      "integrity": "sha512-l6ToIJIotphWahxxHyzK9bnLR6kM4jJIIgLShZeqLY7iboHoGkdgFl7W2/Ivi4SkMJYGKqW8vSuk0uKUj6qsSw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fs-extra": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
+      "integrity": "sha512-9ztMtDZtSKC78V8mev+k31qaTabbmuH5jatdvPBMikrFHvw5BqlYnQIn/WGK3WHeRooSTkRvLa2IPlaHjPq5Sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/gaze": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
+      "integrity": "sha512-3IWbXGkDDHFX8zIlNdfnmhvlSMhpBO6tDr4InB8fGku6dh/gjFPGNqcdsXJajZg05x9jRzXbL6gCnCnuMap4tw==",
+      "dev": true,
+      "dependencies": {
+        "globule": "~0.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/getobject": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+      "integrity": "sha512-hIGEBfnHcZpWkXPsAVeVmpYDvfy/matVl03yOY91FPmnpCC12Lm5izNxCjO3lHAeO6uaTwMxu7g450Siknlhig==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/globule": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+      "integrity": "sha512-3eIcA2OjPCm4VvwIwZPzIxCVssA8HSpM2C6c6kK5ufJH4FGwWoyqL3In19uuX4oe+TwH3w2P1nQDmW56iehO4A==",
+      "dev": true,
+      "dependencies": {
+        "glob": "~3.1.21",
+        "lodash": "~1.0.1",
+        "minimatch": "~0.2.11"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/globule/node_modules/glob": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+      "integrity": "sha512-ANhy2V2+tFpRajE3wN4DhkNQ08KDr0Ir1qL12/cUe5+a7STEK8jkW4onUYuY8/06qAFuT5je7mjAqzx0eKI2tQ==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "graceful-fs": "~1.2.0",
+        "inherits": "1",
+        "minimatch": "~0.2.11"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/globule/node_modules/graceful-fs": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+      "integrity": "sha512-iiTUZ5vZ+2ZV+h71XAgwCSu6+NAizhFU3Yw8aC/hH5SQ3SnISqEqAek40imAFGtDcwJKNhXvSY+hzIolnLwcdQ==",
+      "deprecated": "please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js",
+      "dev": true,
+      "license": "BSD",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/globule/node_modules/inherits": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+      "integrity": "sha512-Al67oatbRSo3RV5hRqIoln6Y5yMVbJSIn4jEJNL7VCImzq/kLr7vvb6sFRJXqr8rpHc/2kJOM+y0sPKN47VdzA==",
+      "dev": true
+    },
+    "node_modules/globule/node_modules/lodash": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+      "integrity": "sha512-0VSEDVec/Me2eATuoiQd8IjyBMMX0fahob8YJ96V1go2RjvCk1m1GxmtfXn8RNSaLaTtop7fsuhhu9oLk3hUgA==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/globule/node_modules/minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha512-zZ+Jy8lVWlvqqeM8iZB7w7KmQkoJn8djM585z88rywrEbzoqawVa9FR5p2hwD+y74nfuKOjmNvi9gtWJNLqHvA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/growl": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz",
+      "integrity": "sha512-VWv7s1EI41AG2LiCr7uAuxWikLDN1SQOuEUc37d/P34NAIIYgkvWYngNw0d9d9iCrDFL0SYCE9UQpxhIjjtuLg==",
+      "dev": true
+    },
+    "node_modules/grunt": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+      "integrity": "sha512-1iq3ylLjzXqz/KSq1OAE2qhnpcbkF2WyhsQcavZt+YmgvHu0EbPMEhGhy2gr0FP67isHpRdfwjB5WVeXXcJemQ==",
+      "dev": true,
+      "dependencies": {
+        "async": "~0.1.22",
+        "coffee-script": "~1.3.3",
+        "colors": "~0.6.2",
+        "dateformat": "1.0.2-1.2.3",
+        "eventemitter2": "~0.4.13",
+        "exit": "~0.1.1",
+        "findup-sync": "~0.1.2",
+        "getobject": "~0.1.0",
+        "glob": "~3.1.21",
+        "grunt-legacy-log": "~0.1.0",
+        "grunt-legacy-util": "~0.2.0",
+        "hooker": "~0.2.3",
+        "iconv-lite": "~0.2.11",
+        "js-yaml": "~2.0.5",
+        "lodash": "~0.9.2",
+        "minimatch": "~0.2.12",
+        "nopt": "~1.0.10",
+        "rimraf": "~2.2.8",
+        "underscore.string": "~2.2.1",
+        "which": "~1.0.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/grunt-autoprefixer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/grunt-autoprefixer/-/grunt-autoprefixer-1.0.1.tgz",
+      "integrity": "sha512-6BtJIoL9Qa56YAfxqOxqA8E9ns9skjqIPSec6yt8MNseL+OZVSioL4wU03vjZ0T4GeZKNcQWMbjnr+nl1T2CGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "autoprefixer-core": "^3.0.0",
+        "chalk": "~0.5.0",
+        "diff": "~1.0.8"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "peerDependencies": {
+        "grunt": "~0.4.2"
+      }
+    },
+    "node_modules/grunt-bower-task": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/grunt-bower-task/-/grunt-bower-task-0.5.0.tgz",
+      "integrity": "sha512-n+1rCCqV5Xcz8z9EticRXxADByptbppUfgmV4ekIHWHJnHK5qZ66c/NKDX+AcUVUplq9se0EaWYVxtiPqDjSog==",
+      "dev": true,
+      "dependencies": {
+        "async": "^2.3.0",
+        "bower": "^1.7.9",
+        "bower-json": "^0.8.1",
+        "colors": "^1.1.2",
+        "fs-extra": "^2.1.2",
+        "lodash": "~0.10.0",
+        "rimraf": "^2.6.1"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/grunt-bower-task/node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/grunt-bower-task/node_modules/async/node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/grunt-bower-task/node_modules/colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/grunt-bower-task/node_modules/lodash": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.10.0.tgz",
+      "integrity": "sha512-v56iCcHwqxrkkFW08F6GFAEYjL/E7Exbk2HZKhaZJsogEMSqse9as4Zmx5fmci4ZCQ/UNVoFHGudYzONfGxANQ==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/grunt-bower-task/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/grunt-coffeelint": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/grunt-coffeelint/-/grunt-coffeelint-0.0.13.tgz",
+      "integrity": "sha512-AjoY762pHh703irpowkm45FkrWlDuNAcEo6PdfCMPFClV0+vPeoipeuq/qCSEQmklXtuOpnWrH+lwatrTBzVYg==",
+      "dev": true,
+      "dependencies": {
+        "coffeelint-stylish": "~0.1.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "peerDependencies": {
+        "coffeelint": "^1",
+        "grunt": "~0.4"
+      }
+    },
+    "node_modules/grunt-contrib-coffee": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-coffee/-/grunt-contrib-coffee-0.11.1.tgz",
+      "integrity": "sha512-Gu8BMXbVns+Zfyy4DiGOnYpEd4Ac6YIZzA24FzxLbNQqupxgk6EKk8YibXXd3umn/1KXcrSNGXjDyAJPIAlhHw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "~0.5.0",
+        "coffee-script": "~1.7.0",
+        "lodash": "~2.4.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "peerDependencies": {
+        "grunt": "~0.4.0"
+      }
+    },
+    "node_modules/grunt-contrib-coffee/node_modules/coffee-script": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.7.1.tgz",
+      "integrity": "sha512-W3s+SROY73OmrSGtPTTW/2wp2rmW5vuh0/tUuCK1NvTuyzLOVPccIP9whmhZ4cYWcr2NJPNENZIFaAMkTD5G3w==",
+      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mkdirp": "~0.3.5"
+      },
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/grunt-contrib-coffee/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/grunt-contrib-concat": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-concat/-/grunt-contrib-concat-0.5.1.tgz",
+      "integrity": "sha512-on8j+wGXvo6yVEDjyoUsFU2GeYcpZ9Qhj78XQMeU3yDYSPcHfCeuOo2hV8GAQO9u1JuQFEHgA0O7wFKXO7miqg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^0.5.1",
+        "source-map": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "grunt": ">=0.4.0"
+      }
+    },
+    "node_modules/grunt-contrib-copy": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-0.5.0.tgz",
+      "integrity": "sha512-qJkJqvttTuVV7hXaQ91ctB1Anha0z6pyZuBlz+Trw8O5tFJ5hpB5f3BNxMfSgO7ciSgw36FgAovLg992x3dqKw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "peerDependencies": {
+        "grunt": "~0.4.0"
+      }
+    },
+    "node_modules/grunt-contrib-jade": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-jade/-/grunt-contrib-jade-0.12.0.tgz",
+      "integrity": "sha512-zuPrZZ7+3eX4Im5S8c2hayCwP72SDjgmd1t4GBh/jkm893VPam2Q1edPUzkJu4eXEDSGsP0eav4GvNO7ZBzebg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "~0.4.0",
+        "grunt-lib-contrib": "~0.6.1",
+        "jade": "~1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "peerDependencies": {
+        "grunt": "~0.4.1"
+      }
+    },
+    "node_modules/grunt-contrib-jade/node_modules/ansi-styles": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+      "integrity": "sha512-3iF4FIKdxaVYT3JqQuY3Wat/T2t7TRbbQ94Fu50ZUCbLy4TFbTzr90NOHQodQkNqmeEGCw8WbeP78WNi6SKYUA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/grunt-contrib-jade/node_modules/chalk": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+      "integrity": "sha512-sQfYDlfv2DGVtjdoQqxS0cEZDroyG8h6TamA6rvxwlrU5BaSLDx9xhatBYl2pxZ7gmpNaPFVwBtdGdu5rQ+tYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "~1.0.0",
+        "has-color": "~0.1.0",
+        "strip-ansi": "~0.1.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/grunt-contrib-jade/node_modules/strip-ansi": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+      "integrity": "sha512-behete+3uqxecWlDAm5lmskaSaISA+ThQ4oNNBDTBJt0x2ppR6IPqfZNuj6BLaLJ/Sji4TPZlcRyOis8wXQTLg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "strip-ansi": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/grunt-contrib-less": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-less/-/grunt-contrib-less-0.11.4.tgz",
+      "integrity": "sha512-IOelFvXMPKOzGxdfLD2IK8PCkzEd+LPRpE/y4xPPKAkHOEiE0jkDbbkpzVecQvDJ4os4yPwb0xtgQ90fWmBbag==",
+      "dev": true,
+      "dependencies": {
+        "async": "^0.2.10",
+        "chalk": "^0.5.1",
+        "less": "^1.7.2",
+        "lodash": "^2.4.1",
+        "maxmin": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "grunt": "~0.4.0"
+      }
+    },
+    "node_modules/grunt-contrib-less/node_modules/async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ==",
+      "dev": true
+    },
+    "node_modules/grunt-contrib-less/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/grunt-contrib-watch": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-0.6.1.tgz",
+      "integrity": "sha512-Ea4f3anehA6G+S88vyTwewA/Mf6SbadTIxSgQClKbZYnHOcJ0PrGc2p+uzR6hS9gp7DG6ObvaxkmE8HKnLOsfA==",
+      "dev": true,
+      "dependencies": {
+        "async": "~0.2.9",
+        "gaze": "~0.5.1",
+        "lodash": "~2.4.1",
+        "tiny-lr-fork": "0.0.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "peerDependencies": {
+        "grunt": "~0.4.0"
+      }
+    },
+    "node_modules/grunt-contrib-watch/node_modules/async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ==",
+      "dev": true
+    },
+    "node_modules/grunt-contrib-watch/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/grunt-legacy-log": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
+      "integrity": "sha512-qYs/uM0ImdzwIXLhS4O5WLV5soAM+PEqqHI/hzSxlo450ERSccEhnXqoeDA9ZozOdaWuYnzTOTwRcVRogleMxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colors": "~0.6.2",
+        "grunt-legacy-log-utils": "~0.1.1",
+        "hooker": "~0.2.3",
+        "lodash": "~2.4.1",
+        "underscore.string": "~2.3.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/grunt-legacy-log-utils": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
+      "integrity": "sha512-D0vbUX00TFYCKNZtcZzemMpwT8TR/FdRs1pmfiBw6qnUw80PfsjV+lhIozY/3eJ3PSG2zj89wd2mH/7f4tNAlw==",
+      "dev": true,
+      "dependencies": {
+        "colors": "~0.6.2",
+        "lodash": "~2.4.1",
+        "underscore.string": "~2.3.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/grunt-legacy-log-utils/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/grunt-legacy-log-utils/node_modules/underscore.string": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+      "integrity": "sha512-hbD5MibthuDAu4yA5wxes5bzFgqd3PpBJuClbRxaNddxfdsz+qf+1kHwrGQFrmchmDHb9iNU+6EHDn8uj0xDJg==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/grunt-legacy-log/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/grunt-legacy-log/node_modules/underscore.string": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+      "integrity": "sha512-hbD5MibthuDAu4yA5wxes5bzFgqd3PpBJuClbRxaNddxfdsz+qf+1kHwrGQFrmchmDHb9iNU+6EHDn8uj0xDJg==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/grunt-legacy-util": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+      "integrity": "sha512-cXPbfF8aM+pvveQeN1K872D5fRm30xfJWZiS63Y8W8oyIPLClCsmI8bW96Txqzac9cyL4lRqEBhbhJ3n5EzUUQ==",
+      "dev": true,
+      "dependencies": {
+        "async": "~0.1.22",
+        "exit": "~0.1.1",
+        "getobject": "~0.1.0",
+        "hooker": "~0.2.3",
+        "lodash": "~0.9.2",
+        "underscore.string": "~2.2.1",
+        "which": "~1.0.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/grunt-lib-contrib": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/grunt-lib-contrib/-/grunt-lib-contrib-0.6.1.tgz",
+      "integrity": "sha512-HdCtJuMmmkSAVrAfsG7lZWE0YabrsPWwzcCCUgWQOAaQsQSUNhw/IwD2YjCSLh5y9NXSPzHTYFLL4ro7QbAJMA==",
+      "dev": true,
+      "dependencies": {
+        "zlib-browserify": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/grunt-mocha-test": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/grunt-mocha-test/-/grunt-mocha-test-0.11.0.tgz",
+      "integrity": "sha512-BDffDt8Y724rbeUhSg3GZdhTx918hJ5WoHRdW3uXCIYNxeySoECjkmTiAEf2tHp6GYwW5sMKXk2jTqCU/LbajA==",
+      "dev": true,
+      "dependencies": {
+        "fs-extra": "~0.9.1",
+        "hooker": "~0.2.3",
+        "mocha": "~1.20.0"
+      },
+      "engines": {
+        "node": ">= 0.10.4"
+      }
+    },
+    "node_modules/grunt-mocha-test/node_modules/fs-extra": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.9.1.tgz",
+      "integrity": "sha512-yctbTOCHGDktj3eorstAjY0Z8WtbzoHlKKiUZRbX25b34BnuIGsdI9HG2dYO72kimROUPRgJhdSxlBRhDtEZqw==",
+      "dev": true,
+      "dependencies": {
+        "jsonfile": "~1.1.0",
+        "mkdirp": "^0.5.0",
+        "ncp": "^0.5.1",
+        "rimraf": "^2.2.8"
+      }
+    },
+    "node_modules/grunt-mocha-test/node_modules/jsonfile": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-1.1.1.tgz",
+      "integrity": "sha512-yrmo536TrJWDHNYlkCjtkPSqNnAkt6u1k89O5Xxr53zc4DkdikTHE+Fx6VF7syJd18xsdo24U4csedAkhLgxVQ==",
+      "dev": true
+    },
+    "node_modules/grunt-mocha-test/node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/grunt-mocha-test/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/grunt-ng-annotate": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/grunt-ng-annotate/-/grunt-ng-annotate-0.3.2.tgz",
+      "integrity": "sha512-jXQh+dJWzaNsvf7vda2Hj+p0QDMF6e/P+6DM7I2YHjaAjuVnjAhH3RCXAZZW+NFPn90HDZv80VdGsQQ/LmO1hA==",
+      "deprecated": "grunt-ng-annotate is deprecated. Switch to babel-plugin-angularjs-annotate or provide annotations by yourself.",
+      "dev": true,
+      "dependencies": {
+        "ng-annotate": "~0.9.9"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "peerDependencies": {
+        "grunt": "~0.4.1"
+      }
+    },
+    "node_modules/grunt/node_modules/coffee-script": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+      "integrity": "sha512-QjQ1T4BqyHv19k6XSfdhy/QLlIOhywz0ekBUCa9h71zYMJlfDTGan/Z1JXzYkZ6v8R+GhvL/p4FZPbPW8WNXlg==",
+      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
+      "dev": true,
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/grunt/node_modules/glob": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+      "integrity": "sha512-ANhy2V2+tFpRajE3wN4DhkNQ08KDr0Ir1qL12/cUe5+a7STEK8jkW4onUYuY8/06qAFuT5je7mjAqzx0eKI2tQ==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "graceful-fs": "~1.2.0",
+        "inherits": "1",
+        "minimatch": "~0.2.11"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/grunt/node_modules/graceful-fs": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+      "integrity": "sha512-iiTUZ5vZ+2ZV+h71XAgwCSu6+NAizhFU3Yw8aC/hH5SQ3SnISqEqAek40imAFGtDcwJKNhXvSY+hzIolnLwcdQ==",
+      "deprecated": "please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js",
+      "dev": true,
+      "license": "BSD",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/grunt/node_modules/inherits": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+      "integrity": "sha512-Al67oatbRSo3RV5hRqIoln6Y5yMVbJSIn4jEJNL7VCImzq/kLr7vvb6sFRJXqr8rpHc/2kJOM+y0sPKN47VdzA==",
+      "dev": true
+    },
+    "node_modules/grunt/node_modules/minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha512-zZ+Jy8lVWlvqqeM8iZB7w7KmQkoJn8djM585z88rywrEbzoqawVa9FR5p2hwD+y74nfuKOjmNvi9gtWJNLqHvA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/gzip-size": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-0.1.1.tgz",
+      "integrity": "sha512-G7KBsKYrNbs0BuoiPkRvbbI+mpa9wfjYTcdAyh9/eo9rBy05F/csSMmbNTkPgKY+nWgUszPV6kQ8lm0E9vBTnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "concat-stream": "^1.4.1",
+        "zlib-browserify": "^0.0.3"
+      },
+      "bin": {
+        "gzip-size": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gzip-size/node_modules/zlib-browserify": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/zlib-browserify/-/zlib-browserify-0.0.3.tgz",
+      "integrity": "sha512-KW42YGoQKq7+oU46deeWMUsrPyBruEWV1DoObBTMfEC2LnTqQIrwKVKrPoz2mn5DXESW4Ca/lIP2MqGHrt/WFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tape": "~0.2.2"
+      }
+    },
+    "node_modules/has-ansi": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+      "integrity": "sha512-1YsTg1fk2/6JToQhtZkArMkurq8UoWU1Qe0aR3VUHjgij4nOylSWLWAtBXoZ4/dXOmugfLGm1c+QhuD0JyedFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^0.2.0"
+      },
+      "bin": {
+        "has-ansi": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-color": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+      "integrity": "sha512-kaNz5OTAYYmt646Hkqw50/qyxP2vFnTVu5AQ1Zmk22Kk5+4Qx6BpO8+u7IKsML5fOsFk0ZT0AcCJNYwcvaLBvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/hawk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+      "integrity": "sha512-am8sVA2bCJIw8fuuVcKvmmNnGFUGW8spTkVtj2fXTEZVkfN42bwFZFtDem57eFi+NSxurJB8EQ7Jd3uCHLn8Vw==",
+      "deprecated": "This module moved to @hapi/hawk. Please make sure to switch over as this distribution is no longer supported and may contain bugs and critical security issues.",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "boom": "0.4.x",
+        "cryptiles": "0.2.x",
+        "hoek": "0.9.x",
+        "sntp": "0.2.x"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/hoek": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+      "integrity": "sha512-ZZ6eGyzGjyMTmpSPYVECXy9uNfqBR7x5CavhUaLOeD6W0vWK1mp/b7O3f86XE0Mtfo9rZ6Bh3fnuw9Xr8MF9zA==",
+      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/hooker": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+      "integrity": "sha512-t+UerCsQviSymAInD01Pw+Dn/usmz1sRO+3Zk1+lx8eg+WKpD2ulcwWqHHL0+aseRBr+3+vIhiG1K1JTwaIcTA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/http-signature": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+      "integrity": "sha512-coK8uR5rq2IMj+Hen+sKPA5ldgbCc1/spPdKCL1Fw6h+D0s/2LzMcRK0Cqufs1h0ryx/niwBHGFu8HC3hwU+lA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "asn1": "0.1.11",
+        "assert-plus": "^0.1.5",
+        "ctype": "0.5.3"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+      "integrity": "sha512-KhmFWgaQZY83Cbhi+ADInoUQ8Etn6BG5fikM9syeOjQltvR45h7cRKJ/9uvQEuD61I3Uju77yYce0/LhKVClQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/intersect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/intersect/-/intersect-1.0.1.tgz",
+      "integrity": "sha512-qsc720yevCO+4NydrJWgEWKccAQwTOvj2m73O/VBA6iUL2HGZJ9XqBiyraNrBXX/W1IAjdpXdRZk24sq8TzBRg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
+      "integrity": "sha512-mjWH5XxnhMA8cFnDchr6qRP9S/kLntKuEfIYku+PaN1CnS8v+OG9O/BKpRCVRJvpIkgAZm0Pf5Is3iSSOILlcg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jade": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-1.3.1.tgz",
+      "integrity": "sha512-21JjsbK/7cBNTBLpkN+1WRTvA3mYc7SMQWYc025NRggDLkKKqHGCiBVmF9ND/i/STmzmROe8hfgfHzbdL50N5w==",
+      "deprecated": "Jade has been renamed to pug, please install the latest version of pug instead of jade",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-parser": "1.2.0",
+        "commander": "2.1.0",
+        "constantinople": "~2.0.0",
+        "mkdirp": "~0.3.5",
+        "monocle": "1.1.51",
+        "transformers": "2.1.0",
+        "with": "~3.0.0"
+      },
+      "bin": {
+        "jade": "bin/jade.js"
+      }
+    },
+    "node_modules/jit-grunt": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/jit-grunt/-/jit-grunt-0.8.0.tgz",
+      "integrity": "sha512-mJ80LXh3rDLhlLMhqZsLu38QZlUR2bKrnT993DnlcvKSECKdt3/1+MNoMaUV8jbKIw16EdxODMPTuLsC8rGg/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      },
+      "peerDependencies": {
+        "grunt": "~0.4.0"
+      }
+    },
+    "node_modules/js-base64": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+      "integrity": "sha512-f+5mYh8iF7FlF7zgmj/yqvvYQUHI0kAxGiLjIfNxZzqJ7RQNc4sjgp8crVJw0Kzv2O6aFGZWgMTnO71I9utHSg==",
+      "dev": true,
+      "license": "BSD"
+    },
+    "node_modules/js-yaml": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+      "integrity": "sha512-VEKcIksckDBUhg2JS874xVouiPkywVUh4yyUmLCDe1Zg3bCd6M+F1eGPenPeHLc2XC8pp9G8bsuofK0NeEqRkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "~ 0.1.11",
+        "esprima": "~ 1.0.2"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/jsonfile": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/less": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/less/-/less-1.7.5.tgz",
+      "integrity": "sha512-+cddvg94fFlyJUijF+jO8Dvrr1RWIAf3l/kXDUiQ65za+o468iA9jwal2dcKnmJTHTFqnQQGo2jT1pJqAlI73Q==",
+      "dev": true,
+      "bin": {
+        "lessc": "bin/lessc"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      },
+      "optionalDependencies": {
+        "clean-css": "2.2.x",
+        "graceful-fs": "~3.0.2",
+        "mime": "~1.2.11",
+        "mkdirp": "~0.5.0",
+        "request": "~2.40.0",
+        "source-map": "0.1.x"
+      }
+    },
+    "node_modules/less/node_modules/graceful-fs": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.12.tgz",
+      "integrity": "sha512-J55gaCS4iTTJfTXIxSVw3EMQckcqkpdRv3IR7gu6sq0+tbC363Zx6KH/SEwXASK9JRbhyZmVjJEVJIOxYsB3Qg==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "natives": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/less/node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/less/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/less/node_modules/source-map": {
+      "version": "0.1.43",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+      "integrity": "sha512-VtCvB9SIQhk3aF6h+N85EaqIaBFIAfZ9Cu+NJHHVvc8BbEcnvDcFw6sqQ2dQrT6SlOrZq3tIvyD9+EGq/lJryQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "amdefine": ">=0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/load-grunt-config": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/load-grunt-config/-/load-grunt-config-0.13.2.tgz",
+      "integrity": "sha512-8rtJvmyRxZwZ5+dYJChdOljF457OEEEIfv4JT8Qsp3TX0Pcoq2y8KRukbrC0bujyh8tv38cx0CrbSsEeFR9Xhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "~0.2.10",
+        "glob": "~3.2.6",
+        "jit-grunt": "~0.8.0",
+        "js-yaml": "~3.0.1",
+        "load-grunt-tasks": "~0.3.0",
+        "lodash-node": "~2.4.1"
+      }
+    },
+    "node_modules/load-grunt-config/node_modules/async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ==",
+      "dev": true
+    },
+    "node_modules/load-grunt-config/node_modules/glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha512-hVb0zwEZwC1FXSKRPFTeOtN7AArJcJlI6ULGLtrstaswKNlrTJqAA+1lYlSUop4vjA423xlBzqfVS3iWGlqJ+g==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "inherits": "2",
+        "minimatch": "0.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/load-grunt-config/node_modules/js-yaml": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.2.tgz",
+      "integrity": "sha512-8PVwV1480dnAPMj8FCW3I/mZZ+gvtOoMAZFWJKagkFq2eWv5kcyzWTR+6MloV0SY57t6jSIaKc7DIz86K9ZCfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "~ 0.1.11",
+        "esprima": "~ 1.0.2"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/load-grunt-config/node_modules/minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha512-WFX1jI1AaxNTZVOHLBVazwTWKaQjoykSzCBNXB72vDTCzopQGtyP91tKdFK5cv1+qMwPyiTu1HqUriqplI8pcA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/load-grunt-tasks": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-0.3.0.tgz",
+      "integrity": "sha512-bgZqR+scmG37RTcJbZgXbH6pfohQl2F7j5wVqNHXS35B280LQKvI5ftMik0Q5qMR8tTecWEtLVNLRdSQGtQeWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "findup-sync": "~0.1.2",
+        "globule": "~0.2.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/load-grunt-tasks/node_modules/glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha512-hVb0zwEZwC1FXSKRPFTeOtN7AArJcJlI6ULGLtrstaswKNlrTJqAA+1lYlSUop4vjA423xlBzqfVS3iWGlqJ+g==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "inherits": "2",
+        "minimatch": "0.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/load-grunt-tasks/node_modules/glob/node_modules/minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha512-WFX1jI1AaxNTZVOHLBVazwTWKaQjoykSzCBNXB72vDTCzopQGtyP91tKdFK5cv1+qMwPyiTu1HqUriqplI8pcA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/load-grunt-tasks/node_modules/globule": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-0.2.0.tgz",
+      "integrity": "sha512-mMhYxzb8wpE7VtHkJi+jk0yjlBLFetYMAnkcFutmDo4uSFAHu/1tLgVm9Y6HcaTaX1DZBJjZOM1KqqCZDvBLBw==",
+      "dev": true,
+      "dependencies": {
+        "glob": "~3.2.7",
+        "lodash": "~2.4.1",
+        "minimatch": "~0.2.11"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/load-grunt-tasks/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/load-grunt-tasks/node_modules/minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha512-zZ+Jy8lVWlvqqeM8iZB7w7KmQkoJn8djM585z88rywrEbzoqawVa9FR5p2hwD+y74nfuKOjmNvi9gtWJNLqHvA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+      "integrity": "sha512-LVbt/rjK62gSbhehDVKL0vlaime4Y1IBixL+bKeNfoY4L2zab/jGrxU6Ka05tMA/zBxkTk5t3ivtphdyYupczw==",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/lodash-node": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz",
+      "integrity": "sha512-egEt8eNQp2kZWRmngahiqMoDCDCENv3uM188S7Ed5t4k3v6RrLELXC+FqLNMUnhCo7gvQX3G1V8opK/Lcslahg==",
+      "deprecated": "This package is discontinued. Use lodash@^4.0.0.",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/maxmin": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-0.1.0.tgz",
+      "integrity": "sha512-grP8Hy0DIXklhjV9qWtQS2i5DIUYaErKIjxIa5N8pq/fka7khzyYuyimAYszFlWmMw6ZTsR+uwS6fjhGy+5vyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^0.4.0",
+        "gzip-size": "^0.1.0",
+        "pretty-bytes": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/maxmin/node_modules/ansi-styles": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+      "integrity": "sha512-3iF4FIKdxaVYT3JqQuY3Wat/T2t7TRbbQ94Fu50ZUCbLy4TFbTzr90NOHQodQkNqmeEGCw8WbeP78WNi6SKYUA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/maxmin/node_modules/chalk": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+      "integrity": "sha512-sQfYDlfv2DGVtjdoQqxS0cEZDroyG8h6TamA6rvxwlrU5BaSLDx9xhatBYl2pxZ7gmpNaPFVwBtdGdu5rQ+tYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "~1.0.0",
+        "has-color": "~0.1.0",
+        "strip-ansi": "~0.1.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/maxmin/node_modules/strip-ansi": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+      "integrity": "sha512-behete+3uqxecWlDAm5lmskaSaISA+ThQ4oNNBDTBJt0x2ppR6IPqfZNuj6BLaLJ/Sji4TPZlcRyOis8wXQTLg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "strip-ansi": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+      "integrity": "sha512-Ysa2F/nqTNGHhhm9MV8ure4+Hc+Y8AWiqUdHxsO7xu8zc92ND9f3kpALHjaP026Ft17UfxrMt95c50PLUeynBw==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+      "integrity": "sha512-echfutj/t5SoTL4WZpqjA1DCud1XO0WQF3/GJ48YBmc4ZMhCK77QA6Z/w6VTQERLKuJ4drze3kw2TUT8xZXVNw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+      "integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mkdirp": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+      "integrity": "sha512-8OCq0De/h9ZxseqzCH8Kw/Filf5pF/vMI6+BH7Lu0jXz2pqYCjTAQRolSxRIi+Ax+oCCjlxoJMP0YQ4XlrQNHg==",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mocha": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.20.1.tgz",
+      "integrity": "sha512-25Nq3BuIYCy80uEix+hBlZcr/gnLzpcYqfsaPAxZm2qbMFmed8I3nP8N05KagK4BTkGYUvsRJ47istvRqFO8fw==",
+      "deprecated": "Mocha v1.x is no longer supported.",
+      "dev": true,
+      "dependencies": {
+        "commander": "2.0.0",
+        "debug": "*",
+        "diff": "1.0.7",
+        "glob": "3.2.3",
+        "growl": "1.7.x",
+        "jade": "0.26.3",
+        "mkdirp": "0.3.5"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 0.4.x"
+      }
+    },
+    "node_modules/mocha/node_modules/commander": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz",
+      "integrity": "sha512-qebjpyeaA/nJ4w3EO2cV2++/zEkccPnjWogzA2rff+Lk8ILI75vULeTmyd4wPxWdKwtP3J+G39IXVZadh0UHyw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.x"
+      }
+    },
+    "node_modules/mocha/node_modules/diff": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.7.tgz",
+      "integrity": "sha512-0bTLzyr1S59cPsgAD/lR+ivvHTbgPb+k/mUR6WGqma1J6QDU+kUegI8uQFuH/cMUNK7JGN3Tk1Y5Jf2MO85WrA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/mocha/node_modules/glob": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+      "integrity": "sha512-WPaLsMHD1lYEqAmIQI6VOJSPwuBdGShDWnj1yUo0vQqEO809R8W3LM9OVU13CnnDhyv/EiNwOtxEW74SmrzS6w==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "graceful-fs": "~2.0.0",
+        "inherits": "2",
+        "minimatch": "~0.2.11"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mocha/node_modules/graceful-fs": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+      "integrity": "sha512-hcj/NTUWv+C3MbqrVb9F+aH6lvTwEHJdx2foBxlrVq5h6zE8Bfu4pv4CAAqbDcZrw/9Ak5lsRXlY9Ao8/F0Tuw==",
+      "deprecated": "please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js",
+      "dev": true,
+      "license": "BSD",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/mocha/node_modules/jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha512-mkk3vzUHFjzKjpCXeu+IjXeZD+QOTjUUdubgmHtHTDwvAO2ZTkMTTVrapts5CWz3JvJryh/4KWZpjeZrCepZ3A==",
+      "deprecated": "Jade has been renamed to pug, please install the latest version of pug instead of jade",
+      "dev": true,
+      "dependencies": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "bin": {
+        "jade": "bin/jade"
+      }
+    },
+    "node_modules/mocha/node_modules/jade/node_modules/commander": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+      "integrity": "sha512-0fLycpl1UMTGX257hRsu/arL/cUbcvQM4zMKwvLvzXtfdezIV4yotPS2dYtknF+NmEfWSoCEF6+hj9XLm/6hEw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.x"
+      }
+    },
+    "node_modules/mocha/node_modules/jade/node_modules/mkdirp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+      "integrity": "sha512-OHsdUcVAQ6pOtg5JYWpCBo9W/GySVuwvP9hueRMW7UqshC0tbfzLv8wjySTPm3tfUZ/21CE9E1pJagOA91Pxew==",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "dev": true,
+      "license": "MIT/X11",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha512-zZ+Jy8lVWlvqqeM8iZB7w7KmQkoJn8djM585z88rywrEbzoqawVa9FR5p2hwD+y74nfuKOjmNvi9gtWJNLqHvA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/monocle": {
+      "version": "1.1.51",
+      "resolved": "https://registry.npmjs.org/monocle/-/monocle-1.1.51.tgz",
+      "integrity": "sha512-G2ozHlK2+Z+oAvKSJ4pN0a7pLvCOWMDuHgtdARDt1uRyak9klMwg71ac37SWeULSzrkV0N75A0z9JaYtqXji1w==",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "readdirp": "~0.2.3"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natives": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
+      "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==",
+      "deprecated": "This module relies on Node.js's internals and will break at some point. Do not use it, and update to graceful-fs@4.x.",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/ncp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.5.1.tgz",
+      "integrity": "sha512-l+pJxuLlzwp11Dy72MJgCPNwIbXdv6imaACLiEMb2TIDyr54qz+nAZeD5qDlJefveaJ+R9Ug6KuozCxRpQXO0Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "ncp": "bin/ncp"
+      }
+    },
+    "node_modules/ng-annotate": {
+      "version": "0.9.11",
+      "resolved": "https://registry.npmjs.org/ng-annotate/-/ng-annotate-0.9.11.tgz",
+      "integrity": "sha512-bAxQjBT+L+dW8UOyrp+Ubmvu58GG4BXorHnJUResm32QBmDbQcErBtaV3goBYFYH2amD/pe9X8iXbY7NkWk3Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "alter": "~0.2.0",
+        "convert-source-map": "~0.4.0",
+        "esprima": "~1.2.0",
+        "optimist": "~0.6.1",
+        "ordered-ast-traverse": "~0.1.1",
+        "simple-fmt": "~0.1.0",
+        "simple-is": "~0.2.0",
+        "source-map": "~0.1.37",
+        "stable": "~0.1.5",
+        "stringmap": "~0.2.2",
+        "stringset": "~0.2.1",
+        "tryor": "~0.1.2"
+      },
+      "bin": {
+        "ng-annotate": "build/es5/ng-annotate"
+      }
+    },
+    "node_modules/ng-annotate/node_modules/esprima": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
+      "integrity": "sha512-S9VbPDU0adFErpDai3qDkjq8+G05ONtKzcyNrPKg/ZKa+tf879nX2KexNU95b31UoTJjRLInNBHHHjFPoCd7lQ==",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ng-annotate/node_modules/source-map": {
+      "version": "0.1.43",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+      "integrity": "sha512-VtCvB9SIQhk3aF6h+N85EaqIaBFIAfZ9Cu+NJHHVvc8BbEcnvDcFw6sqQ2dQrT6SlOrZq3tIvyD9+EGq/lJryQ==",
+      "dev": true,
+      "dependencies": {
+        "amdefine": ">=0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/node-uuid": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+      "integrity": "sha512-TkCET/3rr9mUuRp+CpO7qfgT++aAxfDRaalQhwPFzI9BY/2rCDn6OfpZOVggi1AXfTPpfkTrg5f5WQx5G1uLxA==",
+      "deprecated": "Use uuid module instead",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/noptify": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
+      "integrity": "sha512-EZT35r9AuK+hig+iYv4144kwfDEDhlj3zncVHw9b9d86TUYk/67BtBApkfPD1kslAT/8TTD262xdsVbV+iCSTw==",
+      "dev": true,
+      "dependencies": {
+        "nopt": "~2.0.0"
+      }
+    },
+    "node_modules/noptify/node_modules/nopt": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
+      "integrity": "sha512-uVTsuT8Hm3aN3VttY+BPKw4KU9lVpI0F22UAr/I1r6+kugMr3oyhMALkycikLcdfvGRsgzCYN48DYLBFcJEUVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      }
+    },
+    "node_modules/oauth-sign": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz",
+      "integrity": "sha512-Tr31Sh5FnK9YKm7xTUPyDMsNOvMqkVDND0zvK/Wgj7/H9q8mpye0qG2nVzrnsvLhcsX5DtqXD0la0ks6rkPCGQ==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/omega-pac": {
+      "resolved": "../omega-pac",
+      "link": true
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha512-snN4O4TkigujZphWLN0E//nQmm7790RYaE53DdL7ZYwee2D8DDo9/EyYiKUfN3rneWUjhJnueija3G9I2i0h3g==",
+      "dev": true,
+      "license": "MIT/X11",
+      "dependencies": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      }
+    },
+    "node_modules/ordered-ast-traverse": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ordered-ast-traverse/-/ordered-ast-traverse-0.1.1.tgz",
+      "integrity": "sha512-+ezOFpszs+yIn/mmrDsltqz441H1FkICgi5oWKcBa3YtRrPZaYGh7F7NQ6z+KC2kY8YlUdz9Nzh0o4rHo3SuJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ordered-esprima-props": "~1.0.0"
+      }
+    },
+    "node_modules/ordered-esprima-props": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ordered-esprima-props/-/ordered-esprima-props-1.0.0.tgz",
+      "integrity": "sha512-DlmEsiS7qt6GYq43xWQ9SVwB1hpNUSBve6C5GkbZFGiauCUvx1YMy7AjNlzM/WieK+1knYCqTrcn5DOhy0gn0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-2.2.6.tgz",
+      "integrity": "sha512-8zk4tZ73/ddVQ+Cg2Ca/U4CGT1SAzDYriJDYrRp9ZvNXJPWwYlJaSjHSUJLFKlmuaUjCJvtDnKTwwDpoie55Yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-base64": "~2.1.5",
+        "source-map": "~0.1.40"
+      }
+    },
+    "node_modules/postcss/node_modules/source-map": {
+      "version": "0.1.43",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+      "integrity": "sha512-VtCvB9SIQhk3aF6h+N85EaqIaBFIAfZ9Cu+NJHHVvc8BbEcnvDcFw6sqQ2dQrT6SlOrZq3tIvyD9+EGq/lJryQ==",
+      "dev": true,
+      "dependencies": {
+        "amdefine": ">=0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/pretty-bytes": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-0.1.2.tgz",
+      "integrity": "sha512-TYOKOXttAHbRtQZJGClkQml5sKaM12gGe7xW/SNJkBVs2Jrg1RGTa8a+oM75daQEqKFrFk4MTmvVsgt7uCCc+Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pretty-bytes": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
+      "integrity": "sha512-OgMc+sxI3zWF8D5BJGtA0z7/IsrDy1/0cPaDv6HPpqa2fSTo7AdON5U10NbZCUeF+zCAj3PtfPE50Hf02386aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-promise": "~1"
+      }
+    },
+    "node_modules/qs": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-1.0.2.tgz",
+      "integrity": "sha512-tHuOP9TN/1VmDM/ylApGK1QF3PSIP8I6bHDEfoKNQeViREQ/sfu1bAUrA1hoDun8p8Tpm7jcsz47g+3PiGoYdg==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-0.2.5.tgz",
+      "integrity": "sha512-j3/RLxRiCZSei/4UaYaOAqHa+rQ8ZL9vpolGO9E7mLXiVTb7Fu99eTG74ZmaB/4gCGgy7Veq+U6vw8y7sKJiTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": ">=0.2.4"
+      },
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/request": {
+      "version": "2.40.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.40.0.tgz",
+      "integrity": "sha512-waNoGB4Z7bPn+lgqPk7l7hhze4Vd68jKccnwLeS7vr9GMxz0iWQbYTbBNWzfIk87Urx7V44pu29qjF/omej+Fw==",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+      "dev": true,
+      "engines": [
+        "node >= 0.8.0"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "forever-agent": "~0.5.0",
+        "json-stringify-safe": "~5.0.0",
+        "mime-types": "~1.0.1",
+        "node-uuid": "~1.4.0",
+        "qs": "~1.0.0"
+      },
+      "optionalDependencies": {
+        "aws-sign2": "~0.5.0",
+        "form-data": "~0.1.0",
+        "hawk": "1.1.1",
+        "http-signature": "~0.10.0",
+        "oauth-sign": "~0.3.0",
+        "stringstream": "~0.0.4",
+        "tough-cookie": ">=0.12.0",
+        "tunnel-agent": "~0.4.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz",
+      "integrity": "sha512-UHBY3viPlJKf85YijDUcikKX6tmF4SokIDp518ZDVT92JNDcG5uKIthaT/owt3Sar0lwtOafsQuwrg22/v2Dwg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rimraf": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+      "integrity": "sha512-R5KMKHnPAQaZMqLOsyuyUmcIjSeDm+73eoqQpaXA7AZ22BL+6C+1mcUscgOsNd8WVlJuvlgAPsegcx7pjlV0Dg==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/simple-fmt": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
+      "integrity": "sha512-9a3zTDDh9LXbTR37qBhACWIQ/mP/ry5xtmbE98BJM8GR02sanCkfMzp7AdCTqYhkBZggK/w7hJtc8Pb9nmo16A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/simple-is": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
+      "integrity": "sha512-GJXhv3r5vdj5tGWO+rcrWgjU2azLB+fb7Ehh3SmZpXE0o4KrrFLti0w4mdDCbR29X/z0Ls20ApjZitlpAXhAeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sntp": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+      "integrity": "sha512-bDLrKa/ywz65gCl+LmOiIhteP1bhEsAAzhfMedPoiHP3dyYnAevlaJshdqb9Yu0sRifyP/fRqSt8t+5qGIWlGQ==",
+      "deprecated": "This module moved to @hapi/sntp. Please make sure to switch over as this distribution is no longer supported and may contain bugs and critical security issues.",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "hoek": "0.9.x"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/sort-keys": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+      "integrity": "sha512-vzn8aSqKgytVik0iwdBEi+zevbTYZogewTUM6dtpmGwEcdzbub/TX4bCzRhebDCRC3QzXgJsLRKB2V/Oof7HXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sort-keys-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
+      "integrity": "sha512-GRbEOUqCxemTAk/b32F2xa8wDTs+Z1QHOkbhJDQTvv/6G3ZkbJ+frYWsTcc7cBB3Fu4wy4XlLCuNtJuMn7Gsvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sort-keys": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
+      "integrity": "sha512-jz8leTIGS8+qJywWiO9mKza0hJxexdeIYXhDHw9avTQcXSNAGk3hiiRMpmI2Qf9dOrZDrDpgH9VNefzuacWC9A==",
+      "dev": true,
+      "dependencies": {
+        "amdefine": ">=0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/stable": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
+      "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/stringmap": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
+      "integrity": "sha512-mR1LEHDw6TsHa+LwJeeBc9ZqZqEOm7bHidgxMmDg8HB/rbA1HhDeT08gS67CCCG/xrgIfQx5tW42pd8vFpLUow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stringset": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
+      "integrity": "sha512-km3jeiRpmySChl1oLiBE2ESdG5k/4+6tjENVL6BB3mdmKBiUikI5ks4paad2WAKsxzpNiBqBBbXCC12QqlpLWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stringstream": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/strip-ansi": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+      "integrity": "sha512-DerhZL7j6i6/nEnVG0qViKXI0OKouvvpsAiaj7c+LfqZZZxdwZtv8+UiA/w4VUJpT8UzX0pR1dcHOii1GbmruQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^0.2.1"
+      },
+      "bin": {
+        "strip-ansi": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha512-AOPG8EBc5wAikaG1/7uFCNFJwnKOuQwFTpYBdTW6OvWHeZBQBrAA/amefHGrEiOnCPcLFZK6FUPtWVKpQVIRgg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "strip-json-comments": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+      "integrity": "sha512-tdCZ28MnM7k7cJDJc7Eq80A9CsRFAAOZUy41npOZCs++qSjfIy7o5Rh46CBk+Dk5FbKJ33X3Tqg4YrV07N5RaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "supports-color": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tape": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-0.2.2.tgz",
+      "integrity": "sha512-bfyf/0yv2FZVsf80b7oo50Lyi35sfjE7VM6206du7LtpbdQP8rbLhZy/stuS/Dcq4w6jE1Pz2zFrHtfeOKbaUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-equal": "~0.0.0",
+        "defined": "~0.0.0",
+        "jsonify": "~0.0.0"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tiny-lr-fork": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/tiny-lr-fork/-/tiny-lr-fork-0.0.5.tgz",
+      "integrity": "sha512-vhcvny/8f46rrViKV0BOUjVl4c/rDTztnT1+kT7iyD/Igqb/uyiRsKLxMc2Z8CNvTE1Px1tuNrPM+BOUL+3vlQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "~0.7.0",
+        "faye-websocket": "~0.4.3",
+        "noptify": "~0.0.3",
+        "qs": "~0.5.2"
+      },
+      "bin": {
+        "tiny-lr-fork": "bin/tiny-lr"
+      }
+    },
+    "node_modules/tiny-lr-fork/node_modules/debug": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+      "integrity": "sha512-EohAb3+DSHSGx8carOSKJe8G0ayV5/i609OD0J2orCkuyae7SyZSz2aoLmQF2s0Pj5gITDebwPH7GFBlqOUQ1Q==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tiny-lr-fork/node_modules/qs": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz",
+      "integrity": "sha512-KbOrQrP5Ye+0gmq+hwxoJwAFRwExACWqwxj1IDFFgqOw9Poxy3wwSbafd9ZqP6T6ykMfnxM573kt/a4i9ybatQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/transformers": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/transformers/-/transformers-2.1.0.tgz",
+      "integrity": "sha512-zJf5m2EIOngmBbDe2fhTPpCjzM2qkZVqrFJZc2jaln+KBeEaYKhS2QMOIkfVrNUyoOwqgbTwOHATzr3jZRQDyg==",
+      "deprecated": "Deprecated, use jstransformer",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css": "~1.0.8",
+        "promise": "~2.0",
+        "uglify-js": "~2.2.5"
+      }
+    },
+    "node_modules/transformers/node_modules/optimist": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+      "integrity": "sha512-TCx0dXQzVtSCg2OgY/bO9hjM9cV4XYx09TVK+s3+FhkjT6LovsLe+pPMzpWf+6yXK/hUizs2gUoTw3jHM0VaTQ==",
+      "dev": true,
+      "license": "MIT/X11",
+      "dependencies": {
+        "wordwrap": "~0.0.2"
+      }
+    },
+    "node_modules/transformers/node_modules/source-map": {
+      "version": "0.1.43",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+      "integrity": "sha512-VtCvB9SIQhk3aF6h+N85EaqIaBFIAfZ9Cu+NJHHVvc8BbEcnvDcFw6sqQ2dQrT6SlOrZq3tIvyD9+EGq/lJryQ==",
+      "dev": true,
+      "dependencies": {
+        "amdefine": ">=0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/transformers/node_modules/uglify-js": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
+      "integrity": "sha512-viLk+/8G0zm2aKt1JJAVcz5J/5ytdiNaIsKgrre3yvSUjwVG6ZUujGH7E2TiPigZUwLYCe7eaIUEP2Zka2VJPA==",
+      "dev": true,
+      "dependencies": {
+        "optimist": "~0.3.5",
+        "source-map": "~0.1.7"
+      },
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/tryor": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
+      "integrity": "sha512-2+ilNA00DGvbUYYbRrm3ux+snbo7I6uPXMw8I4p/QMl7HUOWBBZFbk+Mpr8/IAPDQE+LQ8vOdlI6xEzjc+e/BQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+      "integrity": "sha512-e0IoVDWx8SDHc/hwFTqJDQ7CCDTEeGhmcT9jkWJjoGQSpgBz20nAMr80E3Tpk7PatJ1b37DQDgJR3CNSzcMOZQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+      "integrity": "sha512-5rqszGVwYgBoDkIm2oUtvkfZMQ0vk29iDMU0W2qCa3rG0vPDNczCMT4hV/bLBgLg8k8ri6+u3Zbt+S/14eMzlA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uglify-js": {
+      "version": "2.4.24",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
+      "integrity": "sha512-tktIjwackfZLd893KGJmXc1hrRHH1vH9Po3xFh1XBjjeGAnN02xJ3SuoA+n1L29/ZaCA18KzCFlckS+vfPugiA==",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "async": "~0.2.6",
+        "source-map": "0.1.34",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.5.4"
+      },
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/uglify-js/node_modules/async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ==",
+      "dev": true
+    },
+    "node_modules/uglify-js/node_modules/source-map": {
+      "version": "0.1.34",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+      "integrity": "sha512-yfCwDj0vR9RTwt3pEzglgb3ZgmcXHt6DjG3bjJvzPwTL+5zDQ2MhmSzAcTy0GTiQuCiriSWXvWM1/NhKdXuoQA==",
+      "dev": true,
+      "dependencies": {
+        "amdefine": ">=0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha512-vb2s1lYx2xBtUgy+ta+b2J/GLVUR+wmpINwHePmPRhOsIVCG2wDzKJ0n14GslH1BifsqVzSOwQhRaCAsZ/nI4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/underscore": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "integrity": "sha512-cp0oQQyZhUM1kpJDLdGO1jPZHgS/MpzoWYfe9+CM2h/QGDZlqwT2T3YGukuBdaNJ/CAPoeyAZRRHz8JFo176vA==",
+      "dev": true
+    },
+    "node_modules/underscore.string": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+      "integrity": "sha512-3FVmhXqelrj6gfgp3Bn6tOavJvW0dNH2T+heTD38JRxIrAbiuzbqjknszoOYj3DyFB1nWiLj208Qt2no/L4cIA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+      "integrity": "sha512-E87fdQ/eRJr9W1X4wTPejNy9zTW3FI2vpCZSJ/HAY+TkjKVC0TUm1jk6vn2Z7qay0DQy0+RBGdXxj+RmmiGZKQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha512-1pTPQDKTdd61ozlKGNCjhNRd+KPmgLSGa3mZTHoOliaGcESD8G1PXhh7c1fgiPjVbNVfgy2Faw4BI8/m0cC8Mg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/with": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/with/-/with-3.0.1.tgz",
+      "integrity": "sha512-kkmVGj873jXl71lBDCCoZ35tOOyUsMQv2XFmov8hS39PR5u8aTFyN7f0ZjOJ5QipflBdHGT5d9tpwBtBDrE7Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uglify-js": "~2.4.12"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+      "integrity": "sha512-5j382E4xQSs71p/xZQsU1PtRA2HXPAjX0E0DkoGLxwNASMOKX6A9doV1NrZmj85u2Pjquz402qonBzz/yLPbPA==",
+      "dev": true,
+      "license": "MIT/X11",
+      "dependencies": {
+        "camelcase": "^1.0.2",
+        "decamelize": "^1.0.0",
+        "window-size": "0.1.0",
+        "wordwrap": "0.0.2"
+      }
+    },
+    "node_modules/yargs/node_modules/wordwrap": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+      "integrity": "sha512-xSBsCeh+g+dinoBv3GAOWM4LcVVO68wLXRanibtBSdUvkGWQRGeE9P7IwU9EmDDi4jA6L44lz15CGMwdw9N5+Q==",
+      "dev": true,
+      "license": "MIT/X11",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/zlib-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/zlib-browserify/-/zlib-browserify-0.0.1.tgz",
+      "integrity": "sha512-fheIDCKXU0YAGZMv4FFwVTBMQRSv2ZjNqRN1VkZjetZDK/BC/hViEhasTh0kTeogcsIAl5gYE04GN53trT+cFw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -832,6 +832,14 @@
       "resolved": "packages/pac",
       "link": true
     },
+    "node_modules/@switchydelta/target": {
+      "resolved": "packages/target",
+      "link": true
+    },
+    "node_modules/@switchydelta/ui": {
+      "resolved": "packages/ui",
+      "link": true
+    },
     "node_modules/@types/chrome": {
       "version": "0.0.268",
       "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.268.tgz",
@@ -842,6 +850,12 @@
         "@types/filesystem": "*",
         "@types/har-format": "*"
       }
+    },
+    "node_modules/@types/diff-match-patch": {
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
+      "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==",
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -1072,6 +1086,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
@@ -1151,6 +1171,22 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/jsondiffpatch": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.6.2.tgz",
+      "integrity": "sha512-c4RkbPb6RXWjkhirwcKK87PuZCITdGRN1usrW4pXKEkwp7Gqf+0pSwQHoh/LtlYNHcxzoF6kok2/EFe6KL0qqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/diff-match-patch": "^1.0.36",
+        "diff-match-patch": "^1.0.5"
+      },
+      "bin": {
+        "jsondiffpatch": "bin/jsondiffpatch.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
       }
     },
     "node_modules/loupe": {
@@ -1580,6 +1616,24 @@
       "version": "3.0.0",
       "dependencies": {
         "tldts": "^6.1.47"
+      }
+    },
+    "packages/target": {
+      "name": "@switchydelta/target",
+      "version": "3.0.0",
+      "dependencies": {
+        "@switchydelta/pac": "*",
+        "jsondiffpatch": "^0.6.0"
+      }
+    },
+    "packages/ui": {
+      "name": "@switchydelta/ui",
+      "version": "3.0.0",
+      "dependencies": {
+        "@switchydelta/pac": "*"
+      },
+      "devDependencies": {
+        "vite": "^5.4.2"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@types/chrome": "^0.0.268",
         "@types/node": "^20.14.0",
+        "esbuild": "^0.23.0",
         "typescript": "^5.5.4",
         "vitest": "^2.0.5"
       },
@@ -22,9 +23,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz",
+      "integrity": "sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==",
       "cpu": [
         "ppc64"
       ],
@@ -35,13 +36,13 @@
         "aix"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.1.tgz",
+      "integrity": "sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==",
       "cpu": [
         "arm"
       ],
@@ -52,13 +53,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.1.tgz",
+      "integrity": "sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==",
       "cpu": [
         "arm64"
       ],
@@ -69,13 +70,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.1.tgz",
+      "integrity": "sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==",
       "cpu": [
         "x64"
       ],
@@ -86,13 +87,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.1.tgz",
+      "integrity": "sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==",
       "cpu": [
         "arm64"
       ],
@@ -103,13 +104,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.1.tgz",
+      "integrity": "sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==",
       "cpu": [
         "x64"
       ],
@@ -120,13 +121,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.1.tgz",
+      "integrity": "sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==",
       "cpu": [
         "arm64"
       ],
@@ -137,13 +138,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.1.tgz",
+      "integrity": "sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==",
       "cpu": [
         "x64"
       ],
@@ -154,13 +155,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.1.tgz",
+      "integrity": "sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==",
       "cpu": [
         "arm"
       ],
@@ -171,13 +172,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.1.tgz",
+      "integrity": "sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==",
       "cpu": [
         "arm64"
       ],
@@ -188,13 +189,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.1.tgz",
+      "integrity": "sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==",
       "cpu": [
         "ia32"
       ],
@@ -205,13 +206,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.1.tgz",
+      "integrity": "sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==",
       "cpu": [
         "loong64"
       ],
@@ -222,13 +223,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.1.tgz",
+      "integrity": "sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==",
       "cpu": [
         "mips64el"
       ],
@@ -239,13 +240,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.1.tgz",
+      "integrity": "sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==",
       "cpu": [
         "ppc64"
       ],
@@ -256,13 +257,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.1.tgz",
+      "integrity": "sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==",
       "cpu": [
         "riscv64"
       ],
@@ -273,13 +274,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.1.tgz",
+      "integrity": "sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==",
       "cpu": [
         "s390x"
       ],
@@ -290,13 +291,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz",
+      "integrity": "sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==",
       "cpu": [
         "x64"
       ],
@@ -307,13 +308,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz",
+      "integrity": "sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==",
       "cpu": [
         "x64"
       ],
@@ -324,13 +325,30 @@
         "netbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.1.tgz",
+      "integrity": "sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.1.tgz",
+      "integrity": "sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==",
       "cpu": [
         "x64"
       ],
@@ -341,13 +359,13 @@
         "openbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.1.tgz",
+      "integrity": "sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==",
       "cpu": [
         "x64"
       ],
@@ -358,13 +376,13 @@
         "sunos"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.1.tgz",
+      "integrity": "sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==",
       "cpu": [
         "arm64"
       ],
@@ -375,13 +393,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.1.tgz",
+      "integrity": "sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==",
       "cpu": [
         "ia32"
       ],
@@ -392,13 +410,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz",
+      "integrity": "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==",
       "cpu": [
         "x64"
       ],
@@ -409,7 +427,7 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -1104,9 +1122,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.1.tgz",
+      "integrity": "sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1114,32 +1132,33 @@
         "esbuild": "bin/esbuild"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.21.5",
-        "@esbuild/android-arm": "0.21.5",
-        "@esbuild/android-arm64": "0.21.5",
-        "@esbuild/android-x64": "0.21.5",
-        "@esbuild/darwin-arm64": "0.21.5",
-        "@esbuild/darwin-x64": "0.21.5",
-        "@esbuild/freebsd-arm64": "0.21.5",
-        "@esbuild/freebsd-x64": "0.21.5",
-        "@esbuild/linux-arm": "0.21.5",
-        "@esbuild/linux-arm64": "0.21.5",
-        "@esbuild/linux-ia32": "0.21.5",
-        "@esbuild/linux-loong64": "0.21.5",
-        "@esbuild/linux-mips64el": "0.21.5",
-        "@esbuild/linux-ppc64": "0.21.5",
-        "@esbuild/linux-riscv64": "0.21.5",
-        "@esbuild/linux-s390x": "0.21.5",
-        "@esbuild/linux-x64": "0.21.5",
-        "@esbuild/netbsd-x64": "0.21.5",
-        "@esbuild/openbsd-x64": "0.21.5",
-        "@esbuild/sunos-x64": "0.21.5",
-        "@esbuild/win32-arm64": "0.21.5",
-        "@esbuild/win32-ia32": "0.21.5",
-        "@esbuild/win32-x64": "0.21.5"
+        "@esbuild/aix-ppc64": "0.23.1",
+        "@esbuild/android-arm": "0.23.1",
+        "@esbuild/android-arm64": "0.23.1",
+        "@esbuild/android-x64": "0.23.1",
+        "@esbuild/darwin-arm64": "0.23.1",
+        "@esbuild/darwin-x64": "0.23.1",
+        "@esbuild/freebsd-arm64": "0.23.1",
+        "@esbuild/freebsd-x64": "0.23.1",
+        "@esbuild/linux-arm": "0.23.1",
+        "@esbuild/linux-arm64": "0.23.1",
+        "@esbuild/linux-ia32": "0.23.1",
+        "@esbuild/linux-loong64": "0.23.1",
+        "@esbuild/linux-mips64el": "0.23.1",
+        "@esbuild/linux-ppc64": "0.23.1",
+        "@esbuild/linux-riscv64": "0.23.1",
+        "@esbuild/linux-s390x": "0.23.1",
+        "@esbuild/linux-x64": "0.23.1",
+        "@esbuild/netbsd-x64": "0.23.1",
+        "@esbuild/openbsd-arm64": "0.23.1",
+        "@esbuild/openbsd-x64": "0.23.1",
+        "@esbuild/sunos-x64": "0.23.1",
+        "@esbuild/win32-arm64": "0.23.1",
+        "@esbuild/win32-ia32": "0.23.1",
+        "@esbuild/win32-x64": "0.23.1"
       }
     },
     "node_modules/estree-walker": {
@@ -1530,6 +1549,436 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
       }
     },
     "node_modules/vitest": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -828,6 +828,10 @@
         "win32"
       ]
     },
+    "node_modules/@switchydelta/extension": {
+      "resolved": "packages/extension",
+      "link": true
+    },
     "node_modules/@switchydelta/pac": {
       "resolved": "packages/pac",
       "link": true
@@ -1609,6 +1613,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "packages/extension": {
+      "name": "@switchydelta/extension",
+      "version": "3.0.0",
+      "dependencies": {
+        "@switchydelta/pac": "*",
+        "@switchydelta/target": "*"
       }
     },
     "packages/pac": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1586 @@
+{
+  "name": "switchydelta",
+  "version": "3.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "switchydelta",
+      "version": "3.0.0",
+      "license": "GPL-3.0-or-later",
+      "workspaces": [
+        "packages/*"
+      ],
+      "devDependencies": {
+        "@types/chrome": "^0.0.268",
+        "@types/node": "^20.14.0",
+        "typescript": "^5.5.4",
+        "vitest": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@switchydelta/pac": {
+      "resolved": "packages/pac",
+      "link": true
+    },
+    "node_modules/@types/chrome": {
+      "version": "0.0.268",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.268.tgz",
+      "integrity": "sha512-7N1QH9buudSJ7sI8Pe4mBHJr5oZ48s0hcanI9w3wgijAlv1OZNUZve9JR4x42dn5lJ5Sm87V1JNfnoh10EnQlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/filesystem": {
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.36.tgz",
+      "integrity": "sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filewriter": "*"
+      }
+    },
+    "node_modules/@types/filewriter": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.33.tgz",
+      "integrity": "sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/har-format": {
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.16.tgz",
+      "integrity": "sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/pac": {
+      "name": "@switchydelta/pac",
+      "version": "3.0.0",
+      "dependencies": {
+        "tldts": "^6.1.47"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,14 +10,14 @@
   ],
   "scripts": {
     "build": "npm run typecheck && npm run build:ui && npm run build:extension",
-    "typecheck": "tsc --build --force",
+    "typecheck": "tsc --build --force && tsc --noEmit -p packages/ui",
     "test": "TZ=Europe/London vitest run",
     "test:watch": "vitest",
     "lint": "eslint packages --ext .ts,.tsx",
     "clean": "rm -rf packages/*/dist packages/*/tsconfig.tsbuildinfo",
     "build:ui": "npm run build -w @switchydelta/ui",
     "build:extension": "node scripts/build-extension.mjs",
-    "e2e": "node test/e2e/smoke.mjs dist && node test/e2e/profiles.mjs dist && node test/e2e/rule-list.mjs dist"
+    "e2e": "node test/e2e/smoke.mjs dist && node test/e2e/side-panel.mjs dist && node test/e2e/profiles.mjs dist && node test/e2e/rule-list.mjs dist"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.268",

--- a/package.json
+++ b/package.json
@@ -9,18 +9,21 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "npm run build --workspaces --if-present",
+    "build": "npm run typecheck && npm run build:ui && npm run build:extension",
     "typecheck": "tsc --build --force",
     "test": "TZ=Europe/London vitest run",
     "test:watch": "vitest",
     "lint": "eslint packages --ext .ts,.tsx",
-    "clean": "rm -rf packages/*/dist packages/*/tsconfig.tsbuildinfo"
+    "clean": "rm -rf packages/*/dist packages/*/tsconfig.tsbuildinfo",
+    "build:ui": "npm run build -w @switchydelta/ui",
+    "build:extension": "node scripts/build-extension.mjs"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.268",
     "@types/node": "^20.14.0",
     "typescript": "^5.5.4",
-    "vitest": "^2.0.5"
+    "vitest": "^2.0.5",
+    "esbuild": "^0.23.0"
   },
   "engines": {
     "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "switchydelta",
+  "version": "3.0.0",
+  "private": true,
+  "description": "SwitchyDelta - proxy switching browser extension",
+  "license": "GPL-3.0-or-later",
+  "type": "module",
+  "workspaces": [
+    "packages/*"
+  ],
+  "scripts": {
+    "build": "npm run build --workspaces --if-present",
+    "typecheck": "tsc --build --force",
+    "test": "TZ=Europe/London vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint packages --ext .ts,.tsx",
+    "clean": "rm -rf packages/*/dist packages/*/tsconfig.tsbuildinfo"
+  },
+  "devDependencies": {
+    "@types/chrome": "^0.0.268",
+    "@types/node": "^20.14.0",
+    "typescript": "^5.5.4",
+    "vitest": "^2.0.5"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "lint": "eslint packages --ext .ts,.tsx",
     "clean": "rm -rf packages/*/dist packages/*/tsconfig.tsbuildinfo",
     "build:ui": "npm run build -w @switchydelta/ui",
-    "build:extension": "node scripts/build-extension.mjs"
+    "build:extension": "node scripts/build-extension.mjs",
+    "e2e": "node test/e2e/smoke.mjs dist && node test/e2e/profiles.mjs dist && node test/e2e/rule-list.mjs dist"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.268",

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -1,0 +1,66 @@
+{
+  "manifest_version": 3,
+  "name": "__MSG_manifest_app_name__",
+  "version": "3.0.0",
+  "description": "__MSG_manifest_app_description__",
+  "default_locale": "en",
+  "minimum_chrome_version": "109",
+
+  "icons": {
+    "16": "img/icons/omega-action-16.png",
+    "24": "img/icons/omega-action-24.png",
+    "32": "img/icons/omega-action-32.png",
+    "48": "img/icons/omega-48.png",
+    "64": "img/icons/omega-64.png",
+    "128": "img/icons/omega-128.png"
+  },
+
+  "action": {
+    "default_icon": {
+      "16": "img/icons/omega-action-16.png",
+      "19": "img/icons/omega-action-19.png",
+      "24": "img/icons/omega-action-24.png",
+      "32": "img/icons/omega-action-32.png"
+    },
+    "default_title": "__MSG_manifest_icon_default_title__",
+    "default_popup": "popup.html"
+  },
+
+  "background": {
+    "service_worker": "js/sw.js",
+    "type": "module"
+  },
+
+  "options_page": "options.html",
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": true
+  },
+
+  "permissions": [
+    "proxy",
+    "storage",
+    "unlimitedStorage",
+    "alarms",
+    "tabs",
+    "webRequest",
+    "webRequestAuthProvider"
+  ],
+
+  "host_permissions": ["<all_urls>"],
+
+  "commands": {
+    "_execute_action": {
+      "suggested_key": {
+        "default": "Alt+Shift+O"
+      }
+    }
+  },
+
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "switchydelta@madeye.github.io",
+      "strict_min_version": "109.0"
+    }
+  }
+}

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -4,8 +4,7 @@
   "version": "3.0.0",
   "description": "__MSG_manifest_app_description__",
   "default_locale": "en",
-  "minimum_chrome_version": "109",
-
+  "minimum_chrome_version": "114",
   "icons": {
     "16": "img/icons/omega-action-16.png",
     "24": "img/icons/omega-action-24.png",
@@ -14,7 +13,6 @@
     "64": "img/icons/omega-64.png",
     "128": "img/icons/omega-128.png"
   },
-
   "action": {
     "default_icon": {
       "16": "img/icons/omega-action-16.png",
@@ -25,18 +23,18 @@
     "default_title": "__MSG_manifest_icon_default_title__",
     "default_popup": "popup.html"
   },
-
   "background": {
     "service_worker": "js/sw.js",
     "type": "module"
   },
-
+  "side_panel": {
+    "default_path": "options.html"
+  },
   "options_page": "options.html",
   "options_ui": {
     "page": "options.html",
     "open_in_tab": true
   },
-
   "permissions": [
     "proxy",
     "storage",
@@ -44,11 +42,12 @@
     "alarms",
     "tabs",
     "webRequest",
-    "webRequestAuthProvider"
+    "webRequestAuthProvider",
+    "sidePanel"
   ],
-
-  "host_permissions": ["<all_urls>"],
-
+  "host_permissions": [
+    "<all_urls>"
+  ],
   "commands": {
     "_execute_action": {
       "suggested_key": {
@@ -56,7 +55,6 @@
       }
     }
   },
-
   "browser_specific_settings": {
     "gecko": {
       "id": "switchydelta@madeye.github.io",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@switchydelta/extension",
+  "version": "3.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Chromium MV3 service worker and platform bindings for SwitchyDelta",
+  "scripts": {
+    "build": "tsc --build",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@switchydelta/pac": "*",
+    "@switchydelta/target": "*"
+  }
+}

--- a/packages/extension/src/chrome-options.ts
+++ b/packages/extension/src/chrome-options.ts
@@ -7,8 +7,9 @@
  * and the SwitchySharp / external-extension bridges are not part of it.
  */
 
-import { Options, Log } from '@switchydelta/target';
+import { Options, Log, NoOptionsError } from '@switchydelta/target';
 import type { StorageItems } from '@switchydelta/target';
+import type { OmegaOptions } from '@switchydelta/target';
 import { Profiles } from '@switchydelta/pac';
 import type { Profile } from '@switchydelta/pac';
 
@@ -93,6 +94,29 @@ export class ChromeOptions extends Options {
           : profile.profileType;
         return chrome.i18n.getMessage('browserAction_profileDetails_' + type) || null;
       }
+    }
+  }
+
+  /**
+   * Treat entirely empty storage as a first run rather than a corrupt state.
+   *
+   * The base class only knows "unrecognised schemaVersion". In the previous
+   * build this translation lived in the SwitchySharp import path, which is not
+   * part of this design; without it, a fresh install took the generic error
+   * branch, so the firstRun state was never seeded and the options page never
+   * opened on install.
+   */
+  override async upgrade(
+    options: OmegaOptions | null | undefined,
+    changes?: StorageItems,
+  ): Promise<[OmegaOptions, StorageItems]> {
+    try {
+      return await super.upgrade(options, changes);
+    } catch (err) {
+      if (!options || Object.keys(options).length === 0) {
+        throw new NoOptionsError();
+      }
+      throw err;
     }
   }
 

--- a/packages/extension/src/chrome-options.ts
+++ b/packages/extension/src/chrome-options.ts
@@ -1,0 +1,115 @@
+/**
+ * Chromium bindings for the options controller.
+ *
+ * This build is deliberately minimal: the service worker exists to handle proxy
+ * authentication, to run scheduled downloads, and to apply the proxy. The
+ * per-tab icons, request monitor, context menus, quick-switch cycling, badge
+ * and the SwitchySharp / external-extension bridges are not part of it.
+ */
+
+import { Options, Log } from '@switchydelta/target';
+import type { StorageItems } from '@switchydelta/target';
+import { Profiles } from '@switchydelta/pac';
+import type { Profile } from '@switchydelta/pac';
+
+import { fetchUrl } from './fetch-url.js';
+
+export class ChromeOptions extends Options {
+  /** Alarm callbacks, keyed by the name passed to {@link schedule}. */
+  readonly #alarms = new Map<string, () => void>();
+  #alarmListenerInstalled = false;
+
+  override fetchUrl(
+    url: string,
+    bypassCache?: boolean,
+    typeHints?: string[],
+  ): Promise<string> {
+    return fetchUrl(url, bypassCache, typeHints);
+  }
+
+  /**
+   * Schedule a repeating callback.
+   *
+   * `chrome.alarms` is the only timer that survives the worker being
+   * suspended; a `setInterval` would die with it.
+   */
+  override async schedule(
+    name: string,
+    periodInMinutes: number,
+    callback: () => void,
+  ): Promise<void> {
+    const alarmName = 'omega.' + name;
+
+    if (periodInMinutes < 0) {
+      this.#alarms.delete(alarmName);
+      await chrome.alarms.clear(alarmName);
+      return;
+    }
+
+    this.#alarms.set(alarmName, callback);
+
+    if (!this.#alarmListenerInstalled) {
+      this.#alarmListenerInstalled = true;
+      chrome.alarms.onAlarm.addListener((alarm) => {
+        this.#alarms.get(alarm.name)?.();
+      });
+    }
+
+    await chrome.alarms.create(alarmName, { periodInMinutes });
+  }
+
+  /**
+   * Apply a map of changed top-level option keys.
+   *
+   * The UI sends this instead of a jsondiffpatch delta: options is a flat bag
+   * at the top level, and the delta was reduced to exactly this before being
+   * applied anyway. A key with an `undefined` value is a removal.
+   */
+  async applyChanges(changes: StorageItems): Promise<unknown> {
+    return this._setOptions(changes);
+  }
+
+  /** A human-readable description of a profile, for UI tooltips. */
+  override printProfile(profile: Profile): string | null {
+    if (!profile) return null;
+
+    switch (profile.profileType) {
+      case 'FixedProfile': {
+        const lines: string[] = [];
+        for (const scheme of Profiles.schemes) {
+          const proxy = (profile as Record<string, unknown>)[scheme.prop];
+          if (!proxy) continue;
+          const label = scheme.scheme || 'default';
+          lines.push(`${label}: ${Profiles.pacResult(proxy as never)}`);
+        }
+        return lines.length > 0 ? lines.join('\n') : chrome.i18n.getMessage('DirectProfile');
+      }
+      case 'PacProfile':
+      case 'AutoDetectProfile':
+        return (profile as { pacUrl?: string }).pacUrl ?? null;
+      default: {
+        const type = profile.profileType.endsWith('RuleListProfile')
+          ? 'RuleListProfile'
+          : profile.profileType;
+        return chrome.i18n.getMessage('browserAction_profileDetails_' + type) || null;
+      }
+    }
+  }
+
+  /** Open the options page the first time the extension runs. */
+  override onFirstRun(): void {
+    void chrome.tabs.create({ url: chrome.runtime.getURL('options.html') });
+  }
+
+  // Intentionally inert in this build. The base class calls these when the
+  // corresponding settings change; there is nothing here to drive.
+  override async setInspect(): Promise<void> {}
+  override async setMonitorWebRequests(): Promise<void> {}
+  override async setQuickSwitch(): Promise<void> {}
+
+  override currentProfileChanged(reason?: string): void {
+    Log.log('Options#currentProfileChanged', reason ?? '');
+  }
+}
+
+export default ChromeOptions;

--- a/packages/extension/src/chrome-options.ts
+++ b/packages/extension/src/chrome-options.ts
@@ -77,7 +77,7 @@ export class ChromeOptions extends Options {
       case 'FixedProfile': {
         const lines: string[] = [];
         for (const scheme of Profiles.schemes) {
-          const proxy = (profile as Record<string, unknown>)[scheme.prop];
+          const proxy = (profile as unknown as Record<string, unknown>)[scheme.prop];
           if (!proxy) continue;
           const label = scheme.scheme || 'default';
           lines.push(`${label}: ${Profiles.pacResult(proxy as never)}`);

--- a/packages/extension/src/chrome-storage.ts
+++ b/packages/extension/src/chrome-storage.ts
@@ -1,0 +1,197 @@
+/**
+ * A {@link Storage} backed by one `chrome.storage` area.
+ *
+ * Unlike `BrowserStorage`, keys are not prefixed: this is the area's whole
+ * contents, which is how the options bag is stored.
+ */
+
+import {
+  QuotaExceededError,
+  RateLimitExceededError,
+  Storage,
+  StorageUnavailableError,
+} from '@switchydelta/target';
+import type { StorageItems, Unwatch, WatchCallback } from '@switchydelta/target';
+
+interface Watcher {
+  /** null watches every key in the area. */
+  keys: Set<string> | null;
+  callback: WatchCallback;
+}
+
+const SUSTAINED_PER_MINUTE = 'MAX_SUSTAINED_WRITE_OPERATIONS_PER_MINUTE';
+
+/** Monotonic, so two watchers registered in the same tick cannot collide. */
+let nextWatcherId = 0;
+
+export class ChromeStorage extends Storage {
+  /** Watchers by area name, then by id. */
+  static readonly watchers: Record<string, Map<number, Watcher> | undefined> = {};
+  static onChangedListenerInstalled = false;
+
+  /**
+   * Translate a `chrome.runtime.lastError` message into one of the typed
+   * storage errors, so that callers can react to a quota or rate limit without
+   * matching on English prose.
+   */
+  static parseStorageErrors(err: unknown): Promise<never> {
+    const message = (err as { message?: unknown } | null | undefined)?.message;
+    if (typeof message !== 'string') return Promise.reject(err);
+
+    if (message.indexOf('QUOTA_BYTES_PER_ITEM') >= 0) {
+      const error = new QuotaExceededError(message);
+      error.perItem = true;
+      return Promise.reject(error);
+    }
+    if (message.indexOf('QUOTA_BYTES') >= 0) {
+      return Promise.reject(new QuotaExceededError(message));
+    }
+    if (message.indexOf('MAX_ITEMS') >= 0) {
+      const error = new QuotaExceededError(message);
+      error.maxItems = true;
+      return Promise.reject(error);
+    }
+    if (message.indexOf('MAX_WRITE_OPERATIONS_') >= 0) {
+      const error = new RateLimitExceededError(message);
+      // FIX: the original tested these on the freshly constructed error, whose
+      // message is empty, so neither flag was ever set.
+      if (message.indexOf('MAX_WRITE_OPERATIONS_PER_HOUR') >= 0) {
+        error.perHour = true;
+      } else if (message.indexOf('MAX_WRITE_OPERATIONS_PER_MINUTE') >= 0) {
+        error.perMinute = true;
+      }
+      return Promise.reject(error);
+    }
+    if (message.indexOf(SUSTAINED_PER_MINUTE) >= 0) {
+      const error = new RateLimitExceededError(message);
+      error.perMinute = true;
+      error.sustained = true;
+      return Promise.reject(error);
+    }
+    if (message.indexOf('is not available') >= 0) {
+      // Some Chromium-based browsers disable access to the sync storage.
+      return Promise.reject(new StorageUnavailableError(message));
+    }
+    if (message.indexOf('Please set webextensions.storage.sync.enabled to true') >= 0) {
+      // Sync storage disabled in flags.
+      return Promise.reject(new StorageUnavailableError(message));
+    }
+    return Promise.reject(err);
+  }
+
+  /** The single `onChanged` listener, shared by every instance and area. */
+  static readonly onChangedListener = (
+    changes: Record<string, chrome.storage.StorageChange>,
+    areaName: string,
+  ): void => {
+    const area = ChromeStorage.watchers[areaName];
+    if (!area) return;
+
+    // Built at most once per event, and only if something actually matches.
+    let map: StorageItems | null = null;
+    for (const watcher of area.values()) {
+      let match = watcher.keys === null;
+      if (!match) {
+        for (const key of Object.keys(changes)) {
+          if (watcher.keys?.has(key)) {
+            match = true;
+            break;
+          }
+        }
+      }
+      if (!match) continue;
+      if (map === null) {
+        map = {};
+        for (const [key, change] of Object.entries(changes)) {
+          map[key] = change.newValue;
+        }
+      }
+      watcher.callback(map);
+    }
+  };
+
+  readonly areaName: string;
+  private readonly _area: chrome.storage.StorageArea | undefined;
+
+  constructor(areaName: string) {
+    super();
+    this.areaName = areaName;
+    const areas = chrome.storage as unknown as Record<
+      string,
+      chrome.storage.StorageArea | undefined
+    >;
+    this._area = areas[areaName];
+  }
+
+  /**
+   * Run one area call. The promise form rejects on failure, but some hosts
+   * resolve and only report through `runtime.lastError`, so both are checked.
+   */
+  private async _run<T>(operation: (area: chrome.storage.StorageArea) => Promise<T>): Promise<T> {
+    const area = this._area;
+    if (!area) {
+      return ChromeStorage.parseStorageErrors(
+        new Error(`Storage area ${this.areaName} is not available`),
+      );
+    }
+    let result: T;
+    try {
+      result = await operation(area);
+    } catch (e) {
+      return ChromeStorage.parseStorageErrors(e);
+    }
+    const message = chrome.runtime?.lastError?.message;
+    if (message) return ChromeStorage.parseStorageErrors(new Error(message));
+    return result;
+  }
+
+  override get(keys?: string | string[] | null | StorageItems): Promise<StorageItems> {
+    return this._run((area) => area.get(keys ?? null));
+  }
+
+  override async set(items: StorageItems): Promise<StorageItems> {
+    if (Object.keys(items).length === 0) return {};
+    await this._run((area) => area.set(items));
+    return items;
+  }
+
+  override async remove(keys?: string | string[] | null): Promise<void> {
+    if (keys == null) {
+      await this._run((area) => area.clear());
+      return;
+    }
+    if (Array.isArray(keys) && keys.length === 0) return;
+    await this._run((area) => area.remove(keys));
+  }
+
+  override watch(keys: string | string[] | null, callback: WatchCallback): Unwatch {
+    let area = ChromeStorage.watchers[this.areaName];
+    if (!area) {
+      area = new Map();
+      ChromeStorage.watchers[this.areaName] = area;
+    }
+
+    let watchedKeys: Set<string> | null = null;
+    if (typeof keys === 'string') {
+      // FIX: the original only converted the array form, so a single string key
+      // was indexed character-wise and never matched anything.
+      watchedKeys = new Set([keys]);
+    } else if (Array.isArray(keys)) {
+      watchedKeys = new Set(keys);
+    }
+
+    const id = nextWatcherId++;
+    area.set(id, { keys: watchedKeys, callback });
+
+    if (!ChromeStorage.onChangedListenerInstalled) {
+      chrome.storage.onChanged.addListener(ChromeStorage.onChangedListener);
+      ChromeStorage.onChangedListenerInstalled = true;
+    }
+
+    return () => {
+      area.delete(id);
+    };
+  }
+}
+
+export default ChromeStorage;

--- a/packages/extension/src/fetch-url.ts
+++ b/packages/extension/src/fetch-url.ts
@@ -1,0 +1,141 @@
+/**
+ * Downloading of PAC scripts and rule lists.
+ *
+ * Replaces the `xhr` package with `fetch`, which is available in the MV3
+ * service worker and removes the dependency along with its
+ * `request`-style error shape.
+ */
+
+import {
+  ContentTypeRejectedError,
+  HttpError,
+  HttpNotFoundError,
+  HttpServerError,
+  NetworkError,
+} from '@switchydelta/target';
+
+interface Response_ {
+  contentType: string;
+  body: string;
+}
+
+/**
+ * The media type without its parameters, lowercased.
+ *
+ * The CoffeeScript version compared the raw header against the hint, so
+ * `text/html; charset=utf-8` never equalled `text/html`. Since servers almost
+ * always send a charset, the "response must not be HTML" guard silently never
+ * fired and HTML error pages were accepted as rule lists.
+ */
+function mediaType(header: string | null): string {
+  return (header ?? '').split(';')[0]!.trim().toLowerCase();
+}
+
+async function request(url: string): Promise<Response_> {
+  let response: Response;
+  try {
+    response = await fetch(url, { credentials: 'omit', redirect: 'follow' });
+  } catch (e) {
+    // fetch only rejects for transport-level failures.
+    throw new NetworkError(e);
+  }
+
+  if (!response.ok) {
+    const detail = { statusCode: response.status };
+    if (response.status === 404) throw new HttpNotFoundError(detail);
+    if (response.status >= 500 && response.status < 600) throw new HttpServerError(detail);
+    throw new HttpError(detail);
+  }
+
+  return {
+    contentType: mediaType(response.headers.get('content-type')),
+    body: await response.text(),
+  };
+}
+
+type HintHandler = (res: Response_, hint: string) => string | undefined;
+
+function looksLikeHtml(body: string): boolean {
+  return (
+    body.indexOf('<!DOCTYPE') >= 0 ||
+    body.indexOf('<!doctype') >= 0 ||
+    body.indexOf('</html>') >= 0 ||
+    body.indexOf('</body>') >= 0
+  );
+}
+
+const rejectHtml: HintHandler = (res, hint) => {
+  if (res.contentType !== hint.substring(1)) return undefined;
+  // Other content is sometimes served as text/html, so only reject when the
+  // body really does look like markup.
+  if (looksLikeHtml(res.body)) {
+    throw new ContentTypeRejectedError('Response must not be HTML.');
+  }
+  return undefined;
+};
+
+const hintHandlers: Record<string, HintHandler> = {
+  '*': (res) => res.body,
+
+  '!text/html': rejectHtml,
+  '!application/xhtml+xml': rejectHtml,
+
+  'application/x-ns-proxy-autoconfig': (res, hint) => {
+    if (res.contentType === hint) return res.body;
+    // PAC scripts are frequently served with the wrong Content-Type, so fall
+    // back to looking for the entry point the script must define.
+    return res.body.indexOf('FindProxyForURL') >= 0 ? res.body : undefined;
+  },
+};
+
+/**
+ * A hint is either a media type to accept or, prefixed with `!`, one to reject.
+ * Hints are tried in order; the first to return a body wins.
+ */
+const defaultHintHandler: HintHandler = (res, hint) => {
+  if (hint.startsWith('!')) {
+    if (res.contentType === hint.substring(1)) {
+      throw new ContentTypeRejectedError('Response Content-Type blacklisted: ' + res.contentType);
+    }
+    return undefined;
+  }
+  return res.contentType === hint ? res.body : undefined;
+};
+
+function bodyForHints(res: Response_, typeHints?: string[]): string {
+  if (!typeHints || typeHints.length === 0) return res.body;
+
+  for (const hint of typeHints) {
+    const handler = hintHandlers[hint] ?? defaultHintHandler;
+    const result = handler(res, hint);
+    if (result !== undefined) return result;
+  }
+  throw new ContentTypeRejectedError('Unrecognized Content-Type: ' + res.contentType);
+}
+
+/**
+ * Fetch a URL, optionally defeating the HTTP cache.
+ *
+ * Cache busting appends a throwaway query parameter, and only when the URL has
+ * no query of its own, so that servers reading their own parameters are not
+ * disturbed. If that request fails the original URL is tried, since some
+ * servers reject unexpected parameters outright.
+ */
+export async function fetchUrl(
+  destUrl: string,
+  bypassCache?: boolean,
+  typeHints?: string[],
+): Promise<string> {
+  if (bypassCache && destUrl.indexOf('?') < 0) {
+    const url = new URL(destUrl);
+    url.searchParams.set('_', String(Date.now()));
+    try {
+      return bodyForHints(await request(url.href), typeHints);
+    } catch {
+      return bodyForHints(await request(destUrl), typeHints);
+    }
+  }
+  return bodyForHints(await request(destUrl), typeHints);
+}
+
+export default fetchUrl;

--- a/packages/extension/src/proxy-auth.ts
+++ b/packages/extension/src/proxy-auth.ts
@@ -1,0 +1,379 @@
+/**
+ * Proxy authentication for the MV3 service worker.
+ *
+ * The worker is torn down and restarted at will, and a proxy auth challenge is
+ * one of the events that wakes it. Two things follow, and they shape this whole
+ * file:
+ *
+ *  - The `onAuthRequired` listener has to be registered synchronously during
+ *    worker startup, before anything is loaded from storage. A listener
+ *    attached at the end of an async boot is registered too late to see the
+ *    event that caused the wake-up.
+ *  - The credentials themselves therefore cannot live only in memory. They are
+ *    written to storage whenever a profile is applied and read back on demand.
+ *
+ * Hence the module-level singleton: startup registers the listener on it, and
+ * the later async boot fills in the credentials on the same object.
+ */
+
+import { Profiles } from '@switchydelta/pac';
+import type {
+  FixedProfile,
+  Profile,
+  ProxyAuth as ProxyCredentials,
+  ProxyServer,
+} from '@switchydelta/pac';
+import type { Logger } from '@switchydelta/target';
+
+const STORAGE_KEY = 'omegaProxyAuth';
+
+/** One candidate credential for a challenge. Fallbacks carry no `config`. */
+interface AuthEntry {
+  config?: ProxyServer;
+  auth: ProxyCredentials;
+  name: string;
+}
+
+/** What gets persisted; must stay plain JSON. */
+interface AuthPayload {
+  proxies: Record<string, AuthEntry[] | undefined>;
+  fallbacks: AuthEntry[];
+}
+
+/** Credentials in the shape a `{user, pass}`-era options file may still hold. */
+interface LegacyAuth {
+  username?: string;
+  password?: string;
+  user?: string;
+  pass?: string;
+}
+
+type AreaName = 'session' | 'local';
+
+function storageArea(name: AreaName): chrome.storage.StorageArea | undefined {
+  if (typeof chrome === 'undefined' || !chrome.storage) return undefined;
+  return chrome.storage[name];
+}
+
+/** See {@link ProxyAuth.shared}. */
+let sharedInstance: ProxyAuth | null = null;
+
+export class ProxyAuth {
+  /**
+   * The single instance the worker registers its listener on.
+   *
+   * Everything must go through this: a second instance would register a second
+   * listener holding a different credential map, and which of the two answered
+   * a challenge would depend on registration order.
+   */
+  static shared(log?: Logger | null): ProxyAuth {
+    const instance = sharedInstance ?? new ProxyAuth(log);
+    if (log) instance.log = log;
+    return instance;
+  }
+
+  log: Logger | null;
+  listening = false;
+
+  /** Per-request state, keyed by requestId; see {@link _credentialsFor}. */
+  private _requests: Record<string, { authTries: number } | undefined> = {};
+  private _proxies: Record<string, AuthEntry[] | undefined> = {};
+  private _fallbacks: AuthEntry[] = [];
+  private _hydrated = false;
+  private _hydratePromise: Promise<void> | null = null;
+
+  constructor(log?: Logger | null) {
+    this.log = log ?? null;
+    sharedInstance = this;
+  }
+
+  /**
+   * Register the auth listeners. Idempotent, because startup and the first
+   * `applyProfile` both call it and neither knows about the other.
+   */
+  listen(): void {
+    if (this.listening) return;
+    if (!chrome.webRequest) {
+      this.log?.error('Proxy auth disabled! No webRequest permission.');
+      return;
+    }
+    if (!chrome.webRequest.onAuthRequired) {
+      this.log?.error('Proxy auth disabled! onAuthRequired not available.');
+      return;
+    }
+
+    const handler = (
+      details: chrome.webRequest.WebAuthenticationChallengeDetails,
+      asyncCallback?: (response: chrome.webRequest.BlockingResponse) => void,
+    ) => this.authHandler(details, asyncCallback);
+
+    // asyncBlocking is the MV3 form (it needs the webRequestAuthProvider
+    // permission) and is the only one that allows answering a challenge after
+    // an await. Older hosts only understand blocking, and reject the unknown
+    // extraInfoSpec by throwing.
+    try {
+      chrome.webRequest.onAuthRequired.addListener(handler, { urls: ['<all_urls>'] }, [
+        'asyncBlocking',
+      ]);
+    } catch (err) {
+      this.log?.error('asyncBlocking onAuthRequired failed; trying blocking.', err);
+      chrome.webRequest.onAuthRequired.addListener(handler, { urls: ['<all_urls>'] }, [
+        'blocking',
+      ]);
+    }
+
+    chrome.webRequest.onCompleted.addListener((details) => this._requestDone(details), {
+      urls: ['<all_urls>'],
+    });
+    chrome.webRequest.onErrorOccurred.addListener((details) => this._requestDone(details), {
+      urls: ['<all_urls>'],
+    });
+    this.listening = true;
+
+    // Warm the credentials from the last applyProfile so that the common case
+    // does not have to wait for storage inside the challenge handler.
+    void this._hydrate();
+  }
+
+  private _payload(): AuthPayload {
+    return { proxies: this._proxies, fallbacks: this._fallbacks };
+  }
+
+  private _applyPayload(data: AuthPayload | null | undefined): boolean {
+    if (!data) return false;
+    this._proxies = data.proxies || {};
+    this._fallbacks = data.fallbacks || [];
+    return true;
+  }
+
+  /**
+   * Write to both session and local storage.
+   *
+   * Session storage covers worker restarts within a browser session and is
+   * never written to disk. Local storage covers a full browser restart, where
+   * the first proxied request can easily beat `Options.init` to re-applying the
+   * profile — without it, that request would get no credentials at all.
+   */
+  private _persist(): void {
+    const payload = { [STORAGE_KEY]: this._payload() };
+    for (const areaName of ['session', 'local'] as const) {
+      const area = storageArea(areaName);
+      if (!area) continue;
+      try {
+        void Promise.resolve(area.set(payload)).catch(() => undefined);
+      } catch {
+        // A storage area that throws synchronously is unusable; the in-memory
+        // credentials still work for as long as this worker lives.
+      }
+    }
+  }
+
+  private async _getFromArea(areaName: AreaName): Promise<AuthPayload | null> {
+    const area = storageArea(areaName);
+    if (!area) return null;
+    try {
+      const items = await area.get(STORAGE_KEY);
+      if (chrome.runtime?.lastError) return null;
+      return (items?.[STORAGE_KEY] as AuthPayload | undefined) ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Load persisted credentials once, preferring session storage.
+   *
+   * Concurrent callers share one read: several challenges can arrive back to
+   * back on the same wake-up.
+   */
+  private _hydrate(): Promise<void> {
+    if (this._hydrated) return Promise.resolve();
+    if (this._hydratePromise) return this._hydratePromise;
+
+    this._hydratePromise = (async () => {
+      try {
+        let data = await this._getFromArea('session');
+        if (!data) {
+          data = await this._getFromArea('local');
+          // Mirror local into session so later wake-ups in this browser session
+          // take the cheap path and stop touching disk.
+          const session = data ? storageArea('session') : undefined;
+          if (session) {
+            try {
+              void Promise.resolve(session.set({ [STORAGE_KEY]: data })).catch(() => undefined);
+            } catch {
+              // Ignore; the local copy is still authoritative.
+            }
+          }
+        }
+        this._applyPayload(data);
+      } catch {
+        // Never let a storage failure hold a challenge open forever; without
+        // credentials the request simply fails to authenticate.
+      } finally {
+        this._hydrated = true;
+        this._hydratePromise = null;
+      }
+    })();
+    return this._hydratePromise;
+  }
+
+  private _keyForProxy(proxy: { host?: string; port: number | undefined }): string {
+    const host = (proxy.host || '').toLowerCase();
+    return `${host}:${String(proxy.port)}`;
+  }
+
+  /**
+   * The keys a challenge may be stored under.
+   *
+   * Chromium reports IPv6 challengers in bracketed form (`[::1]`) while the
+   * profile stores the bare address, so both spellings are tried.
+   */
+  private _keysForChallenger(challenger: { host?: string; port: number | undefined }): string[] {
+    const host = (challenger.host || '').toLowerCase();
+    const port = challenger.port;
+    const keys = [`${host}:${String(port)}`];
+    if (host.length >= 2 && host[0] === '[' && host[host.length - 1] === ']') {
+      keys.push(`${host.substring(1, host.length - 1)}:${String(port)}`);
+    }
+    return keys;
+  }
+
+  /** Rebuild the credential map from the profiles the current profile uses. */
+  setProxies(profiles: Profile[]): void {
+    this._proxies = {};
+    this._fallbacks = [];
+
+    for (const profile of profiles) {
+      // Only FixedProfile carries `auth`, but the check stays value-based so
+      // that an unexpected profile type with credentials is still honoured.
+      const profileAuth = (profile as FixedProfile).auth;
+      if (!profileAuth) continue;
+
+      for (const scheme of Profiles.schemes) {
+        const proxy = (profile as FixedProfile)[scheme.prop];
+        if (!proxy) continue;
+        const auth = profileAuth[scheme.prop];
+        if (!auth?.username) continue;
+        const key = this._keyForProxy(proxy);
+        let list = this._proxies[key];
+        if (!list) {
+          list = [];
+          this._proxies[key] = list;
+        }
+        list.push({
+          config: proxy,
+          auth: { username: auth.username, password: auth.password ?? '' },
+          name: profile.name + '.' + scheme.prop,
+        });
+      }
+
+      const fallback = profileAuth['all'];
+      if (fallback?.username) {
+        this._fallbacks.push({
+          auth: { username: fallback.username, password: fallback.password ?? '' },
+          name: profile.name + '.all',
+        });
+      }
+    }
+
+    this._hydrated = true;
+    this._persist();
+  }
+
+  private _normalizeAuth(auth: LegacyAuth | null | undefined): ProxyCredentials | null {
+    if (!auth) return null;
+    const username = auth.username ?? auth.user;
+    if (username == null) return null;
+    return { username, password: auth.password ?? auth.pass ?? '' };
+  }
+
+  /**
+   * Pick the credentials for one challenge.
+   *
+   * Chromium re-fires `onAuthRequired` for the same requestId when the
+   * credentials are rejected, so `authTries` walks the candidates registered
+   * for the challenged proxy and then the profile-wide fallbacks, one per
+   * attempt, instead of replying with the same rejected password forever.
+   */
+  private _credentialsFor(
+    details: chrome.webRequest.WebAuthenticationChallengeDetails,
+  ): chrome.webRequest.BlockingResponse {
+    if (!details.isProxy) return {};
+    let req = this._requests[details.requestId];
+    if (!req) {
+      req = { authTries: 0 };
+      this._requests[details.requestId] = req;
+    }
+
+    let list: AuthEntry[] | undefined;
+    let key: string | undefined;
+    for (const k of this._keysForChallenger(details.challenger)) {
+      if (this._proxies[k]) {
+        list = this._proxies[k];
+        key = k;
+        break;
+      }
+    }
+    key ??= this._keyForProxy(details.challenger);
+    list ??= this._proxies[key];
+
+    const listLen = list ? list.length : 0;
+    const entry =
+      req.authTries < listLen
+        ? list?.[req.authTries]
+        : this._fallbacks[req.authTries - listLen];
+    this.log?.log('ProxyAuth', key, req.authTries, entry?.name);
+
+    if (!entry) return {};
+    const credentials = this._normalizeAuth(entry.auth);
+    if (!credentials) return {};
+    req.authTries++;
+    return { authCredentials: credentials };
+  }
+
+  /**
+   * @param asyncCallback present only when registered with `asyncBlocking`.
+   */
+  authHandler(
+    details: chrome.webRequest.WebAuthenticationChallengeDetails,
+    asyncCallback?: (response: chrome.webRequest.BlockingResponse) => void,
+  ): chrome.webRequest.BlockingResponse | undefined {
+    const respond = (
+      result: chrome.webRequest.BlockingResponse,
+    ): chrome.webRequest.BlockingResponse | undefined => {
+      if (typeof asyncCallback === 'function') {
+        asyncCallback(result);
+        return undefined;
+      }
+      return result;
+    };
+
+    if (!details.isProxy) return respond({});
+
+    // Fast path: credentials are already in memory.
+    if (this._hydrated) return respond(this._credentialsFor(details));
+
+    // The worker has just woken up. Only asyncBlocking lets us answer after
+    // reading storage; in plain blocking mode there is nothing to wait with.
+    if (typeof asyncCallback === 'function') {
+      void this._hydrate().then(
+        () => {
+          respond(this._credentialsFor(details));
+        },
+        () => {
+          respond({});
+        },
+      );
+      return undefined;
+    }
+
+    return respond(this._credentialsFor(details));
+  }
+
+  private _requestDone(details: { requestId: string }): void {
+    delete this._requests[details.requestId];
+  }
+}
+
+export default ProxyAuth;

--- a/packages/extension/src/proxy-settings.ts
+++ b/packages/extension/src/proxy-settings.ts
@@ -1,0 +1,192 @@
+/**
+ * Programming the browser proxy through `chrome.proxy.settings`.
+ *
+ * This is the only `ProxyImpl` in the Chromium build: the script-based and
+ * listener-based implementations existed for Firefox and are gone, as is the
+ * on-demand `importScripts` of a separate PAC compiler bundle — `PacGenerator`
+ * now emits compact script text directly.
+ */
+
+import { Conditions, PacGenerator, Profiles } from '@switchydelta/pac';
+import type {
+  BypassCondition,
+  FixedProfile,
+  OptionsBag,
+  Profile,
+  ProxyServer,
+} from '@switchydelta/pac';
+import { Log } from '@switchydelta/target';
+import type { Logger } from '@switchydelta/target';
+
+import { ProxyAuth } from './proxy-auth.js';
+
+const PROTOCOLS = ['proxyForHttp', 'proxyForHttps', 'proxyForFtp'] as const;
+
+/**
+ * `chrome.proxy.settings` is a ChromeSetting, which has no promise form, so
+ * these keep the callback and translate `runtime.lastError` into a rejection.
+ */
+function settingsSet(details: chrome.types.ChromeSettingSetDetails): Promise<void> {
+  return new Promise((resolve, reject) => {
+    chrome.proxy.settings.set(details, () => {
+      const error = chrome.runtime.lastError;
+      if (error) reject(new Error(error.message));
+      else resolve();
+    });
+  });
+}
+
+function settingsClear(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    chrome.proxy.settings.clear({}, () => {
+      const error = chrome.runtime.lastError;
+      if (error) reject(new Error(error.message));
+      else resolve();
+    });
+  });
+}
+
+/**
+ * Structurally conforms to the `ProxyImpl` interface in `@switchydelta/target`
+ * (`options.ts`), which is not re-exported from that package's entry point.
+ */
+export class ProxySettings {
+  static isSupported(): boolean {
+    return typeof chrome !== 'undefined' && chrome.proxy?.settings != null;
+  }
+
+  readonly features: readonly string[] = ['fullUrlHttp', 'pacScript'];
+
+  log: Logger;
+
+  constructor(log?: Logger | null) {
+    this.log = log ?? Log;
+  }
+
+  async applyProfile(
+    profile: Profile,
+    meta?: Profile | null,
+    options?: OptionsBag | null,
+  ): Promise<void> {
+    // `meta` identified the profile in the PAC magic comment, which no longer
+    // exists; the parameter stays for the ProxyImpl signature.
+    void meta;
+    const opts = options ?? {};
+
+    if (profile.profileType === 'SystemProfile') {
+      // Clear proxy settings, returning proxy control to Chromium.
+      await settingsClear();
+      return;
+    }
+
+    let config: chrome.proxy.ProxyConfig;
+    if (profile.profileType === 'DirectProfile') {
+      config = { mode: 'direct' };
+    } else if (profile.profileType === 'PacProfile') {
+      config = {
+        mode: 'pac_script',
+        pacScript:
+          !profile.pacScript || Profiles.isFileUrl(profile.pacUrl)
+            ? { url: profile.pacUrl, mandatory: true }
+            : { data: PacGenerator.ascii(profile.pacScript), mandatory: true },
+      };
+    } else if (profile.profileType === 'FixedProfile') {
+      config = this._fixedProfileConfig(profile);
+    } else {
+      config = {
+        mode: 'pac_script',
+        pacScript: { mandatory: true, data: this.getProfilePacScript(profile, opts) },
+      };
+    }
+
+    await this.setProxyAuth(profile, opts);
+    await settingsSet({ value: config });
+  }
+
+  private _fixedProfileConfig(profile: FixedProfile): chrome.proxy.ProxyConfig {
+    const rules: chrome.proxy.ProxyRules = {};
+    let protocolProxySet = false;
+    for (const protocol of PROTOCOLS) {
+      const proxy = profile[protocol];
+      if (proxy) {
+        rules[protocol] = proxy;
+        protocolProxySet = true;
+      }
+    }
+
+    let mode = 'fixed_servers';
+    const fallback: ProxyServer | undefined = profile.fallbackProxy;
+    if (fallback) {
+      if (fallback.scheme === 'http') {
+        // Chromium refuses an HTTP proxy in `rules.fallbackProxy`: that slot is
+        // for the non-per-protocol catch-all, which it only accepts as SOCKS or
+        // HTTPS. The equivalent configuration therefore has to be expressed
+        // per protocol instead — as `singleProxy` when nothing else is set, or
+        // by filling every empty protocol slot with the same server.
+        if (!protocolProxySet) {
+          rules.singleProxy = fallback;
+        } else {
+          for (const protocol of PROTOCOLS) {
+            rules[protocol] ??= { ...fallback };
+          }
+        }
+      } else {
+        rules.fallbackProxy = fallback;
+      }
+    } else if (!protocolProxySet) {
+      mode = 'direct';
+    }
+
+    if (mode === 'direct') return { mode };
+
+    // FIX: `bypassList` is optional on a FixedProfile; the original iterated it
+    // unguarded and threw on a profile that had never had one.
+    rules.bypassList = (profile.bypassList ?? []).map((condition) =>
+      this._formatBypassItem(condition),
+    );
+    return { mode, rules };
+  }
+
+  /** Chromium wants the bare pattern, not the `Bypass: ` prefixed rule line. */
+  private _formatBypassItem(condition: BypassCondition): string {
+    const str = Conditions.str(condition);
+    const i = str.indexOf(' ');
+    return str.substring(i + 1);
+  }
+
+  private _profileNotFound(name: string): Profile {
+    this.log.error(`Profile ${name} not found! Things may go very, very wrong.`);
+    return Profiles.create({
+      name,
+      profileType: 'VirtualProfile',
+      defaultProfileName: 'direct',
+    } as Profile);
+  }
+
+  /**
+   * Hand the credentials of every profile this one depends on to the auth
+   * singleton, which the service worker has already attached its listener to.
+   */
+  async setProxyAuth(profile: Profile, options: OptionsBag): Promise<void> {
+    const proxyAuth = ProxyAuth.shared(this.log);
+    proxyAuth.listen();
+
+    const referenced: Profile[] = [];
+    const refSet = Profiles.allReferenceSet(profile, options, {
+      profileNotFound: (name) => this._profileNotFound(name),
+    });
+    for (const name of Object.values(refSet)) {
+      const referencedProfile = Profiles.byName(name, options);
+      if (referencedProfile) referenced.push(referencedProfile);
+    }
+    proxyAuth.setProxies(referenced);
+  }
+
+  getProfilePacScript(profile: Profile, options: OptionsBag): string {
+    return PacGenerator.script(options, profile, {
+      profileNotFound: (name) => this._profileNotFound(name),
+    });
+  }
+}
+
+export default ProxySettings;

--- a/packages/extension/src/sw.ts
+++ b/packages/extension/src/sw.ts
@@ -1,0 +1,122 @@
+/**
+ * MV3 service worker entry point.
+ *
+ * Responsibilities in this build, and nothing more:
+ *   - proxy authentication (the only context where onAuthRequired can live)
+ *   - scheduled PAC / rule-list downloads, via chrome.alarms
+ *   - applying the selected profile to chrome.proxy.settings
+ *   - answering RPC from the options page and popup
+ *
+ * The worker is event-driven and is expected to be suspended when idle. Nothing
+ * here may assume it stays resident.
+ */
+
+import { BrowserStorage, OptionsSync, Options, Log } from '@switchydelta/target';
+import type { StorageItems } from '@switchydelta/target';
+
+import { ChromeOptions } from './chrome-options.js';
+import { ChromeStorage } from './chrome-storage.js';
+import { ProxyAuth } from './proxy-auth.js';
+import { ProxySettings } from './proxy-settings.js';
+
+/**
+ * Registered before anything async runs.
+ *
+ * MV3 delivers the event that woke the worker only if its listener was
+ * registered in the first turn of the event loop. Deferring this until boot()
+ * resolves would drop the auth challenge that started the worker.
+ */
+ProxyAuth.shared(Log).listen();
+
+/** An Error flattened for structured cloning back to the UI. */
+function encodeError(value: unknown): unknown {
+  if (!(value instanceof Error)) return value;
+  return {
+    _error: 'error',
+    name: value.name,
+    message: value.message,
+    stack: value.stack,
+    original: (value as Error & { original?: unknown }).original,
+  };
+}
+
+let options: ChromeOptions | undefined;
+const state = new BrowserStorage('omega.local.');
+
+async function boot(): Promise<Options> {
+  const storage = new ChromeStorage('local');
+
+  // Sync is optional: it is absent when the browser has sync storage disabled.
+  let sync: OptionsSync | null = null;
+  if (chrome.storage.sync) {
+    sync = new OptionsSync(new ChromeStorage('sync'));
+    sync.transformValue = Options.transformValueForSync;
+    // Read the persisted preference before Options.init runs, so a first push
+    // cannot overwrite remote state that the user has not opted into syncing.
+    const { syncOptions } = await state.get({ syncOptions: '' });
+    sync.enabled = syncOptions === 'sync';
+  }
+
+  options = new ChromeOptions(null, storage, state, Log, sync, new ProxySettings());
+  await options.ready;
+  return options;
+}
+
+const ready = boot().catch((err: unknown) => {
+  Log.error('Service worker boot failed', err);
+  throw err;
+});
+
+/**
+ * RPC dispatcher.
+ *
+ * The UI sends `{method, args}` and expects `{result}` or `{error}`.
+ */
+chrome.runtime.onMessage.addListener((request, _sender, respond) => {
+  const { method, args = [], noReply } = (request ?? {}) as {
+    method?: string;
+    args?: unknown[];
+    noReply?: boolean;
+  };
+  if (!method) return false;
+
+  void (async () => {
+    try {
+      await ready;
+      const target = options;
+      if (!target) throw new Error('Options are not ready');
+
+      let result: unknown;
+      if (method === 'getState') {
+        result = await state.get(args[0] as string | string[] | StorageItems);
+      } else if (method === 'setState') {
+        result = await state.set(args[0] as StorageItems);
+      } else {
+        const fn = (target as unknown as Record<string, unknown>)[method];
+        if (typeof fn !== 'function') throw new Error(`No such method: ${method}`);
+        result = await (fn as (...a: unknown[]) => unknown).apply(target, args);
+      }
+
+      if (noReply) return;
+      // updateProfile resolves to a map that may contain Errors per profile.
+      if (method === 'updateProfile' && result && typeof result === 'object') {
+        const encoded: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(result)) {
+          encoded[key] = encodeError(value);
+        }
+        result = encoded;
+      }
+      respond({ result });
+    } catch (error) {
+      if (!noReply) respond({ error: encodeError(error) });
+    }
+  })();
+
+  // Keeps the message channel open for the async response.
+  return !noReply;
+});
+
+/** Reapply the current profile when the browser starts cold. */
+chrome.runtime.onStartup?.addListener(() => {
+  void ready.then(() => options?.applyProfile(options.currentProfile()?.name ?? 'system'));
+});

--- a/packages/extension/tsconfig.json
+++ b/packages/extension/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "lib": ["ES2022", "DOM", "WebWorker"],
+    "types": ["chrome"]
+  },
+  "include": ["src/**/*.ts"],
+  "references": [{ "path": "../pac" }, { "path": "../target" }]
+}

--- a/packages/pac/package.json
+++ b/packages/pac/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@switchydelta/pac",
+  "version": "3.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Profile, condition and PAC-script logic for SwitchyDelta",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./psl": {
+      "types": "./dist/psl.d.ts",
+      "default": "./dist/psl.js"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc --build",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "tldts": "^6.1.47"
+  }
+}

--- a/packages/pac/src/codegen.ts
+++ b/packages/pac/src/codegen.ts
@@ -1,0 +1,230 @@
+/**
+ * Minimal JavaScript code emitter for generated PAC scripts.
+ *
+ * This replaces the UglifyJS 2 AST that the CoffeeScript implementation used to
+ * build, compress and mangle. Because we control every byte of the generated
+ * output we can emit already-compact code directly, which makes a
+ * general-purpose minifier unnecessary and removes uglify-js (1.4 MB) from the
+ * extension entirely.
+ *
+ * Expressions carry their precedence so parentheses are inserted only where
+ * they are actually required.
+ */
+
+export const Prec = {
+  Lowest: 0,
+  Conditional: 3,
+  LogicalOr: 4,
+  LogicalAnd: 5,
+  Equality: 9,
+  Relational: 10,
+  Additive: 12,
+  Multiplicative: 13,
+  Unary: 15,
+  Call: 17,
+  Member: 18,
+  Primary: 20,
+} as const;
+
+export interface Expr {
+  readonly code: string;
+  readonly prec: number;
+}
+
+const BINARY_PREC: Record<string, number> = {
+  '||': Prec.LogicalOr,
+  '&&': Prec.LogicalAnd,
+  '===': Prec.Equality,
+  '!==': Prec.Equality,
+  '==': Prec.Equality,
+  '!=': Prec.Equality,
+  '<': Prec.Relational,
+  '<=': Prec.Relational,
+  '>': Prec.Relational,
+  '>=': Prec.Relational,
+  '+': Prec.Additive,
+  '-': Prec.Additive,
+  '*': Prec.Multiplicative,
+  '/': Prec.Multiplicative,
+  '%': Prec.Multiplicative,
+};
+
+/** Wrap `e` in parentheses when its precedence is looser than `min`. */
+function paren(e: Expr, min: number): string {
+  return e.prec < min ? `(${e.code})` : e.code;
+}
+
+export function raw(code: string, prec: number = Prec.Primary): Expr {
+  return { code, prec };
+}
+
+/**
+ * Emit a JavaScript string literal containing only printable ASCII.
+ *
+ * PAC scripts are handed to the browser's proxy resolver as bytes with no
+ * declared encoding, so every non-ASCII character is escaped. This folds in the
+ * separate `ascii()` post-processing pass the old generator needed.
+ */
+export function str(value: string): string {
+  let out = '"';
+  for (let i = 0; i < value.length; i++) {
+    const c = value.charCodeAt(i);
+    switch (c) {
+      case 0x22:
+        out += '\\"';
+        break;
+      case 0x5c:
+        out += '\\\\';
+        break;
+      case 0x0a:
+        out += '\\n';
+        break;
+      case 0x0d:
+        out += '\\r';
+        break;
+      case 0x09:
+        out += '\\t';
+        break;
+      default:
+        if (c < 0x20 || c > 0x7e) {
+          out += '\\u' + c.toString(16).padStart(4, '0');
+        } else {
+          out += value[i];
+        }
+    }
+  }
+  return out + '"';
+}
+
+export function string(value: string): Expr {
+  return raw(str(value));
+}
+
+export function num(value: number): Expr {
+  // Negative literals must be parenthesised so that `a-` + `-1` cannot glue
+  // into the decrement operator `--`.
+  return value < 0 ? raw(String(value), Prec.Unary) : raw(String(value));
+}
+
+export const TRUE: Expr = raw('true');
+export const FALSE: Expr = raw('false');
+
+export function bool(value: boolean): Expr {
+  return value ? TRUE : FALSE;
+}
+
+export function ref(name: string): Expr {
+  return raw(name);
+}
+
+/** A regular expression literal. Source is assumed slash-escaped already. */
+export function regexp(re: RegExp): Expr {
+  const source = re.source === '' ? '(?:)' : re.source;
+  return raw(`/${source}/${re.flags}`);
+}
+
+export function member(object: Expr, property: string): Expr {
+  return raw(`${paren(object, Prec.Member)}.${property}`, Prec.Member);
+}
+
+export function index(object: Expr, property: Expr): Expr {
+  return raw(`${paren(object, Prec.Member)}[${property.code}]`, Prec.Member);
+}
+
+export function call(callee: Expr, args: Expr[] = []): Expr {
+  const list = args.map((a) => a.code).join(',');
+  return raw(`${paren(callee, Prec.Call)}(${list})`, Prec.Call);
+}
+
+export function construct(callee: Expr, args: Expr[] = []): Expr {
+  const list = args.map((a) => a.code).join(',');
+  return raw(`new ${paren(callee, Prec.Member)}(${list})`, Prec.Call);
+}
+
+export function binary(op: string, left: Expr, right: Expr): Expr {
+  const prec = BINARY_PREC[op];
+  if (prec === undefined) throw new Error(`Unsupported operator: ${op}`);
+  // Left-associative: the right operand needs tighter binding to stay unwrapped.
+  return raw(`${paren(left, prec)}${op}${paren(right, prec + 1)}`, prec);
+}
+
+export function unary(op: string, operand: Expr): Expr {
+  // Word operators such as `typeof` need a separating space.
+  const sep = /[a-z]$/.test(op) ? ' ' : '';
+  return raw(`${op}${sep}${paren(operand, Prec.Unary)}`, Prec.Unary);
+}
+
+export function conditional(test: Expr, consequent: Expr, alternate: Expr): Expr {
+  return raw(
+    `${paren(test, Prec.Conditional + 1)}?${paren(consequent, Prec.Conditional)}:${paren(
+      alternate,
+      Prec.Conditional,
+    )}`,
+    Prec.Conditional,
+  );
+}
+
+/**
+ * A function expression. `body` is raw statement text.
+ *
+ * Precedence is reported as Lowest so that any use in expression position gets
+ * parenthesised, which also keeps it out of statement-start position where it
+ * would be parsed as a declaration.
+ */
+export function func(params: string[], body: string): Expr {
+  return raw(`function(${params.join(',')}){${body}}`, Prec.Lowest);
+}
+
+// --- Statements -------------------------------------------------------------
+
+export function ret(value: Expr): string {
+  return `return ${value.code};`;
+}
+
+export function ifThen(test: Expr, consequent: string): string {
+  return `if(${test.code}){${consequent}}`;
+}
+
+export function varDecl(name: string, value: Expr): string {
+  return `var ${name}=${value.code};`;
+}
+
+export function exprStmt(value: Expr): string {
+  return `${value.code};`;
+}
+
+export function doWhile(body: string, test: Expr): string {
+  return `do{${body}}while(${test.code});`;
+}
+
+/**
+ * A switch statement. A case with `test: null` is emitted as `default`.
+ */
+export function switchStmt(
+  discriminant: Expr,
+  cases: Array<{ test: Expr | null; body: string }>,
+): string {
+  const body = cases
+    .map((c) => (c.test === null ? `default:${c.body}` : `case ${c.test.code}:${c.body}`))
+    .join('');
+  return `switch(${discriminant.code}){${body}}`;
+}
+
+// --- Convenience builders used across condition/profile compilation ---------
+
+/** `subject.test(/regexp/)` — i.e. `/regexp/.test(subject)`. */
+export function regexTest(subject: string, re: RegExp): Expr {
+  return call(member(regexp(re), 'test'), [ref(subject)]);
+}
+
+/** `a && b && ...`, collapsing the trivial cases. */
+export function and(parts: Expr[]): Expr {
+  if (parts.length === 0) return TRUE;
+  return parts.reduce((acc, p) => binary('&&', acc, p));
+}
+
+/** `a || b || ...`, collapsing the trivial cases. */
+export function or(parts: Expr[]): Expr {
+  if (parts.length === 0) return FALSE;
+  return parts.reduce((acc, p) => binary('||', acc, p));
+}

--- a/packages/pac/src/conditions.ts
+++ b/packages/pac/src/conditions.ts
@@ -1,0 +1,650 @@
+/**
+ * Condition matching and PAC compilation.
+ *
+ * Every condition type provides `match` (evaluated in-process) and `compile`
+ * (emitted into the generated PAC script). The two must agree; the test suite
+ * asserts that for every fixture.
+ */
+
+import * as g from './codegen.js';
+import { escapeSlash, safeRegExp, shExp2RegExp } from './shexp.js';
+import { AttachedCache, unbracket } from './utils.js';
+import { formatIp, isInSubnet, netmask, parseIp, subnetSuffix, type IpAddress } from './ip.js';
+import type {
+  Condition,
+  ConditionType,
+  HostLevelsCondition,
+  IpCondition,
+  KeywordCondition,
+  PatternCondition,
+  Request,
+  TimeCondition,
+  WeekdayCondition,
+} from './types.js';
+
+const CHAR_COLON = ':'.charCodeAt(0);
+const CHAR_DOT = '.'.charCodeAt(0);
+
+/** Hosts that Chromium's `<local>` bypass token covers. */
+export const localHosts: readonly string[] = ['127.0.0.1', '[::1]', 'localhost'];
+
+interface AnalysisCache {
+  analyzed: unknown;
+  compiled?: g.Expr;
+}
+
+interface Handler<C extends Condition = Condition, A = unknown> {
+  abbrs: string[];
+  analyze(condition: C): A;
+  match(condition: C, request: Request, analyzed: A): boolean;
+  compile(condition: C, analyzed: A): g.Expr;
+  str?(condition: C): string;
+  fromStr?(text: string, condition: { conditionType: ConditionType }): Condition | null;
+  tag?(condition: C): string;
+}
+
+// --- Public API -------------------------------------------------------------
+
+/** Build a matcher request from a URL string or parsed URL. */
+export function requestFromUrl(url: string | URL): Request {
+  const parsed = typeof url === 'string' ? new URL(url) : url;
+  return {
+    url: parsed.href,
+    // PAC passes `host` unbracketed, so IPv6 literals are normalised to match.
+    host: unbracket(parsed.hostname),
+    scheme: parsed.protocol.replace(':', ''),
+  };
+}
+
+/**
+ * Reduce a `*://host/*` URL wildcard to the bare host wildcard, or undefined
+ * when the pattern is not of that shape.
+ */
+export function urlWildcard2HostWildcard(pattern: string): string | undefined {
+  const result = /^\*:\/\/((?:\w|[?*._\-])+)\/\*$/.exec(pattern);
+  return result?.[1];
+}
+
+export function tag(condition: Condition): string {
+  return condCache.tag(condition) as string;
+}
+
+export function analyze(condition: Condition): unknown {
+  return getCache(condition).analyzed;
+}
+
+export function match(condition: Condition, request: Request): boolean {
+  const cache = getCache(condition);
+  const handler = handlerFor(condition.conditionType);
+  return handler.match(condition, request, cache.analyzed);
+}
+
+export function compile(condition: Condition): g.Expr {
+  const cache = getCache(condition);
+  if (cache.compiled !== undefined) return cache.compiled;
+  const handler = handlerFor(condition.conditionType);
+  cache.compiled = handler.compile(condition, cache.analyzed);
+  return cache.compiled;
+}
+
+export interface StrOptions {
+  /**
+   * Which abbreviation to use. A number indexes into the type's abbreviation
+   * list (negative counts from the end, the default -1 being the longest,
+   * most readable form). A non-number uses the full condition type name.
+   */
+  abbr?: number | boolean;
+}
+
+/** Render a condition as a single rule-list line. */
+export function str(condition: Condition, options: StrOptions = { abbr: -1 }): string {
+  const handler = handlerFor(condition.conditionType);
+  const abbr = options.abbr ?? -1;
+
+  // Host wildcards have an empty abbreviation, so a plain pattern needs no
+  // prefix at all — unless it would be ambiguous with a typed line.
+  if (handler.abbrs[0]!.length === 0) {
+    const pattern = (condition as PatternCondition).pattern;
+    const endCode = pattern.charCodeAt(pattern.length - 1);
+    if (endCode !== CHAR_COLON && pattern.indexOf(' ') < 0) {
+      return pattern;
+    }
+  }
+
+  const typeStr =
+    typeof abbr === 'number'
+      ? handler.abbrs[(handler.abbrs.length + abbr) % handler.abbrs.length]!
+      : condition.conditionType;
+
+  const part = handler.str ? handler.str(condition) : (condition as PatternCondition).pattern;
+  return part ? `${typeStr}: ${part}` : `${typeStr}:`;
+}
+
+/** Parse a rule-list line back into a condition, or null if unrecognised. */
+export function fromStr(text: string): Condition | null {
+  let rest = text.trim();
+  let i = rest.indexOf(' ');
+  if (i < 0) i = rest.length;
+
+  let typeName: string;
+  if (rest.charCodeAt(i - 1) === CHAR_COLON) {
+    typeName = rest.substring(0, i - 1);
+    rest = rest.substring(i + 1).trim();
+  } else {
+    typeName = '';
+  }
+
+  const conditionType = typeFromAbbr(typeName);
+  if (!conditionType) return null;
+
+  const handler = handlerFor(conditionType);
+  if (handler.fromStr) {
+    return handler.fromStr(rest, { conditionType });
+  }
+  return { conditionType, pattern: rest } as Condition;
+}
+
+let abbrIndex: Map<string, ConditionType> | null = null;
+
+/** Resolve an abbreviation (case-insensitive) to a condition type. */
+export function typeFromAbbr(abbr: string): ConditionType | undefined {
+  if (abbrIndex === null) {
+    abbrIndex = new Map();
+    for (const [type, handler] of Object.entries(handlers) as Array<[ConditionType, Handler]>) {
+      abbrIndex.set(type.toUpperCase(), type);
+      for (const ab of handler.abbrs) {
+        abbrIndex.set(ab.toUpperCase(), type);
+      }
+    }
+  }
+  return abbrIndex.get(abbr.toUpperCase());
+}
+
+/** The seven-day enabled flags of a weekday condition. */
+export function getWeekdayList(condition: WeekdayCondition): boolean[] {
+  const result: boolean[] = [];
+  for (let i = 0; i < 7; i++) {
+    if (condition.days) {
+      result.push(condition.days.charCodeAt(i) > 64);
+    } else {
+      result.push((condition.startDay ?? 0) <= i && i <= (condition.endDay ?? 0));
+    }
+  }
+  return result;
+}
+
+export { parseIp };
+
+/** Canonical text form of a parsed address. */
+export function normalizeIp(address: IpAddress): string {
+  return formatIp(address);
+}
+
+// --- Internals --------------------------------------------------------------
+
+const condCache = new AttachedCache<Condition, AnalysisCache>((condition) => {
+  const handler = handlerFor(condition.conditionType);
+  const result = handler.tag ? handler.tag(condition) : str(condition);
+  return condition.conditionType + '$' + result;
+});
+
+function getCache(condition: Condition): AnalysisCache {
+  return condCache.get(condition, () => ({
+    analyzed: handlerFor(condition.conditionType).analyze(condition),
+  }));
+}
+
+function handlerFor(conditionType: ConditionType | Condition): Handler {
+  const name = typeof conditionType === 'string' ? conditionType : conditionType.conditionType;
+  const handler = (handlers as Record<string, Handler | undefined>)[name];
+  if (handler === undefined) throw new Error(`Unknown condition type: ${name}`);
+  return handler;
+}
+
+/**
+ * A numeric range test, specialised for compactness.
+ *
+ * A single value collapses to `===`, an empty range to `false`, and a short
+ * integer range to a character-table lookup, which is both shorter and faster
+ * than two comparisons in the PAC interpreter.
+ */
+function between(value: g.Expr, min: number, max: number): g.Expr {
+  if (min === max) {
+    return g.binary('===', value, g.num(min));
+  }
+  if (min > max) {
+    return g.FALSE;
+  }
+  if (Number.isInteger(min) && Number.isInteger(max) && max - min < 32) {
+    const template = '0123456789abcdefghijklmnopqrstuvwxyz';
+    const table =
+      max < template.length
+        ? template.substring(min, max + 1)
+        : template.substring(0, max - min + 1);
+    const pos = min === 0 ? value : g.binary('-', value, g.num(min));
+    return g.binary('>', g.call(g.member(g.string(table), 'charCodeAt'), [pos]), g.num(0));
+  }
+  return g.and([g.binary('<=', g.num(min), value), g.binary('<=', value, g.num(max))]);
+}
+
+interface BypassAnalysis {
+  host: string | RegExp | null;
+  ip: IpCondition | null;
+  scheme: string | null;
+  url: RegExp | null;
+  port: string | null;
+  normalizedPattern: string;
+}
+
+interface IpAnalysis {
+  addr: IpAddress;
+  normalized: string;
+  mask: string;
+}
+
+const handlers = {
+  TrueCondition: {
+    abbrs: ['True'],
+    analyze: () => null,
+    match: () => true,
+    compile: () => g.TRUE,
+    str: () => '',
+    fromStr: (_text, condition) => condition as Condition,
+  } satisfies Handler<Condition, null>,
+
+  FalseCondition: {
+    abbrs: ['False', 'Disabled'],
+    analyze: () => null,
+    match: () => false,
+    compile: () => g.FALSE,
+    fromStr: (text, condition) => {
+      if (text.length > 0) {
+        (condition as PatternCondition).pattern = text;
+      }
+      return condition as Condition;
+    },
+  } satisfies Handler<Condition, null>,
+
+  UrlRegexCondition: {
+    abbrs: ['UR', 'URegex', 'UrlR', 'UrlRegex'],
+    analyze: (condition) => safeRegExp(escapeSlash(condition.pattern)),
+    match: (_condition, request, analyzed) => analyzed.test(request.url),
+    compile: (_condition, analyzed) => g.regexTest('url', analyzed),
+  } satisfies Handler<PatternCondition, RegExp>,
+
+  UrlWildcardCondition: {
+    abbrs: ['U', 'UW', 'Url', 'UrlW', 'UWild', 'UWildcard', 'UrlWild', 'UrlWildcard'],
+    analyze: (condition) => {
+      const parts = condition.pattern
+        .split('|')
+        .filter((pattern) => pattern)
+        .map((pattern) => shExp2RegExp(pattern, { trimAsterisk: true }));
+      return safeRegExp(parts.join('|'));
+    },
+    match: (_condition, request, analyzed) => analyzed.test(request.url),
+    compile: (_condition, analyzed) => g.regexTest('url', analyzed),
+  } satisfies Handler<PatternCondition, RegExp>,
+
+  HostRegexCondition: {
+    abbrs: ['R', 'HR', 'Regex', 'HostR', 'HRegex', 'HostRegex'],
+    analyze: (condition) => safeRegExp(escapeSlash(condition.pattern)),
+    match: (_condition, request, analyzed) => analyzed.test(request.host),
+    compile: (_condition, analyzed) => g.regexTest('host', analyzed),
+  } satisfies Handler<PatternCondition, RegExp>,
+
+  HostWildcardCondition: {
+    abbrs: [
+      '',
+      'H',
+      'W',
+      'HW',
+      'Wild',
+      'Wildcard',
+      'Host',
+      'HostW',
+      'HWild',
+      'HWildcard',
+      'HostWild',
+      'HostWildcard',
+    ],
+    analyze: (condition) => {
+      const parts = condition.pattern
+        .split('|')
+        .filter((pattern) => pattern)
+        .map((pattern) => hostWildcardToRegExpSource(pattern));
+      return safeRegExp(parts.join('|'));
+    },
+    match: (_condition, request, analyzed) => analyzed.test(request.host),
+    compile: (_condition, analyzed) => g.regexTest('host', analyzed),
+  } satisfies Handler<PatternCondition, RegExp>,
+
+  BypassCondition: {
+    abbrs: ['B', 'Bypass'],
+    // See https://developer.chrome.com/docs/extensions/reference/api/proxy
+    analyze: (condition): BypassAnalysis => analyzeBypass(condition.pattern),
+    match: (_condition, request, analyzed) => {
+      if (analyzed.scheme !== null && analyzed.scheme !== request.scheme) return false;
+      if (analyzed.ip !== null && !match(analyzed.ip, request)) return false;
+      if (analyzed.host !== null) {
+        if (analyzed.host === '<local>') {
+          // Align with Chromium, which bypasses 127.0.0.1, ::1 and any host
+          // without dots. Note this also matches IPv6 literals, which have none.
+          return (
+            request.host === '127.0.0.1' ||
+            request.host === '::1' ||
+            request.host.indexOf('.') < 0
+          );
+        }
+        if (!(analyzed.host as RegExp).test(request.host)) return false;
+      }
+      if (analyzed.url !== null && !analyzed.url.test(request.url)) return false;
+      return true;
+    },
+    str: (condition) => {
+      const analyzed = analyzeBypass(condition.pattern);
+      return analyzed.normalizedPattern || condition.pattern;
+    },
+    compile: (_condition, analyzed) => {
+      if (analyzed.url !== null) {
+        return g.regexTest('url', analyzed.url);
+      }
+      if (analyzed.host === '<local>') {
+        const hostEquals = (host: string) => g.binary('===', g.ref('host'), g.string(host));
+        return g.or([
+          hostEquals('127.0.0.1'),
+          hostEquals('::1'),
+          g.binary('<', g.call(g.member(g.ref('host'), 'indexOf'), [g.string('.')]), g.num(0)),
+        ]);
+      }
+      const conditions: g.Expr[] = [];
+      if (analyzed.scheme !== null) {
+        conditions.push(g.binary('===', g.ref('scheme'), g.string(analyzed.scheme)));
+      }
+      if (analyzed.host !== null) {
+        conditions.push(g.regexTest('host', analyzed.host as RegExp));
+      } else if (analyzed.ip !== null) {
+        conditions.push(compile(analyzed.ip));
+      }
+      return g.and(conditions);
+    },
+  } satisfies Handler<PatternCondition, BypassAnalysis>,
+
+  KeywordCondition: {
+    abbrs: ['K', 'KW', 'Keyword'],
+    analyze: () => null,
+    match: (condition, request) =>
+      request.scheme === 'http' && request.url.indexOf(condition.pattern) >= 0,
+    compile: (condition) =>
+      g.and([
+        g.binary('===', g.ref('scheme'), g.string('http')),
+        g.binary(
+          '>=',
+          g.call(g.member(g.ref('url'), 'indexOf'), [g.string(condition.pattern)]),
+          g.num(0),
+        ),
+      ]),
+  } satisfies Handler<KeywordCondition, null>,
+
+  IpCondition: {
+    abbrs: ['Ip'],
+    analyze: (condition): IpAnalysis => {
+      const ip = unbracket(condition.ip);
+      const text = `${ip}/${condition.prefixLength}`;
+      const addr = parseIp(text);
+      if (addr === null) throw new Error(`Invalid IP address ${text}`);
+      return { addr, normalized: formatIp(addr), mask: formatIp(netmask(addr)) };
+    },
+    match: (_condition, request, analyzed) => {
+      const addr = parseIp(request.host);
+      if (addr === null) return false;
+      if (addr.v4 !== analyzed.addr.v4) return false;
+      return isInSubnet(addr, analyzed.addr);
+    },
+    compile: (_condition, analyzed) => {
+      // Guard isInNet with a cheap syntactic check so that a hostname never
+      // reaches it — that would trigger a blocking DNS lookup.
+      const hostLooksLikeIp = analyzed.addr.v4
+        ? // A trailing digit is a good enough proxy for "is an IPv4 literal".
+          g.binary(
+            '>=',
+            g.index(g.ref('host'), g.binary('-', g.member(g.ref('host'), 'length'), g.num(1))),
+            g.num(0),
+          )
+        : // Likewise, a colon means "is an IPv6 literal".
+          g.binary('>=', g.call(g.member(g.ref('host'), 'indexOf'), [g.string(':')]), g.num(0));
+
+      if (analyzed.addr.prefixLength === 0) {
+        // 0.0.0.0/0 or ::/0 — matches every literal of that family, so the
+        // syntactic check alone is both sufficient and cheaper than isInNet.
+        return hostLooksLikeIp;
+      }
+
+      let hostIsInNet: g.Expr = g.call(g.ref('isInNet'), [
+        g.ref('host'),
+        g.string(analyzed.normalized),
+        g.string(analyzed.mask),
+      ]);
+
+      if (!analyzed.addr.v4) {
+        // isInNetEx takes a prefix directly and is the only correct option for
+        // IPv6, but it is not universally available.
+        const hostIsInNetEx = g.call(g.ref('isInNetEx'), [
+          g.ref('host'),
+          g.string(analyzed.normalized + subnetSuffix(analyzed.addr)),
+        ]);
+        hostIsInNet = g.conditional(
+          g.binary('===', g.unary('typeof', g.ref('isInNetEx')), g.string('function')),
+          hostIsInNetEx,
+          hostIsInNet,
+        );
+      }
+
+      return g.and([hostLooksLikeIp, hostIsInNet]);
+    },
+    str: (condition) => `${condition.ip}/${condition.prefixLength}`,
+    fromStr: (text, condition) => {
+      const target = condition as unknown as IpCondition;
+      const addr = parseIp(text);
+      if (addr !== null) {
+        target.ip = formatIp(addr);
+        target.prefixLength = addr.prefixLength;
+      } else {
+        target.ip = '0.0.0.0';
+        target.prefixLength = 0;
+      }
+      return target;
+    },
+  } satisfies Handler<IpCondition, IpAnalysis>,
+
+  HostLevelsCondition: {
+    abbrs: ['Lv', 'Level', 'Levels', 'HL', 'HLv', 'HLevel', 'HLevels', 'HostL', 'HostLv', 'HostLevel', 'HostLevels'],
+    analyze: () => null,
+    match: (condition, request) => {
+      let dotCount = 0;
+      for (let i = 0; i < request.host.length; i++) {
+        if (request.host.charCodeAt(i) === CHAR_DOT) {
+          dotCount++;
+          if (dotCount > condition.maxValue) return false;
+        }
+      }
+      return dotCount >= condition.minValue;
+    },
+    compile: (condition) => {
+      const value = g.member(g.call(g.member(g.ref('host'), 'split'), [g.string('.')]), 'length');
+      return between(value, condition.minValue + 1, condition.maxValue + 1);
+    },
+    str: (condition) => `${condition.minValue}~${condition.maxValue}`,
+    fromStr: (text, condition) => {
+      const target = condition as unknown as HostLevelsCondition;
+      const [minValue, maxValue] = text.split('~');
+      target.minValue = parseInt(minValue ?? '', 10);
+      target.maxValue = parseInt(maxValue ?? '', 10);
+      if (!(target.minValue > 0)) target.minValue = 1;
+      if (!(target.maxValue > 0)) target.maxValue = 1;
+      return target;
+    },
+  } satisfies Handler<HostLevelsCondition, null>,
+
+  WeekdayCondition: {
+    abbrs: ['WD', 'Week', 'Day', 'Weekday'],
+    analyze: () => null,
+    match: (condition) => {
+      const day = new Date().getDay();
+      if (condition.days) return condition.days.charCodeAt(day) > 64;
+      return (condition.startDay ?? 0) <= day && day <= (condition.endDay ?? 0);
+    },
+    compile: (condition) => {
+      const getDay = g.call(g.member(g.construct(g.ref('Date')), 'getDay'));
+      if (condition.days) {
+        return g.binary(
+          '>',
+          g.call(g.member(g.string(condition.days), 'charCodeAt'), [getDay]),
+          g.num(64),
+        );
+      }
+      return between(getDay, condition.startDay ?? 0, condition.endDay ?? 0);
+    },
+    str: (condition) =>
+      condition.days ? condition.days : `${condition.startDay}~${condition.endDay}`,
+    fromStr: (text, condition) => {
+      const target = condition as unknown as WeekdayCondition;
+      if (text.indexOf('~') < 0 && text.length === 7) {
+        target.days = text;
+      } else {
+        const [startDay, endDay] = text.split('~');
+        target.startDay = parseInt(startDay ?? '', 10);
+        target.endDay = parseInt(endDay ?? '', 10);
+        if (!(target.startDay >= 0 && target.startDay <= 6)) target.startDay = 0;
+        if (!(target.endDay >= 0 && target.endDay <= 6)) target.endDay = 0;
+      }
+      return target;
+    },
+  } satisfies Handler<WeekdayCondition, null>,
+
+  TimeCondition: {
+    abbrs: ['T', 'Time', 'Hour'],
+    analyze: () => null,
+    match: (condition) => {
+      const hour = new Date().getHours();
+      return condition.startHour <= hour && hour <= condition.endHour;
+    },
+    compile: (condition) => {
+      const getHours = g.call(g.member(g.construct(g.ref('Date')), 'getHours'));
+      return between(getHours, condition.startHour, condition.endHour);
+    },
+    str: (condition) => `${condition.startHour}~${condition.endHour}`,
+    fromStr: (text, condition) => {
+      const target = condition as unknown as TimeCondition;
+      const [startHour, endHour] = text.split('~');
+      target.startHour = parseInt(startHour ?? '', 10);
+      target.endHour = parseInt(endHour ?? '', 10);
+      if (!(target.startHour >= 0 && target.startHour < 24)) target.startHour = 0;
+      if (!(target.endHour >= 0 && target.endHour < 24)) target.endHour = 0;
+      return target;
+    },
+  } satisfies Handler<TimeCondition, null>,
+} as const;
+
+/**
+ * Host wildcard patterns carry extra magic beyond plain globbing:
+ *   .example.com  is shorthand for *.example.com
+ *   *.example.com matches the apex domain as well as any subdomain
+ *   **.example.com matches subdomains only, never the apex
+ * See the Host-wildcard-condition wiki page for the full rationale.
+ */
+function hostWildcardToRegExpSource(pattern: string): string {
+  let source = pattern;
+  if (source.charCodeAt(0) === CHAR_DOT) {
+    source = '*' + source;
+  }
+  if (source.indexOf('**.') === 0) {
+    return shExp2RegExp(source.substring(1), { trimAsterisk: true });
+  }
+  if (source.indexOf('*.') === 0) {
+    return shExp2RegExp(source.substring(2), { trimAsterisk: false })
+      .replace(/./, '(?:^|\\.)')
+      .replace(/\.\*\$$/, '');
+  }
+  return shExp2RegExp(source, { trimAsterisk: true });
+}
+
+function analyzeBypass(pattern: string): BypassAnalysis {
+  const cache: BypassAnalysis = {
+    host: null,
+    ip: null,
+    scheme: null,
+    url: null,
+    port: null,
+    normalizedPattern: '',
+  };
+
+  let server = pattern;
+  if (server === '<local>') {
+    cache.host = server;
+    return cache;
+  }
+
+  const schemeParts = server.split('://');
+  if (schemeParts.length > 1) {
+    cache.scheme = schemeParts[0]!;
+    cache.normalizedPattern = cache.scheme + '://';
+    server = schemeParts[1]!;
+  }
+
+  const slashParts = server.split('/');
+  if (slashParts.length > 1) {
+    const addr = parseIp(slashParts[0]!);
+    const prefixLength = parseInt(slashParts[1]!, 10);
+    if (addr !== null && !Number.isNaN(prefixLength)) {
+      cache.ip = {
+        conditionType: 'IpCondition',
+        ip: formatIp(addr),
+        prefixLength,
+      };
+      cache.normalizedPattern += `${cache.ip.ip}/${cache.ip.prefixLength}`;
+      return cache;
+    }
+  }
+
+  // The server may be an IP literal with or without brackets, and with or
+  // without a port.
+  let matchPort: string | undefined;
+  let serverIp = parseIp(server);
+  if (serverIp === null) {
+    const pos = server.lastIndexOf(':');
+    if (pos >= 0) {
+      matchPort = server.substring(pos + 1);
+      server = server.substring(0, pos);
+    }
+    serverIp = parseIp(server);
+  }
+
+  if (serverIp !== null) {
+    server = formatIp(serverIp);
+    cache.normalizedPattern += serverIp.v4 ? server : `[${server}]`;
+  } else {
+    if (server.charCodeAt(0) === CHAR_DOT) {
+      server = '*' + server;
+    }
+    // Note: the CoffeeScript original assigned here instead of appending,
+    // which silently dropped the scheme from patterns like
+    // `http://*.example.com` when rendered back to text.
+    cache.normalizedPattern += server;
+  }
+
+  if (matchPort) {
+    cache.port = matchPort;
+    cache.normalizedPattern += ':' + cache.port;
+    // Inside a URL, IPv6 literals must be bracketed.
+    const urlServer = serverIp !== null && !serverIp.v4 ? `[${server}]` : server;
+    let serverRegex = shExp2RegExp(urlServer);
+    serverRegex = serverRegex.substring(1, serverRegex.length - 1);
+    const scheme = cache.scheme ?? '[^:]+';
+    cache.url = safeRegExp(`^${scheme}:\\/\\/${serverRegex}:${matchPort}\\/`);
+  } else if (server !== '*') {
+    // Inside a host, IPv6 literals are never bracketed.
+    cache.host = safeRegExp(shExp2RegExp(server, { trimAsterisk: true }));
+  }
+
+  return cache;
+}

--- a/packages/pac/src/domain-trie.ts
+++ b/packages/pac/src/domain-trie.ts
@@ -1,0 +1,175 @@
+/**
+ * Domain label trie for host wildcard matching.
+ *
+ * Ported from meow-rs `meow-trie::DomainTrie` (reverse-label prefix tree).
+ *
+ * Pattern forms on insert:
+ *   example.com    exact host
+ *   *.example.com  one label under example.com
+ *   .example.com   one or more labels under example.com
+ *   +.example.com  one or more labels (star + dot), not the apex
+ *
+ * Labels are matched from the TLD leftward. Values are first-insert-wins;
+ * `searchMin` folds the minimum value across all matching patterns, which for
+ * rule indices yields the earliest matching rule.
+ */
+
+const CHAR_DOT = 46;
+
+interface TrieNode<V> {
+  children: Map<string, TrieNode<V>>;
+  exact: V | undefined;
+  star: V | undefined;
+  dot: V | undefined;
+}
+
+type NodeKind = 'exact' | 'star' | 'dot';
+
+function newNode<V>(): TrieNode<V> {
+  return { children: new Map(), exact: undefined, star: undefined, dot: undefined };
+}
+
+export class DomainTrie<V> {
+  #root: TrieNode<V> = newNode<V>();
+  #size = 0;
+
+  isEmpty(): boolean {
+    return this.#size === 0;
+  }
+
+  size(): number {
+    return this.#size;
+  }
+
+  /**
+   * Insert a pattern. Returns false when the pattern is empty or degenerate,
+   * in which case the caller must keep the rule on the linear match path.
+   */
+  insert(domain: string | null | undefined, data: V): boolean {
+    const pattern = (domain ?? '').trim().toLowerCase();
+    if (pattern.length === 0) return false;
+
+    if (pattern.startsWith('+.')) {
+      const rest = pattern.substring(2);
+      if (rest.length === 0) return false;
+      this.#insertInto(rest, data, 'star');
+      this.#insertInto(rest, data, 'dot');
+      this.#size += 2;
+      return true;
+    }
+
+    if (pattern.startsWith('*.')) {
+      const rest = pattern.substring(2);
+      if (rest.length === 0) return false;
+      this.#insertInto(rest, data, 'star');
+      this.#size += 1;
+      return true;
+    }
+
+    if (pattern.charCodeAt(0) === CHAR_DOT) {
+      const rest = pattern.substring(1);
+      if (rest.length === 0) return false;
+      this.#insertInto(rest, data, 'dot');
+      this.#size += 1;
+      return true;
+    }
+
+    this.#insertInto(pattern, data, 'exact');
+    this.#size += 1;
+    return true;
+  }
+
+  #insertInto(baseDomain: string, value: V, kind: NodeKind): void {
+    let node = this.#root;
+    const labels = baseDomain.split('.');
+    // Walk TLD -> subdomain.
+    for (let i = labels.length - 1; i >= 0; i--) {
+      const label = labels[i]!;
+      if (label.length === 0) continue;
+      let child = node.children.get(label);
+      if (child === undefined) {
+        child = newNode<V>();
+        node.children.set(label, child);
+      }
+      node = child;
+    }
+    if (node[kind] === undefined) {
+      node[kind] = value;
+    }
+  }
+
+  /** Most-specific match: exact beats star beats a deeper dot. */
+  search(domain: string): V | undefined {
+    if (this.#size === 0) return undefined;
+    const query = normalizeQuery(domain);
+    if (query === null) return undefined;
+
+    const labels = query.split('.');
+    const n = labels.length;
+    let node = this.#root;
+    let best: V | undefined;
+
+    for (let d = 0; d < n; d++) {
+      const child = node.children.get(labels[n - 1 - d]!);
+      if (child === undefined) break;
+      node = child;
+      const remaining = n - d - 1;
+      if (remaining === 0) {
+        if (node.exact !== undefined) return node.exact;
+      } else if (remaining === 1) {
+        if (node.star !== undefined) best = node.star;
+        else if (node.dot !== undefined) best = node.dot;
+      } else if (node.dot !== undefined) {
+        best = node.dot;
+      }
+    }
+    return best;
+  }
+
+  /**
+   * Minimum value across every matching pattern. With rule indices as values
+   * this is the earliest matching rule, i.e. first-match-wins.
+   */
+  searchMin(domain: string): V | undefined {
+    if (this.#size === 0) return undefined;
+    const query = normalizeQuery(domain);
+    if (query === null) return undefined;
+
+    const labels = query.split('.');
+    const n = labels.length;
+    let node = this.#root;
+    let best: V | undefined;
+
+    for (let d = 0; d < n; d++) {
+      const child = node.children.get(labels[n - 1 - d]!);
+      if (child === undefined) break;
+      node = child;
+      const remaining = n - d - 1;
+      if (remaining === 0) {
+        best = foldMin(best, node.exact);
+      } else {
+        if (remaining === 1) best = foldMin(best, node.star);
+        best = foldMin(best, node.dot);
+      }
+    }
+    return best;
+  }
+}
+
+function normalizeQuery(domain: string | null | undefined): string | null {
+  let query = (domain ?? '').trim();
+  if (query.length === 0) return null;
+  while (query.length > 0 && query.charCodeAt(query.length - 1) === CHAR_DOT) {
+    query = query.substring(0, query.length - 1);
+  }
+  if (query.length === 0) return null;
+  return query.toLowerCase();
+}
+
+function foldMin<V>(best: V | undefined, candidate: V | undefined): V | undefined {
+  if (candidate === undefined) return best;
+  if (best === undefined) return candidate;
+  // Values are compared with the natural ordering of whatever V is; for the
+  // rule-index case that V is always a number.
+  return (best as unknown as number) <= (candidate as unknown as number) ? best : candidate;
+}

--- a/packages/pac/src/index.ts
+++ b/packages/pac/src/index.ts
@@ -1,0 +1,20 @@
+/**
+ * omega-pac: profile, condition and PAC-script logic.
+ *
+ * This entry point is dependency-free and safe to load in a service worker.
+ * Public-suffix helpers live in the separate `./psl` entry point because they
+ * carry a large data table that most callers never need.
+ */
+
+export * as Conditions from './conditions.js';
+export * as PacGenerator from './pac-generator.js';
+export * as Profiles from './profiles.js';
+export * as RuleList from './rule-list.js';
+export * as ShexpUtils from './shexp.js';
+
+export { DomainTrie } from './domain-trie.js';
+export { AttachedCache, Revision, isIp, hostnameOf, unbracket } from './utils.js';
+export { parseIp, formatIp, isInSubnet, netmask, subnetSuffix } from './ip.js';
+export type { IpAddress } from './ip.js';
+
+export type * from './types.js';

--- a/packages/pac/src/ip.ts
+++ b/packages/pac/src/ip.ts
@@ -1,0 +1,262 @@
+/**
+ * Compact IPv4/IPv6 address handling.
+ *
+ * Replaces the `ip-address` package (204 KB with its jsbn/sprintf-js
+ * dependencies) which was used only for parsing, normalising and subnet
+ * comparison. Addresses are held as raw bytes, so subnet maths is a byte
+ * compare rather than BigInteger arithmetic.
+ */
+
+export interface IpAddress {
+  /** True for IPv4, false for IPv6. */
+  readonly v4: boolean;
+  /** 4 bytes for IPv4, 16 for IPv6. */
+  readonly bytes: Uint8Array;
+  /** Prefix length in bits; defaults to the full width when absent. */
+  readonly prefixLength: number;
+  /** True when the source text carried an explicit `/prefix`. */
+  readonly hasPrefix: boolean;
+}
+
+const V4_BITS = 32;
+const V6_BITS = 128;
+
+function parseIpv4Bytes(text: string): Uint8Array | null {
+  const parts = text.split('.');
+  if (parts.length !== 4) return null;
+  const bytes = new Uint8Array(4);
+  for (let i = 0; i < 4; i++) {
+    const part = parts[i]!;
+    // Digits only, and short enough that Number() cannot lose precision.
+    if (part.length === 0 || part.length > 3) return null;
+    for (let j = 0; j < part.length; j++) {
+      const c = part.charCodeAt(j);
+      if (c < 0x30 || c > 0x39) return null;
+    }
+    const value = Number(part);
+    if (value > 255) return null;
+    bytes[i] = value;
+  }
+  return bytes;
+}
+
+function parseIpv6Bytes(text: string): Uint8Array | null {
+  // Drop any zone identifier (fe80::1%eth0); it plays no part in matching.
+  const zone = text.indexOf('%');
+  if (zone >= 0) text = text.substring(0, zone);
+  if (text.length === 0) return null;
+
+  const doubleColon = text.indexOf('::');
+  if (doubleColon !== text.lastIndexOf('::')) return null; // at most one "::"
+
+  let headText: string;
+  let tailText: string;
+  if (doubleColon >= 0) {
+    headText = text.substring(0, doubleColon);
+    tailText = text.substring(doubleColon + 2);
+  } else {
+    headText = text;
+    tailText = '';
+  }
+
+  const head = headText.length > 0 ? headText.split(':') : [];
+  const tail = tailText.length > 0 ? tailText.split(':') : [];
+
+  // A trailing group may be a dotted-quad (::ffff:192.0.2.1).
+  let embedded: Uint8Array | null = null;
+  const groups = tail.length > 0 ? tail : head;
+  const last = groups[groups.length - 1];
+  if (last !== undefined && last.indexOf('.') >= 0) {
+    embedded = parseIpv4Bytes(last);
+    if (embedded === null) return null;
+    groups.pop();
+  }
+
+  const embeddedGroups = embedded ? 2 : 0;
+  const total = head.length + tail.length + embeddedGroups;
+  if (doubleColon >= 0 ? total > 8 : total !== 8) return null;
+
+  const bytes = new Uint8Array(16);
+  let offset = 0;
+
+  const writeGroup = (group: string): boolean => {
+    if (group.length === 0 || group.length > 4) return false;
+    let value = 0;
+    for (let i = 0; i < group.length; i++) {
+      const digit = parseHexDigit(group.charCodeAt(i));
+      if (digit < 0) return false;
+      value = value * 16 + digit;
+    }
+    bytes[offset++] = value >> 8;
+    bytes[offset++] = value & 0xff;
+    return true;
+  };
+
+  for (const group of head) {
+    if (!writeGroup(group)) return null;
+  }
+  // The "::" run expands to however many zero groups are missing; the bytes are
+  // already zero, so we only advance the write cursor.
+  offset = 16 - (tail.length + embeddedGroups) * 2;
+  for (const group of tail) {
+    if (!writeGroup(group)) return null;
+  }
+  if (embedded) {
+    bytes.set(embedded, offset);
+  }
+  return bytes;
+}
+
+function parseHexDigit(code: number): number {
+  if (code >= 0x30 && code <= 0x39) return code - 0x30;
+  if (code >= 0x61 && code <= 0x66) return code - 0x61 + 10;
+  if (code >= 0x41 && code <= 0x46) return code - 0x41 + 10;
+  return -1;
+}
+
+/**
+ * Parse an address, optionally bracketed (`[::1]`) and optionally carrying a
+ * `/prefix` suffix. Returns null when the text is not an IP address at all,
+ * which is how callers distinguish hostnames from literals.
+ */
+export function parseIp(text: string): IpAddress | null {
+  if (text.length === 0) return null;
+  let body = text.trim();
+
+  let prefixLength = -1;
+  const slash = body.lastIndexOf('/');
+  if (slash >= 0) {
+    const suffix = body.substring(slash + 1);
+    if (suffix.length === 0 || !/^\d+$/.test(suffix)) return null;
+    prefixLength = Number(suffix);
+    body = body.substring(0, slash);
+  }
+
+  // Brackets are only stripped when they enclose the whole address. Anything
+  // trailing them (`[::1]:8080`) means this is not a bare address, and the
+  // caller is expected to split the port off first.
+  if (body.charCodeAt(0) === 0x5b /* [ */) {
+    if (body.charCodeAt(body.length - 1) !== 0x5d /* ] */) return null;
+    body = body.substring(1, body.length - 1);
+  }
+
+  const v4 = parseIpv4Bytes(body);
+  if (v4 !== null) {
+    if (prefixLength > V4_BITS) return null;
+    return {
+      v4: true,
+      bytes: v4,
+      prefixLength: prefixLength < 0 ? V4_BITS : prefixLength,
+      hasPrefix: prefixLength >= 0,
+    };
+  }
+
+  const v6 = parseIpv6Bytes(body);
+  if (v6 !== null) {
+    if (prefixLength > V6_BITS) return null;
+    return {
+      v4: false,
+      bytes: v6,
+      prefixLength: prefixLength < 0 ? V6_BITS : prefixLength,
+      hasPrefix: prefixLength >= 0,
+    };
+  }
+
+  return null;
+}
+
+function formatIpv4(bytes: Uint8Array): string {
+  return `${bytes[0]}.${bytes[1]}.${bytes[2]}.${bytes[3]}`;
+}
+
+/**
+ * RFC 5952 canonical text: lowercase, no leading zeros, and the longest run of
+ * two or more zero groups replaced by "::" (leftmost wins on a tie).
+ */
+function formatIpv6(bytes: Uint8Array): string {
+  const groups = new Array<number>(8);
+  for (let i = 0; i < 8; i++) {
+    groups[i] = (bytes[i * 2]! << 8) | bytes[i * 2 + 1]!;
+  }
+
+  let bestStart = -1;
+  let bestLength = 0;
+  let runStart = -1;
+  let runLength = 0;
+  for (let i = 0; i < 8; i++) {
+    if (groups[i] === 0) {
+      if (runStart < 0) runStart = i;
+      runLength++;
+      if (runLength > bestLength) {
+        bestStart = runStart;
+        bestLength = runLength;
+      }
+    } else {
+      runStart = -1;
+      runLength = 0;
+    }
+  }
+  if (bestLength < 2) {
+    bestStart = -1;
+    bestLength = 0;
+  }
+
+  let out = '';
+  for (let i = 0; i < 8; i++) {
+    if (bestStart >= 0 && i === bestStart) {
+      out += i === 0 ? '::' : ':';
+      i += bestLength - 1;
+      continue;
+    }
+    out += groups[i]!.toString(16);
+    if (i < 7) out += ':';
+  }
+  return out;
+}
+
+/** Canonical text form, without any prefix suffix. */
+export function formatIp(address: IpAddress): string {
+  return address.v4 ? formatIpv4(address.bytes) : formatIpv6(address.bytes);
+}
+
+/** The `/prefix` suffix, e.g. `"/33"`. */
+export function subnetSuffix(address: IpAddress): string {
+  return '/' + address.prefixLength;
+}
+
+function maskBytes(width: number, prefixLength: number): Uint8Array {
+  const bytes = new Uint8Array(width);
+  let bits = prefixLength;
+  for (let i = 0; i < width && bits > 0; i++) {
+    const take = Math.min(8, bits);
+    bytes[i] = (0xff << (8 - take)) & 0xff;
+    bits -= take;
+  }
+  return bytes;
+}
+
+/** The netmask of `address` as an address of the same family (e.g. 255.255.255.0). */
+export function netmask(address: IpAddress): IpAddress {
+  const width = address.v4 ? 4 : 16;
+  return {
+    v4: address.v4,
+    bytes: maskBytes(width, address.prefixLength),
+    prefixLength: address.v4 ? V4_BITS : V6_BITS,
+    hasPrefix: false,
+  };
+}
+
+/** True when `address` falls inside the subnet described by `subnet`. */
+export function isInSubnet(address: IpAddress, subnet: IpAddress): boolean {
+  if (address.v4 !== subnet.v4) return false;
+  const width = subnet.v4 ? 4 : 16;
+  let bits = subnet.prefixLength;
+  for (let i = 0; i < width; i++) {
+    if (bits <= 0) break;
+    const take = Math.min(8, bits);
+    const mask = (0xff << (8 - take)) & 0xff;
+    if ((address.bytes[i]! & mask) !== (subnet.bytes[i]! & mask)) return false;
+    bits -= take;
+  }
+  return true;
+}

--- a/packages/pac/src/pac-generator.ts
+++ b/packages/pac/src/pac-generator.ts
@@ -1,0 +1,107 @@
+/**
+ * PAC script generation.
+ *
+ * The generated script resolves a profile chain iteratively: each profile is
+ * either a literal PAC result string or a function returning the next profile
+ * key (prefixed with `+`), so following references costs no recursion.
+ *
+ * Output is emitted already-compact, which is why no minifier is involved.
+ */
+
+import * as g from './codegen.js';
+import * as Profiles from './profiles.js';
+import type { OptionsBag, Profile, ProfileNotFoundAction } from './types.js';
+
+export interface ScriptArgs {
+  profileNotFound?: ProfileNotFoundAction;
+}
+
+/**
+ * Escape every non-ASCII character so the script survives transports that do
+ * not declare an encoding.
+ *
+ * String literals are already escaped at emit time; this remains exported for
+ * callers that splice in externally-sourced PAC text.
+ */
+export function ascii(str: string): string {
+  return str.replace(/[\u0080-\uffff]/g, (char) => {
+    return '\\u' + char.charCodeAt(0).toString(16).padStart(4, '0');
+  });
+}
+
+/** Generate a complete PAC script defining `FindProxyForURL`. */
+export function script(
+  options: OptionsBag,
+  profile: string | Profile,
+  args?: ScriptArgs,
+): string {
+  const resolved = typeof profile === 'string' ? Profiles.byName(profile, options) : profile;
+  if (!resolved) {
+    throw new Error(`Profile ${String(profile)} does not exist!`);
+  }
+
+  const refs = Profiles.allReferenceSet(resolved, options, {
+    profileNotFound: args?.profileNotFound,
+  });
+
+  const properties: string[] = [];
+  for (const [key, name] of Object.entries(refs)) {
+    if (key === '+direct') continue;
+    let target: Profile | null | undefined =
+      resolved.name === name ? resolved : Profiles.byName(name, options);
+    if (!target) {
+      target = Profiles.profileNotFound(name, args?.profileNotFound);
+      if (!target) continue;
+    }
+    properties.push(`${g.str(key)}:${Profiles.compile(target).code}`);
+  }
+
+  const profilesObject = g.raw(`{${properties.join(',')}}`);
+
+  // var result = init, scheme = url.substr(0, url.indexOf(":"));
+  const schemeInit = g.call(g.member(g.ref('url'), 'substr'), [
+    g.num(0),
+    g.call(g.member(g.ref('url'), 'indexOf'), [g.string(':')]),
+  ]);
+
+  // result = profiles[result];
+  // if (typeof result === "function") result = result(url, host, scheme);
+  const step =
+    g.exprStmt(
+      g.raw(`result=${g.index(g.ref('profiles'), g.ref('result')).code}`, g.Prec.Lowest),
+    ) +
+    g.ifThen(
+      g.binary('===', g.unary('typeof', g.ref('result')), g.string('function')),
+      g.exprStmt(
+        g.raw(
+          `result=${g.call(g.ref('result'), [g.ref('url'), g.ref('host'), g.ref('scheme')]).code}`,
+          g.Prec.Lowest,
+        ),
+      ),
+    );
+
+  // Keep resolving while the value is not yet a PAC result string, i.e. while
+  // it is a function or a "+profile" reference.
+  const loopTest = g.or([
+    g.binary('!==', g.unary('typeof', g.ref('result')), g.string('string')),
+    g.binary(
+      '===',
+      g.call(g.member(g.ref('result'), 'charCodeAt'), [g.num(0)]),
+      g.num('+'.charCodeAt(0)),
+    ),
+  ]);
+
+  const findProxyForUrl = g.func(
+    ['url', 'host'],
+    '"use strict";' +
+      `var result=init,scheme=${schemeInit.code};` +
+      g.doWhile(step, loopTest) +
+      g.ret(g.ref('result')),
+  );
+
+  const factory = g.func(['init', 'profiles'], g.ret(findProxyForUrl));
+
+  const call = g.call(factory, [Profiles.profileResult(resolved.name), profilesObject]);
+
+  return `var FindProxyForURL=${call.code};`;
+}

--- a/packages/pac/src/profiles.ts
+++ b/packages/pac/src/profiles.ts
@@ -1,0 +1,707 @@
+/**
+ * Profile behaviour: matching, PAC compilation, reference graph and updates.
+ */
+
+import * as g from './codegen.js';
+import * as Conditions from './conditions.js';
+import * as RuleList from './rule-list.js';
+import { DomainTrie } from './domain-trie.js';
+import { AttachedCache, Revision } from './utils.js';
+import type {
+  Condition,
+  FixedProfile,
+  HostWildcardCondition,
+  MatchResult,
+  OptionsBag,
+  PacProfile,
+  Profile,
+  ProfileNotFoundAction,
+  ProfileType,
+  ProxyAuth,
+  ProxyServer,
+  Request,
+  Rule,
+  RuleListFormat,
+  RuleListProfile,
+  SwitchProfile,
+} from './types.js';
+
+const CHAR_PLUS = '+'.charCodeAt(0);
+
+export const builtinProfiles: Record<string, Profile> = {
+  '+direct': {
+    name: 'direct',
+    profileType: 'DirectProfile',
+    color: '#aaaaaa',
+    builtin: true,
+  },
+  '+system': {
+    name: 'system',
+    profileType: 'SystemProfile',
+    color: '#000000',
+    builtin: true,
+  },
+};
+
+export interface SchemeMapping {
+  scheme: string;
+  prop: 'proxyForHttp' | 'proxyForHttps' | 'proxyForFtp' | 'fallbackProxy';
+}
+
+export const schemes: readonly SchemeMapping[] = [
+  { scheme: 'http', prop: 'proxyForHttp' },
+  { scheme: 'https', prop: 'proxyForHttps' },
+  { scheme: 'ftp', prop: 'proxyForFtp' },
+  { scheme: '', prop: 'fallbackProxy' },
+];
+
+export const pacProtocols: Record<string, string> = {
+  http: 'PROXY',
+  https: 'HTTPS',
+  socks4: 'SOCKS',
+  socks5: 'SOCKS5',
+};
+
+export const formatByType: Record<string, RuleListFormat> = {
+  SwitchyRuleListProfile: 'Switchy',
+  AutoProxyRuleListProfile: 'AutoProxy',
+};
+
+export const ruleListFormats: readonly RuleListFormat[] = ['Switchy', 'AutoProxy'];
+
+export function parseHostPort(str: string, scheme: string): ProxyServer | undefined {
+  const sep = str.lastIndexOf(':');
+  if (sep < 0) return undefined;
+  const port = parseInt(str.substring(sep + 1), 10) || 80;
+  const host = str.substring(0, sep);
+  if (!host) return undefined;
+  return { scheme, host, port };
+}
+
+/** The PAC return string for a proxy server, e.g. `PROXY 127.0.0.1:8080`. */
+export function pacResult(proxy?: ProxyServer): string {
+  if (!proxy) return 'DIRECT';
+  if (proxy.scheme === 'socks5') {
+    // SOCKS5 is not understood by every client, so a SOCKS4 fallback follows.
+    return `SOCKS5 ${proxy.host}:${proxy.port}; SOCKS ${proxy.host}:${proxy.port}`;
+  }
+  return `${pacProtocols[proxy.scheme]} ${proxy.host}:${proxy.port}`;
+}
+
+export function isFileUrl(url: string | undefined): boolean {
+  return !!(url?.substring(0, 5).toUpperCase() === 'FILE:');
+}
+
+export function nameAsKey(profileName: string | Profile): string {
+  const name = typeof profileName === 'string' ? profileName : profileName.name;
+  return '+' + name;
+}
+
+export function byName(
+  profileName: string | Profile | undefined,
+  options: OptionsBag,
+): Profile | undefined {
+  if (typeof profileName !== 'string') return profileName;
+  const key = nameAsKey(profileName);
+  return (builtinProfiles[key] ?? options[key]) as Profile | undefined;
+}
+
+export function byKey(key: string | Profile, options: OptionsBag): Profile | undefined {
+  if (typeof key !== 'string') return key;
+  return (builtinProfiles[key] ?? options[key]) as Profile | undefined;
+}
+
+/** Visit every profile in `options`, then every builtin profile. */
+export function each(
+  options: OptionsBag,
+  callback: (key: string, profile: Profile) => void,
+): void {
+  for (const [key, profile] of Object.entries(options)) {
+    if (key.charCodeAt(0) === CHAR_PLUS) callback(key, profile as Profile);
+  }
+  for (const [key, profile] of Object.entries(builtinProfiles)) {
+    if (key.charCodeAt(0) === CHAR_PLUS) callback(key, profile);
+  }
+}
+
+/** The PAC expression that yields a profile reference (or DIRECT). */
+export function profileResult(profileName: string | Profile): g.Expr {
+  const key = nameAsKey(profileName);
+  return g.string(key === '+direct' ? pacResult() : key);
+}
+
+export function isIncludable(profile: Profile): boolean {
+  const includable = handlerFor(profile).includable;
+  if (typeof includable === 'function') return !!includable(profile);
+  return !!includable;
+}
+
+export function isInclusive(profile: Profile): boolean {
+  return !!handlerFor(profile).inclusive;
+}
+
+export function updateUrl(profile: Profile): string | undefined {
+  return handlerFor(profile).updateUrl?.(profile);
+}
+
+export function updateContentTypeHints(profile: Profile): string[] | undefined {
+  return handlerFor(profile).updateContentTypeHints?.();
+}
+
+export function update(profile: Profile, data: string): boolean {
+  const handler = handlerFor(profile);
+  if (!handler.update) return false;
+  return handler.update(profile, data);
+}
+
+export function tag(profile: Profile): unknown {
+  return profileCache.tag(profile);
+}
+
+export function create(profile: string | Profile, optProfileType?: ProfileType): Profile {
+  let target: Profile;
+  if (typeof profile === 'string') {
+    target = { name: profile, profileType: optProfileType } as Profile;
+  } else {
+    target = profile;
+    if (optProfileType) target.profileType = optProfileType;
+  }
+  handlerFor(target).create?.(target);
+  return target;
+}
+
+export function updateRevision(profile: Profile, revision?: string): void {
+  profile.revision = revision ?? Revision.fromTime();
+}
+
+export function replaceRef(profile: Profile, fromName: string, toName: string): boolean {
+  if (!isInclusive(profile)) return false;
+  return handlerFor(profile).replaceRef?.(profile, fromName, toName) ?? false;
+}
+
+interface ProfileCache {
+  analyzed?: unknown;
+  compiled?: g.Expr;
+  directReferenceSet?: Record<string, string>;
+}
+
+const profileCache = new AttachedCache<Profile, ProfileCache>((profile) => profile.revision);
+
+export function analyze(profile: Profile): unknown {
+  const cache = profileCache.get(profile, () => ({}) as ProfileCache);
+  if (!('analyzed' in cache)) {
+    cache.analyzed = handlerFor(profile).analyze?.(profile);
+  }
+  return cache.analyzed;
+}
+
+export function dropCache(profile: Profile): void {
+  profileCache.drop(profile);
+}
+
+export function directReferenceSet(profile: Profile): Record<string, string> {
+  if (!isInclusive(profile)) return {};
+  const cache = profileCache.get(profile, () => ({}) as ProfileCache);
+  if (cache.directReferenceSet) return cache.directReferenceSet;
+  cache.directReferenceSet = handlerFor(profile).directReferenceSet?.(profile) ?? {};
+  return cache.directReferenceSet;
+}
+
+export function profileNotFound(name: string, action?: ProfileNotFoundAction): Profile | null {
+  if (action === undefined || action === null) {
+    throw new Error(`Profile ${name} does not exist!`);
+  }
+  let resolved = action;
+  if (typeof resolved === 'function') {
+    resolved = resolved(name);
+  }
+  if (typeof resolved === 'object' && resolved.profileType) {
+    return resolved;
+  }
+  switch (resolved) {
+    case 'ignore':
+      return null;
+    case 'dumb':
+      return create({
+        name,
+        profileType: 'VirtualProfile',
+        defaultProfileName: 'direct',
+      } as Profile);
+    default:
+      throw resolved;
+  }
+}
+
+export interface ReferenceSetArgs {
+  out?: Record<string, string>;
+  profileNotFound?: ProfileNotFoundAction;
+}
+
+/** Every profile transitively reachable from `profile`, keyed by `+name`. */
+export function allReferenceSet(
+  profile: string | Profile | undefined,
+  options: OptionsBag,
+  args: ReferenceSetArgs = {},
+): Record<string, string> {
+  const original = profile;
+  let resolved = byName(profile, options);
+  if (!resolved && typeof original === 'string') {
+    resolved = profileNotFound(original, args.profileNotFound) ?? undefined;
+  }
+  const result = (args.out ??= {});
+  if (resolved) {
+    result[nameAsKey(resolved.name)] = resolved.name;
+    for (const name of Object.values(directReferenceSet(resolved))) {
+      if (!(nameAsKey(name) in result)) {
+        allReferenceSet(name, options, args);
+      }
+    }
+  }
+  return result;
+}
+
+/** Every profile that transitively references `profile`. */
+export function referencedBySet(
+  profile: string | Profile,
+  options: OptionsBag,
+  args: ReferenceSetArgs = {},
+): Record<string, string> {
+  const profileKey = nameAsKey(profile);
+  const result = (args.out ??= {});
+  each(options, (key, prof) => {
+    if (directReferenceSet(prof)[profileKey] && !(key in result)) {
+      result[key] = prof.name;
+      referencedBySet(prof, options, args);
+    }
+  });
+  return result;
+}
+
+/** Profiles that `profile` may target without creating a reference cycle. */
+export function validResultProfilesFor(
+  profile: string | Profile,
+  options: OptionsBag,
+): Profile[] {
+  const resolved = byName(profile, options);
+  if (!resolved || !isInclusive(resolved)) return [];
+  const profileKey = nameAsKey(resolved);
+  const ref = referencedBySet(resolved, options);
+  ref[profileKey] = profileKey;
+  const result: Profile[] = [];
+  each(options, (key, prof) => {
+    if (!ref[key] && isIncludable(prof)) result.push(prof);
+  });
+  return result;
+}
+
+export function match(
+  profile: Profile,
+  request: Request,
+  optProfileType?: ProfileType,
+): MatchResult {
+  const type = optProfileType ?? profile.profileType;
+  const analyzed = analyze(profile);
+  return handlerFor(type).match?.(profile, request, analyzed);
+}
+
+export function compile(profile: Profile, optProfileType?: ProfileType): g.Expr {
+  const type = optProfileType ?? profile.profileType;
+  const cache = profileCache.get(profile, () => ({}) as ProfileCache);
+  if (cache.compiled !== undefined) return cache.compiled;
+  // analyze() shares the same cache entry and must run first.
+  const analyzed = analyze(profile);
+  cache.compiled = handlerFor(type).compile(profile, analyzed);
+  return cache.compiled;
+}
+
+// --- Rule analysis (DomainTrie acceleration) --------------------------------
+
+export interface RulesAnalysis {
+  rules: Rule[];
+  domainTrie: DomainTrie<number>;
+  /** Per-rule: true when every pattern of the rule went into the trie. */
+  simpleHost: boolean[];
+  hasNonHostRules: boolean;
+}
+
+/** True when a domain still has wildcards after prefix forms are stripped. */
+function isComplexHostDomain(domain: string): boolean {
+  return domain.indexOf('*') >= 0 || domain.indexOf('?') >= 0;
+}
+
+/**
+ * Map a host wildcard pattern to DomainTrie keys, mirroring the matching magic
+ * in `Conditions`. Returns null when the pattern is too complex for the trie,
+ * in which case the rule stays on the linear match path.
+ *
+ * Exported for tests: the trie keys must stay in lockstep with the regular
+ * expressions `Conditions` builds for the same pattern.
+ */
+export function hostPatternToTrieKeys(pattern: string): string[] | null {
+  let source = pattern;
+  if (source.charCodeAt(0) === '.'.charCodeAt(0)) {
+    source = '*' + source;
+  }
+
+  if (source.indexOf('**.') === 0) {
+    const domain = source.substring(3);
+    if (domain.length === 0 || isComplexHostDomain(domain)) return null;
+    // Any subdomain depth, but never the apex.
+    return ['.' + domain];
+  }
+
+  if (source.indexOf('*.') === 0) {
+    const domain = source.substring(2);
+    if (domain.length === 0 || isComplexHostDomain(domain)) return null;
+    // The magical form: apex plus any subdomain depth.
+    return [domain, '.' + domain];
+  }
+
+  if (source.length === 0 || isComplexHostDomain(source)) return null;
+  return [source];
+}
+
+export function buildRulesAnalysis(rules: Rule[]): RulesAnalysis {
+  const domainTrie = new DomainTrie<number>();
+  const simpleHost = new Array<boolean>(rules.length).fill(false);
+  let hasNonHostRules = false;
+
+  rules.forEach((rule, i) => {
+    const cond = rule.condition;
+    if (cond.conditionType !== 'HostWildcardCondition') {
+      hasNonHostRules = true;
+      return;
+    }
+    const patterns = (cond as HostWildcardCondition).pattern.split('|').filter((p) => p);
+    const keysPerPattern: string[][] = [];
+    let allSimple = patterns.length > 0;
+    for (const pattern of patterns) {
+      const keys = hostPatternToTrieKeys(pattern);
+      if (keys === null) {
+        allSimple = false;
+        break;
+      }
+      keysPerPattern.push(keys);
+    }
+    if (allSimple) {
+      for (const keys of keysPerPattern) {
+        for (const key of keys) domainTrie.insert(key, i);
+      }
+      simpleHost[i] = true;
+    } else {
+      hasNonHostRules = true;
+    }
+  });
+
+  return { rules, domainTrie, simpleHost, hasNonHostRules };
+}
+
+// --- Handlers ---------------------------------------------------------------
+
+interface ProfileHandler<P extends Profile = Profile, A = unknown> {
+  includable?: boolean | ((profile: P) => boolean);
+  inclusive?: boolean;
+  create?(profile: P): void;
+  analyze?(profile: P): A;
+  match?(profile: P, request: Request, analyzed: A): MatchResult;
+  compile(profile: P, analyzed: A): g.Expr;
+  str?(profile: P): string;
+  directReferenceSet?(profile: P): Record<string, string>;
+  replaceRef?(profile: P, fromName: string, toName: string): boolean;
+  updateUrl?(profile: P): string | undefined;
+  updateContentTypeHints?(): string[];
+  update?(profile: P, data: string): boolean;
+}
+
+/**
+ * Handlers are authored against their concrete profile type but dispatched
+ * dynamically, so the registry erases the parameter types.
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+type AnyProfileHandler = ProfileHandler<any, any>;
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+function handlerFor(profileType: ProfileType | Profile): AnyProfileHandler {
+  let name: string = typeof profileType === 'string' ? profileType : profileType.profileType;
+  let handler: AnyProfileHandler | string | undefined = name;
+  // Aliases are stored as strings pointing at another handler.
+  while (typeof handler === 'string') {
+    name = handler;
+    handler = profileTypes[handler];
+  }
+  if (handler === undefined) {
+    throw new Error(`Unknown profile type: ${name}`);
+  }
+  return handler;
+}
+
+const PAC_ARGS = ['url', 'host', 'scheme'];
+
+const profileTypes: Record<string, AnyProfileHandler | string> = {
+  SystemProfile: {
+    compile(): g.Expr {
+      throw new Error('SystemProfile cannot be used in PAC scripts');
+    },
+  },
+
+  DirectProfile: {
+    includable: true,
+    compile: () => g.string(pacResult()),
+  },
+
+  FixedProfile: {
+    includable: true,
+    create(profile: FixedProfile) {
+      profile.bypassList ??= [
+        { conditionType: 'BypassCondition', pattern: '127.0.0.1' },
+        { conditionType: 'BypassCondition', pattern: '[::1]' },
+        { conditionType: 'BypassCondition', pattern: 'localhost' },
+      ];
+    },
+    match(profile: FixedProfile, request: Request): MatchResult {
+      if (profile.bypassList) {
+        for (const cond of profile.bypassList) {
+          if (Conditions.match(cond, request)) {
+            return [pacResult(), cond, { scheme: 'direct' }, undefined] as unknown as MatchResult;
+          }
+        }
+      }
+      for (const s of schemes) {
+        if (s.scheme === request.scheme && profile[s.prop]) {
+          return [
+            pacResult(profile[s.prop]),
+            s.scheme,
+            profile[s.prop],
+            profile.auth?.[s.prop] ?? profile.auth?.['all'],
+          ] as unknown as MatchResult;
+        }
+      }
+      return [
+        pacResult(profile.fallbackProxy),
+        '',
+        profile.fallbackProxy,
+        profile.auth?.['fallbackProxy'] ?? profile.auth?.['all'],
+      ] as unknown as MatchResult;
+    },
+    compile(profile: FixedProfile): g.Expr {
+      // With no bypass list and no per-scheme proxies there is nothing to
+      // branch on, so a constant result is enough.
+      if (
+        (!profile.bypassList || !profile.fallbackProxy) &&
+        !profile.proxyForHttp &&
+        !profile.proxyForHttps &&
+        !profile.proxyForFtp
+      ) {
+        return g.string(pacResult(profile.fallbackProxy));
+      }
+
+      let body = '"use strict";';
+
+      if (profile.bypassList && profile.bypassList.length) {
+        const conditions = g.or(profile.bypassList.map((cond) => Conditions.compile(cond)));
+        body += g.ifThen(conditions, g.ret(g.string(pacResult())));
+      }
+
+      if (!profile.proxyForHttp && !profile.proxyForHttps && !profile.proxyForFtp) {
+        body += g.ret(g.string(pacResult(profile.fallbackProxy)));
+      } else {
+        const cases = schemes
+          .filter((s) => !s.scheme || profile[s.prop])
+          .map((s) => ({
+            test: s.scheme ? g.string(s.scheme) : null,
+            body: g.ret(g.string(pacResult(profile[s.prop]))),
+          }));
+        body += g.switchStmt(g.ref('scheme'), cases);
+      }
+
+      return g.func(PAC_ARGS, body);
+    },
+  },
+
+  PacProfile: {
+    includable: (profile: PacProfile) => !isFileUrl(profile.pacUrl),
+    create(profile: PacProfile) {
+      profile.pacScript ??= 'function FindProxyForURL(url, host) {\n  return "DIRECT";\n}';
+    },
+    compile(profile: PacProfile): g.Expr {
+      // The user's PAC script is spliced in verbatim, so it must be terminated
+      // defensively (see SwitchyOmega issue #390):
+      //   1. a newline ends any trailing line comment (// ...)
+      //   2. a second newline survives a trailing backslash escaping the first
+      //   3. a comment block closes any unterminated /* ...
+      //   4. a semicolon terminates the final statement
+      const raw = `;\n${profile.pacScript ?? ''}\n\n/* End of PAC */;`;
+      const body = raw + g.ret(g.ref('FindProxyForURL'));
+      return g.call(g.member(g.func([], body), 'call'), [g.ref('this')]);
+    },
+    updateUrl: (profile: PacProfile) => (isFileUrl(profile.pacUrl) ? undefined : profile.pacUrl),
+    updateContentTypeHints: () => [
+      '!text/html',
+      '!application/xhtml+xml',
+      'application/x-ns-proxy-autoconfig',
+      'application/x-javascript-config',
+    ],
+    update(profile: PacProfile, data: string): boolean {
+      if (profile.pacScript === data) return false;
+      profile.pacScript = data;
+      return true;
+    },
+  },
+
+  AutoDetectProfile: 'PacProfile',
+
+  SwitchProfile: {
+    includable: true,
+    inclusive: true,
+    create(profile: SwitchProfile) {
+      profile.defaultProfileName ??= 'direct';
+      profile.rules ??= [];
+    },
+    directReferenceSet(profile: SwitchProfile): Record<string, string> {
+      const refs: Record<string, string> = {};
+      refs[nameAsKey(profile.defaultProfileName)] = profile.defaultProfileName;
+      for (const rule of profile.rules) {
+        if (rule.profileName) refs[nameAsKey(rule.profileName)] = rule.profileName;
+      }
+      return refs;
+    },
+    analyze: (profile: SwitchProfile) => buildRulesAnalysis(profile.rules),
+    replaceRef(profile: SwitchProfile, fromName: string, toName: string): boolean {
+      let changed = false;
+      if (profile.defaultProfileName === fromName) {
+        profile.defaultProfileName = toName;
+        changed = true;
+      }
+      for (const rule of profile.rules) {
+        if (rule.profileName === fromName) {
+          rule.profileName = toName;
+          changed = true;
+        }
+      }
+      return changed;
+    },
+    match(profile: SwitchProfile, request: Request, analyzed: RulesAnalysis): MatchResult {
+      const { rules, simpleHost, domainTrie } = analyzed;
+      // The trie resolves first-match among all simple host rules in one pass,
+      // so those rules never need their regex evaluated.
+      const hostRuleIndex = domainTrie.isEmpty() ? undefined : domainTrie.searchMin(request.host);
+
+      for (let i = 0; i < rules.length; i++) {
+        const rule = rules[i]!;
+        if (simpleHost[i]) {
+          if (hostRuleIndex === i) return rule;
+          continue;
+        }
+        if (Conditions.match(rule.condition, request)) return rule;
+      }
+      return [nameAsKey(profile.defaultProfileName), null];
+    },
+    compile(profile: SwitchProfile, analyzed: RulesAnalysis): g.Expr {
+      const rules = analyzed.rules;
+      if (rules.length === 0) {
+        return profileResult(profile.defaultProfileName);
+      }
+      let body = '"use strict";';
+      for (const rule of rules) {
+        body += g.ifThen(
+          Conditions.compile(rule.condition),
+          g.ret(profileResult(rule.profileName ?? profile.defaultProfileName)),
+        );
+      }
+      body += g.ret(profileResult(profile.defaultProfileName));
+      return g.func(PAC_ARGS, body);
+    },
+  },
+
+  VirtualProfile: 'SwitchProfile',
+
+  RuleListProfile: {
+    includable: true,
+    inclusive: true,
+    create(profile: RuleListProfile) {
+      profile.profileType ??= 'RuleListProfile';
+      profile.format ??= formatByType[profile.profileType] ?? 'Switchy';
+      profile.defaultProfileName ??= 'direct';
+      profile.matchProfileName ??= 'direct';
+      profile.ruleList ??= '';
+    },
+    directReferenceSet(profile: RuleListProfile): Record<string, string> {
+      if (profile.ruleList != null) {
+        const format = profile.format ?? formatByType[profile.profileType];
+        const refs = format ? RuleList.formats[format]?.directReferenceSet?.(profile) : undefined;
+        if (refs) return refs;
+      }
+      const refs: Record<string, string> = {};
+      for (const name of [profile.matchProfileName, profile.defaultProfileName]) {
+        refs[nameAsKey(name)] = name;
+      }
+      return refs;
+    },
+    replaceRef(profile: RuleListProfile, fromName: string, toName: string): boolean {
+      let changed = false;
+      if (profile.defaultProfileName === fromName) {
+        profile.defaultProfileName = toName;
+        changed = true;
+      }
+      if (profile.matchProfileName === fromName) {
+        profile.matchProfileName = toName;
+        changed = true;
+      }
+      return changed;
+    },
+    analyze(profile: RuleListProfile): RulesAnalysis {
+      const format = profile.format ?? formatByType[profile.profileType];
+      const formatHandler = format ? RuleList.formats[format] : undefined;
+      if (!formatHandler) {
+        throw new Error(`Unsupported rule list format ${format}!`);
+      }
+      let ruleList = profile.ruleList?.trim() || '';
+      if (formatHandler.preprocess) {
+        ruleList = formatHandler.preprocess(ruleList);
+      }
+      const rules = formatHandler.parse(
+        ruleList,
+        profile.matchProfileName,
+        profile.defaultProfileName,
+      );
+      return buildRulesAnalysis(rules);
+    },
+    match: (profile: RuleListProfile, request: Request) =>
+      match(profile, request, 'SwitchProfile'),
+    compile: (profile: RuleListProfile) => compile(profile, 'SwitchProfile'),
+    updateUrl: (profile: RuleListProfile) => profile.sourceUrl,
+    updateContentTypeHints: () => ['!text/html', '!application/xhtml+xml', 'text/plain', '*'],
+    update(profile: RuleListProfile, data: string): boolean {
+      let text = data.trim();
+      const original = profile.format ?? formatByType[profile.profileType];
+      profile.profileType = 'RuleListProfile';
+
+      let format: RuleListFormat | null = original ?? null;
+      if (format && RuleList.formats[format]?.detect?.(text) === false) {
+        // The data does not belong to the currently configured format.
+        format = null;
+      }
+      for (const formatName of Object.keys(RuleList.formats) as RuleListFormat[]) {
+        const result = RuleList.formats[formatName]?.detect?.(text);
+        if (result === true || (result !== false && format === null)) {
+          format = formatName;
+          profile.format = formatName;
+        }
+      }
+      format ??= original ?? 'Switchy';
+
+      const formatHandler = RuleList.formats[format];
+      if (formatHandler?.preprocess) {
+        text = formatHandler.preprocess(text);
+      }
+      if (profile.ruleList === text) return false;
+      profile.ruleList = text;
+      return true;
+    },
+  },
+
+  SwitchyRuleListProfile: 'RuleListProfile',
+  AutoProxyRuleListProfile: 'RuleListProfile',
+};
+
+export type { ProxyAuth, Condition };

--- a/packages/pac/src/psl.ts
+++ b/packages/pac/src/psl.ts
@@ -1,0 +1,32 @@
+/**
+ * Public-suffix helpers.
+ *
+ * Kept in a separate entry point because the public suffix list is a large
+ * data table. Only the "suggest a wildcard for this site" UI path needs it, so
+ * the service worker never has to load it.
+ */
+
+import { getDomain } from 'tldts';
+import { isIp } from './utils.js';
+
+/**
+ * The registrable domain of a host, e.g. `images.google.co.uk` ->
+ * `google.co.uk`. IP literals and hosts with no known suffix are returned
+ * unchanged.
+ */
+export function getBaseDomain(domain: string): string {
+  if (isIp(domain)) return domain;
+  return getDomain(domain) ?? domain;
+}
+
+/** A host wildcard pattern covering the whole registrable domain. */
+export function wildcardForDomain(domain: string): string {
+  if (isIp(domain)) return domain;
+  return '*.' + getBaseDomain(domain);
+}
+
+/** As {@link wildcardForDomain}, taking a full URL. */
+export function wildcardForUrl(url: string): string {
+  const hostname = new URL(url).hostname;
+  return wildcardForDomain(hostname);
+}

--- a/packages/pac/src/rule-list.ts
+++ b/packages/pac/src/rule-list.ts
@@ -1,0 +1,383 @@
+/** Parsing and composing of the AutoProxy and Switchy rule list formats. */
+
+import * as Conditions from './conditions.js';
+import type { Condition, Rule, RuleListFormat, RuleListProfile } from './types.js';
+
+export interface ParseArgs {
+  /** Throw on malformed lines instead of skipping them. */
+  strict?: boolean;
+  /** Record the originating text on each rule. Defaults to true. */
+  source?: boolean;
+}
+
+export interface RuleListError extends Error {
+  reason: string;
+  source?: string;
+  sourceLineNo?: number;
+}
+
+export interface FormatHandler {
+  /** True/false when the format is certain, undefined when unknown. */
+  detect?(text: string): boolean | undefined;
+  preprocess?(text: string): string;
+  parse(text: string, matchProfileName: string, defaultProfileName: string): Rule[];
+  directReferenceSet?(profile: RuleListProfile): Record<string, string> | undefined;
+}
+
+function decodeBase64Utf8(text: string): string {
+  const binary = atob(text);
+  const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
+// --- AutoProxy --------------------------------------------------------------
+
+const AUTOPROXY_MAGIC_PREFIX = 'W0F1dG9Qcm94'; // base64 of "[AutoProxy"
+
+export const AutoProxy: FormatHandler = {
+  detect(text) {
+    if (text.startsWith(AUTOPROXY_MAGIC_PREFIX)) return true;
+    if (text.startsWith('[AutoProxy')) return true;
+    return undefined;
+  },
+
+  preprocess(text) {
+    return text.startsWith(AUTOPROXY_MAGIC_PREFIX) ? decodeBase64Utf8(text) : text;
+  },
+
+  parse(text, matchProfileName, defaultProfileName) {
+    const normalRules: Rule[] = [];
+    const exclusiveRules: Rule[] = [];
+
+    for (const rawLine of text.split(/\n|\r/)) {
+      let line = rawLine.trim();
+      if (line.length === 0 || line[0] === '!' || line[0] === '[') continue;
+
+      const source = line;
+      let profile = matchProfileName;
+      let list = normalRules;
+
+      if (line[0] === '@' && line[1] === '@') {
+        profile = defaultProfileName;
+        list = exclusiveRules;
+        line = line.substring(2);
+      }
+
+      let condition: Condition;
+      if (line[0] === '/') {
+        condition = {
+          conditionType: 'UrlRegexCondition',
+          pattern: line.substring(1, line.length - 1),
+        };
+      } else if (line[0] === '|') {
+        condition =
+          line[1] === '|'
+            ? { conditionType: 'HostWildcardCondition', pattern: '*.' + line.substring(2) }
+            : { conditionType: 'UrlWildcardCondition', pattern: line.substring(1) + '*' };
+      } else if (line.indexOf('*') < 0) {
+        condition = { conditionType: 'KeywordCondition', pattern: line };
+      } else {
+        condition = { conditionType: 'UrlWildcardCondition', pattern: 'http://*' + line + '*' };
+      }
+
+      list.push({ condition, profileName: profile, source });
+    }
+
+    // Exclusive rules take priority, so they are evaluated first.
+    return exclusiveRules.concat(normalRules);
+  },
+};
+
+// --- Switchy ----------------------------------------------------------------
+
+const OMEGA_PREFIX = '[SwitchyDelta Conditions';
+/** Rule lists written before the project was renamed. */
+const LEGACY_OMEGA_PREFIX = '[SwitchyOmega Conditions';
+const SPECIAL_LINE_START = '[;#@!';
+
+type SwitchyParser = 'parseOmega' | 'parseLegacy';
+
+function getParser(text: string): SwitchyParser {
+  const hasOmegaHeader =
+    text.startsWith(OMEGA_PREFIX) || text.startsWith(LEGACY_OMEGA_PREFIX);
+  if (!hasOmegaHeader && (text[0] === '#' || text.indexOf('\n#') >= 0)) {
+    return 'parseLegacy';
+  }
+  return 'parseOmega';
+}
+
+export interface ComposeOptions {
+  withResult?: boolean;
+  useExclusive?: boolean;
+}
+
+/**
+ * For the Switchy rule list format, see:
+ * https://github.com/FelisCatus/SwitchyOmega/wiki/SwitchyOmega-conditions-format
+ */
+export function compose(
+  { rules, defaultProfileName }: { rules: Rule[]; defaultProfileName: string },
+  { withResult, useExclusive }: ComposeOptions = {},
+): string {
+  const eol = '\r\n';
+  let ruleList = '[SwitchyDelta Conditions]' + eol;
+  useExclusive ??= !withResult;
+  ruleList += withResult ? '@with result' + eol + eol : eol;
+
+  const specialLineStart = SPECIAL_LINE_START + '+';
+  for (const rule of rules) {
+    if (rule.note) {
+      ruleList += '@note ' + rule.note + eol;
+    }
+    let line = Conditions.str(rule.condition);
+    if (useExclusive && rule.profileName === defaultProfileName) {
+      line = '!' + line;
+    } else {
+      if (specialLineStart.indexOf(line[0]!) >= 0) {
+        line = ': ' + line;
+      }
+      if (withResult) {
+        line += ' +' + rule.profileName;
+      }
+    }
+    ruleList += line + eol;
+  }
+  if (withResult) {
+    ruleList += eol + '* +' + defaultProfileName + eol;
+  }
+  return ruleList;
+}
+
+function conditionFromLegacyWildcard(pattern: string): Condition {
+  let source = pattern;
+  if (source[0] === '@') {
+    source = source.substring(1);
+  } else {
+    if (source.indexOf('://') <= 0 && source[0] !== '*') {
+      source = '*' + source;
+    }
+    if (source[source.length - 1] !== '*') {
+      source += '*';
+    }
+  }
+
+  const host = Conditions.urlWildcard2HostWildcard(source);
+  return host
+    ? { conditionType: 'HostWildcardCondition', pattern: host }
+    : { conditionType: 'UrlWildcardCondition', pattern: source };
+}
+
+function parseLegacy(
+  text: string,
+  matchProfileName: string,
+  defaultProfileName: string,
+): Rule[] {
+  const normalRules: Rule[] = [];
+  const exclusiveRules: Rule[] = [];
+  let begin = false;
+  let section = 'WILDCARD';
+
+  for (const rawLine of text.split(/\n|\r/)) {
+    let line = rawLine.trim();
+    if (line.length === 0 || line[0] === ';') continue;
+
+    if (!begin) {
+      if (line.toUpperCase() === '#BEGIN') begin = true;
+      continue;
+    }
+    if (line.toUpperCase() === '#END') break;
+
+    if (line[0] === '[' && line[line.length - 1] === ']') {
+      section = line.substring(1, line.length - 1).toUpperCase();
+      continue;
+    }
+
+    const source = line;
+    let profile = matchProfileName;
+    let list = normalRules;
+    if (line[0] === '!') {
+      profile = defaultProfileName;
+      list = exclusiveRules;
+      line = line.substring(1);
+    }
+
+    let condition: Condition | null = null;
+    if (section === 'WILDCARD') {
+      condition = conditionFromLegacyWildcard(line);
+    } else if (section === 'REGEXP') {
+      condition = { conditionType: 'UrlRegexCondition', pattern: line };
+    }
+
+    if (condition) {
+      list.push({ condition, profileName: profile, source });
+    }
+  }
+
+  return exclusiveRules.concat(normalRules);
+}
+
+function parseOmega(
+  text: string,
+  matchProfileName: string,
+  defaultProfileName: string,
+  args: ParseArgs = {},
+): Rule[] {
+  const { strict } = args;
+  const includeSource = args.source ?? true;
+
+  const fail = (fields: { message: string; reason: string; source?: string; sourceLineNo?: number }) => {
+    if (!strict) return;
+    const err = new Error(fields.message) as RuleListError;
+    err.reason = fields.reason;
+    if (fields.source !== undefined) err.source = fields.source;
+    if (fields.sourceLineNo !== undefined) err.sourceLineNo = fields.sourceLineNo;
+    throw err;
+  };
+
+  const rules: Rule[] = [];
+  const rulesWithDefaultProfile: Rule[] = [];
+  let withResult = false;
+  let exclusiveProfile: string | null = null;
+  let noteForNextRule: string | null = null;
+  let lno = 0;
+
+  for (const rawLine of text.split(/\n|\r/)) {
+    lno++;
+    let line = rawLine.trim();
+    if (line.length === 0) continue;
+
+    if (line[0] === '[' || line[0] === ';') continue; // header / comment
+
+    if (line[0] === '@') {
+      // Directive line.
+      let iSpace = line.indexOf(' ');
+      if (iSpace < 0) iSpace = line.length;
+      const directive = line.substring(1, iSpace);
+      line = line.substring(iSpace + 1).trim();
+      const upper = directive.toUpperCase();
+      if (upper === 'WITH') {
+        const feature = line.toUpperCase();
+        if (feature === 'RESULT' || feature === 'RESULTS') withResult = true;
+      } else if (upper === 'NOTE') {
+        noteForNextRule = line;
+      }
+      continue;
+    }
+
+    let source: string | null = null;
+    if (strict) exclusiveProfile = null;
+
+    let profile: string | null;
+    if (line[0] === '!') {
+      profile = withResult ? null : defaultProfileName;
+      source = line;
+      line = line.substring(1);
+    } else if (withResult) {
+      const iSpace = line.lastIndexOf(' +');
+      if (iSpace < 0) {
+        fail({
+          message: 'Missing result profile name: ' + line,
+          reason: 'missingResultProfile',
+          source: line,
+          sourceLineNo: lno,
+        });
+        continue;
+      }
+      profile = line.substring(iSpace + 2).trim();
+      line = line.substring(0, iSpace).trim();
+      if (line === '*') exclusiveProfile = profile;
+    } else {
+      profile = matchProfileName;
+    }
+
+    const condition = Conditions.fromStr(line);
+    if (!condition) {
+      fail({
+        message: 'Invalid rule: ' + line,
+        reason: 'invalidRule',
+        source: source ?? line,
+        sourceLineNo: lno,
+      });
+      continue;
+    }
+
+    const rule: Rule = { condition, profileName: profile };
+    if (includeSource) rule.source = source ?? line;
+    if (noteForNextRule !== null) {
+      rule.note = noteForNextRule;
+      noteForNextRule = null;
+    }
+    rules.push(rule);
+    if (!profile) rulesWithDefaultProfile.push(rule);
+  }
+
+  if (withResult) {
+    if (!exclusiveProfile) {
+      fail({
+        message: "Missing default rule with catch-all '*' condition",
+        reason: 'noDefaultRule',
+      });
+      exclusiveProfile = defaultProfileName || 'direct';
+    }
+    for (const rule of rulesWithDefaultProfile) {
+      rule.profileName = exclusiveProfile;
+    }
+  }
+
+  return rules;
+}
+
+export const Switchy: FormatHandler & {
+  compose: typeof compose;
+  parseOmega: typeof parseOmega;
+  parseLegacy: typeof parseLegacy;
+  conditionFromLegacyWildcard: typeof conditionFromLegacyWildcard;
+  omegaPrefix: string;
+  legacyOmegaPrefix: string;
+  specialLineStart: string;
+} = {
+  omegaPrefix: OMEGA_PREFIX,
+  legacyOmegaPrefix: LEGACY_OMEGA_PREFIX,
+  specialLineStart: SPECIAL_LINE_START,
+
+  detect(text) {
+    if (text.startsWith(OMEGA_PREFIX)) return true;
+    if (text.startsWith(LEGACY_OMEGA_PREFIX)) return true;
+    return undefined;
+  },
+
+  parse(text, matchProfileName, defaultProfileName) {
+    const parser = getParser(text);
+    return parser === 'parseOmega'
+      ? parseOmega(text, matchProfileName, defaultProfileName)
+      : parseLegacy(text, matchProfileName, defaultProfileName);
+  },
+
+  directReferenceSet({ ruleList, defaultProfileName }) {
+    const text = ruleList.trim();
+    if (getParser(text) !== 'parseOmega') return undefined;
+    if (!/(^|\n)@with\s+results?(\r|\n|$)/i.test(text)) return undefined;
+
+    const refs: Record<string, string> = {};
+    for (const rawLine of text.split(/\n|\r/)) {
+      const line = rawLine.trim();
+      if (SPECIAL_LINE_START.indexOf(line[0]!) < 0) {
+        const iSpace = line.lastIndexOf(' +');
+        const profile =
+          iSpace < 0 ? defaultProfileName || 'direct' : line.substring(iSpace + 2).trim();
+        refs['+' + profile] = profile;
+      }
+    }
+    return refs;
+  },
+
+  compose,
+  parseOmega,
+  parseLegacy,
+  conditionFromLegacyWildcard,
+};
+
+export const formats: Record<RuleListFormat, FormatHandler> = {
+  Switchy,
+  AutoProxy,
+};

--- a/packages/pac/src/shexp.ts
+++ b/packages/pac/src/shexp.ts
@@ -1,0 +1,81 @@
+/** Shell-expression (glob) to regular-expression translation. */
+
+const REGEXP_META_CHARS: ReadonlySet<number> = new Set(
+  Array.from('\\[^$.|?*+(){}/', (c) => c.charCodeAt(0)),
+);
+
+const CHAR_SLASH = 47; // /
+const CHAR_BACKSLASH = 92; // \
+const CHAR_ASTERISK = 42; // *
+const CHAR_QUESTION = 63; // ?
+
+/**
+ * Escape forward slashes that are not already escaped, so the pattern is safe
+ * to embed in a `/.../` regular expression literal.
+ */
+export function escapeSlash(pattern: string): string {
+  let escaped = false;
+  let start = 0;
+  let result = '';
+  for (let i = 0; i < pattern.length; i++) {
+    const code = pattern.charCodeAt(i);
+    if (code === CHAR_SLASH && !escaped) {
+      result += pattern.substring(start, i);
+      result += '\\';
+      start = i;
+    }
+    escaped = code === CHAR_BACKSLASH && !escaped;
+  }
+  return result + pattern.substring(start);
+}
+
+export interface ShExpOptions {
+  /**
+   * Strip leading and trailing asterisks and drop the corresponding `^`/`$`
+   * anchors, yielding a substring match.
+   */
+  trimAsterisk?: boolean;
+}
+
+/** Translate a shell wildcard pattern into regular expression source. */
+export function shExp2RegExp(pattern: string, options?: ShExpOptions): string {
+  const trimAsterisk = options?.trimAsterisk ?? false;
+  let start = 0;
+  let end = pattern.length;
+
+  if (trimAsterisk) {
+    while (start < end && pattern.charCodeAt(start) === CHAR_ASTERISK) start++;
+    while (start < end && pattern.charCodeAt(end - 1) === CHAR_ASTERISK) end--;
+    if (end - start === 1 && pattern.charCodeAt(start) === CHAR_ASTERISK) {
+      return '';
+    }
+  }
+
+  let regex = start === 0 ? '^' : '';
+  for (let i = start; i < end; i++) {
+    const code = pattern.charCodeAt(i);
+    if (code === CHAR_ASTERISK) {
+      regex += '.*';
+    } else if (code === CHAR_QUESTION) {
+      regex += '.';
+    } else {
+      if (REGEXP_META_CHARS.has(code)) regex += '\\';
+      regex += pattern[i];
+    }
+  }
+  if (end === pattern.length) regex += '$';
+
+  return regex;
+}
+
+/**
+ * Compile a regular expression, falling back to a never-matching expression
+ * when the source is invalid. User-authored patterns reach this directly.
+ */
+export function safeRegExp(source: string): RegExp {
+  try {
+    return new RegExp(source);
+  } catch {
+    return /(?!)/;
+  }
+}

--- a/packages/pac/src/types.ts
+++ b/packages/pac/src/types.ts
@@ -1,0 +1,205 @@
+/** Shared data model for profiles, conditions and rules. */
+
+export interface ProxyServer {
+  scheme: string;
+  host: string;
+  port: number;
+}
+
+export interface ProxyAuth {
+  username: string;
+  password: string;
+}
+
+/** A request as seen by the matcher; mirrors the PAC `FindProxyForURL` inputs. */
+export interface Request {
+  url: string;
+  host: string;
+  scheme: string;
+}
+
+// --- Conditions -------------------------------------------------------------
+
+export type ConditionType =
+  | 'TrueCondition'
+  | 'FalseCondition'
+  | 'UrlRegexCondition'
+  | 'UrlWildcardCondition'
+  | 'HostRegexCondition'
+  | 'HostWildcardCondition'
+  | 'BypassCondition'
+  | 'KeywordCondition'
+  | 'IpCondition'
+  | 'HostLevelsCondition'
+  | 'WeekdayCondition'
+  | 'TimeCondition';
+
+export interface TrueCondition {
+  conditionType: 'TrueCondition';
+  pattern?: string;
+}
+export interface FalseCondition {
+  conditionType: 'FalseCondition';
+  pattern?: string;
+}
+export interface UrlRegexCondition {
+  conditionType: 'UrlRegexCondition';
+  pattern: string;
+}
+export interface UrlWildcardCondition {
+  conditionType: 'UrlWildcardCondition';
+  pattern: string;
+}
+export interface HostRegexCondition {
+  conditionType: 'HostRegexCondition';
+  pattern: string;
+}
+export interface HostWildcardCondition {
+  conditionType: 'HostWildcardCondition';
+  pattern: string;
+}
+export interface BypassCondition {
+  conditionType: 'BypassCondition';
+  pattern: string;
+}
+export interface KeywordCondition {
+  conditionType: 'KeywordCondition';
+  pattern: string;
+}
+export interface IpCondition {
+  conditionType: 'IpCondition';
+  ip: string;
+  prefixLength: number;
+}
+export interface HostLevelsCondition {
+  conditionType: 'HostLevelsCondition';
+  minValue: number;
+  maxValue: number;
+}
+export interface WeekdayCondition {
+  conditionType: 'WeekdayCondition';
+  /** Seven characters; a letter (code > 64) enables that weekday. */
+  days?: string;
+  startDay?: number;
+  endDay?: number;
+}
+export interface TimeCondition {
+  conditionType: 'TimeCondition';
+  startHour: number;
+  endHour: number;
+}
+
+export type Condition =
+  | TrueCondition
+  | FalseCondition
+  | UrlRegexCondition
+  | UrlWildcardCondition
+  | HostRegexCondition
+  | HostWildcardCondition
+  | BypassCondition
+  | KeywordCondition
+  | IpCondition
+  | HostLevelsCondition
+  | WeekdayCondition
+  | TimeCondition;
+
+/** Conditions whose entire state is a single `pattern` string. */
+export type PatternCondition = Extract<Condition, { pattern: string }>;
+
+export interface Rule {
+  condition: Condition;
+  /** Null while parsing a `@with result` list before the default is resolved. */
+  profileName: string | null;
+  source?: string;
+  note?: string;
+}
+
+// --- Profiles ---------------------------------------------------------------
+
+export type ProfileType =
+  | 'DirectProfile'
+  | 'SystemProfile'
+  | 'FixedProfile'
+  | 'PacProfile'
+  | 'AutoDetectProfile'
+  | 'SwitchProfile'
+  | 'VirtualProfile'
+  | 'RuleListProfile'
+  | 'SwitchyRuleListProfile'
+  | 'AutoProxyRuleListProfile';
+
+export interface ProfileBase {
+  name: string;
+  profileType: ProfileType;
+  revision?: string;
+  color?: string;
+  builtin?: boolean;
+}
+
+export interface DirectProfile extends ProfileBase {
+  profileType: 'DirectProfile';
+}
+
+export interface SystemProfile extends ProfileBase {
+  profileType: 'SystemProfile';
+}
+
+export interface FixedProfile extends ProfileBase {
+  profileType: 'FixedProfile';
+  bypassList?: BypassCondition[];
+  proxyForHttp?: ProxyServer;
+  proxyForHttps?: ProxyServer;
+  proxyForFtp?: ProxyServer;
+  fallbackProxy?: ProxyServer;
+  auth?: Record<string, ProxyAuth | undefined>;
+}
+
+export interface PacProfile extends ProfileBase {
+  profileType: 'PacProfile' | 'AutoDetectProfile';
+  pacUrl?: string;
+  pacScript?: string;
+}
+
+export interface SwitchProfile extends ProfileBase {
+  profileType: 'SwitchProfile' | 'VirtualProfile';
+  defaultProfileName: string;
+  rules: Rule[];
+}
+
+export interface RuleListProfile extends ProfileBase {
+  profileType: 'RuleListProfile' | 'SwitchyRuleListProfile' | 'AutoProxyRuleListProfile';
+  format?: RuleListFormat;
+  defaultProfileName: string;
+  matchProfileName: string;
+  ruleList: string;
+  sourceUrl?: string;
+}
+
+export type RuleListFormat = 'Switchy' | 'AutoProxy';
+
+export type Profile =
+  | DirectProfile
+  | SystemProfile
+  | FixedProfile
+  | PacProfile
+  | SwitchProfile
+  | RuleListProfile;
+
+/**
+ * The persisted options bag. Profile entries are keyed by `+name`; other keys
+ * hold unrelated settings, so lookups are narrowed at the call site.
+ */
+export type OptionsBag = Record<string, unknown>;
+
+/**
+ * What a matcher returns: the winning rule, or a synthesised
+ * `[profileKey, null]` pair when nothing matched and the default applies.
+ */
+export type MatchResult = Rule | [string, null] | null | undefined;
+
+/** How to react to a reference to a profile that does not exist. */
+export type ProfileNotFoundAction =
+  | 'ignore'
+  | 'dumb'
+  | Profile
+  | ((name: string) => 'ignore' | 'dumb' | Profile);

--- a/packages/pac/src/utils.ts
+++ b/packages/pac/src/utils.ts
@@ -1,0 +1,100 @@
+/** Revision stamps and analysis caching. */
+
+export const Revision = {
+  /** Monotonic-ish revision derived from wall clock, hex encoded. */
+  fromTime(time?: number | Date): string {
+    const date = time !== undefined ? new Date(time) : new Date();
+    return date.getTime().toString(16);
+  },
+
+  /**
+   * Order two revisions. Longer strings are newer, otherwise lexicographic —
+   * which works because the values are fixed-radix hex timestamps.
+   */
+  compare(a: string | null | undefined, b: string | null | undefined): number {
+    if (!a && !b) return 0;
+    if (!a) return -1;
+    if (!b) return 1;
+    if (a.length > b.length) return 1;
+    if (a.length < b.length) return -1;
+    if (a > b) return 1;
+    if (a < b) return -1;
+    return 0;
+  },
+} as const;
+
+/**
+ * Memoises a derived value against an object, invalidated by a tag.
+ *
+ * The CoffeeScript version stored the cache in a non-enumerable property on the
+ * object itself, using `Object.defineProperty` to keep it out of JSON. A
+ * WeakMap gives the same lifetime without mutating caller-owned objects, so
+ * profiles can be persisted or structured-cloned without stripping fields.
+ */
+export class AttachedCache<T extends object, V> {
+  readonly #store = new WeakMap<T, { tag: unknown; value: V }>();
+  readonly #tagFn: (obj: T) => unknown;
+
+  constructor(tagFn: (obj: T) => unknown) {
+    this.#tagFn = tagFn;
+  }
+
+  tag(obj: T): unknown {
+    return this.#tagFn(obj);
+  }
+
+  get(obj: T, otherwise: V | (() => V)): V {
+    const tag = this.#tagFn(obj);
+    const cached = this.#store.get(obj);
+    if (cached !== undefined && cached.tag === tag) {
+      return cached.value;
+    }
+    const value = typeof otherwise === 'function' ? (otherwise as () => V)() : otherwise;
+    this.#store.set(obj, { tag, value });
+    return value;
+  }
+
+  drop(obj: T): void {
+    this.#store.delete(obj);
+  }
+}
+
+/**
+ * Cheap check for whether a host is an IP literal rather than a domain name.
+ * Exact parsing is deliberately avoided: this only needs to be right for hosts
+ * that reach it from a URL.
+ */
+export function isIp(domain: string): boolean {
+  if (domain.indexOf(':') > 0) return true; // IPv6
+  const lastCharCode = domain.charCodeAt(domain.length - 1);
+  return lastCharCode >= 48 && lastCharCode <= 57; // trailing digit => IPv4
+}
+
+/**
+ * Hostname of a URL, with any IPv6 brackets removed.
+ *
+ * The WHATWG `URL` keeps brackets in `hostname` (`[::1]`) whereas the Node
+ * `url.parse` this replaces stripped them. Matching stays on the legacy
+ * (bracket-free) form because conditions compare against PAC's `host`
+ * argument, which is also unbracketed.
+ */
+export function hostnameOf(url: string): string {
+  const parsed = tryParseUrl(url);
+  if (parsed === null) return '';
+  return unbracket(parsed.hostname);
+}
+
+export function unbracket(host: string): string {
+  if (host.charCodeAt(0) === 0x5b /* [ */ && host.charCodeAt(host.length - 1) === 0x5d /* ] */) {
+    return host.substring(1, host.length - 1);
+  }
+  return host;
+}
+
+export function tryParseUrl(url: string): URL | null {
+  try {
+    return new URL(url);
+  } catch {
+    return null;
+  }
+}

--- a/packages/pac/test/conditions.test.ts
+++ b/packages/pac/test/conditions.test.ts
@@ -1,0 +1,860 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import * as Conditions from '../src/conditions.js';
+import type { Condition, Request } from '../src/types.js';
+
+/**
+ * Assert that a condition agrees with itself: `match` evaluated in-process and
+ * the compiled PAC expression evaluated as real JavaScript must both give
+ * `shouldMatch`. This cross-check is the core invariant of the whole module.
+ */
+function testCond(
+  condition: Condition,
+  request: string | Partial<Request>,
+  shouldMatch: boolean,
+): boolean {
+  const req = (
+    typeof request === 'string' ? Conditions.requestFromUrl(request) : request
+  ) as Request;
+
+  const matchResult = Conditions.match(condition, req);
+
+  const expr = Conditions.compile(condition);
+  const compiled = new Function('url', 'host', 'scheme', `return (${expr.code});`) as (
+    url: string,
+    host: string,
+    scheme: string,
+  ) => unknown;
+  const compileResult = !!compiled(req.url, req.host, req.scheme);
+
+  const describeCase = (which: string) =>
+    `expected ${which}condition ${JSON.stringify(condition)} ` +
+    `${shouldMatch ? 'to match' : 'not to match'} request ${JSON.stringify(request)}`;
+
+  expect(matchResult, describeCase('')).toBe(shouldMatch);
+  expect(compileResult, describeCase('COMPILED ')).toBe(shouldMatch);
+
+  return matchResult;
+}
+
+/** Evaluate a compiled condition with a stub `isInNet` that always matches. */
+function compileWithStubIsInNet(condition: Condition) {
+  const expr = Conditions.compile(condition);
+  return new Function(
+    'url',
+    'host',
+    'scheme',
+    `var isInNet = function () { return true; }; return (${expr.code});`,
+  ) as (url: unknown, host: string, scheme?: string) => boolean;
+}
+
+describe('Conditions', () => {
+  describe('TrueCondition', () => {
+    it('should always return true', () => {
+      testCond({ conditionType: 'TrueCondition' }, {}, true);
+    });
+  });
+
+  describe('FalseCondition', () => {
+    it('should always return false', () => {
+      testCond({ conditionType: 'FalseCondition' }, {}, false);
+    });
+  });
+
+  describe('UrlRegexCondition', () => {
+    const cond: Condition = {
+      conditionType: 'UrlRegexCondition',
+      pattern: 'example\\.com',
+    };
+    it('should match requests based on regex pattern', () => {
+      testCond(cond, 'http://www.example.com/', true);
+    });
+    it('should not match requests not matching the pattern', () => {
+      testCond(cond, 'http://www.example.net/', false);
+    });
+    it('should support regex meta chars', () => {
+      testCond(
+        { conditionType: 'UrlRegexCondition', pattern: 'exam.*\\.com' },
+        'http://www.example.com/',
+        true,
+      );
+    });
+    it('should fallback to not match if pattern is invalid', () => {
+      testCond(
+        { conditionType: 'UrlRegexCondition', pattern: ')Invalid(' },
+        'http://www.example.com/',
+        false,
+      );
+    });
+  });
+
+  describe('UrlWildcardCondition', () => {
+    const cond: Condition = {
+      conditionType: 'UrlWildcardCondition',
+      pattern: '*example.com*',
+    };
+    it('should match requests based on wildcard pattern', () => {
+      testCond(cond, 'http://www.example.com/', true);
+    });
+    it('should not match requests not matching the pattern', () => {
+      testCond(cond, 'http://www.example.net/', false);
+    });
+    it('should support wildcard question marks', () => {
+      testCond(
+        { conditionType: 'UrlWildcardCondition', pattern: '*exam???.com*' },
+        'http://www.example.com/',
+        true,
+      );
+    });
+    it('should not support regex meta chars', () => {
+      testCond(
+        { conditionType: 'UrlWildcardCondition', pattern: '.*example.com.*' },
+        'http://example.com/',
+        false,
+      );
+    });
+    it('should support multiple patterns in one condition', () => {
+      const multi: Condition = {
+        conditionType: 'UrlWildcardCondition',
+        pattern: '*.example.com/*|*.example.net/*',
+      };
+      testCond(multi, 'http://a.example.com/abc', true);
+      testCond(multi, 'http://b.example.net/def', true);
+      testCond(multi, 'http://c.example.org/ghi', false);
+    });
+  });
+
+  describe('HostRegexCondition', () => {
+    const cond: Condition = {
+      conditionType: 'HostRegexCondition',
+      pattern: '.*\\.example\\.com',
+    };
+    it('should match requests based on regex pattern', () => {
+      testCond(cond, 'http://www.example.com/', true);
+    });
+    it('should not match requests not matching the pattern', () => {
+      testCond(cond, 'http://example.com/', false);
+    });
+    it('should not match URL parts other than the host', () => {
+      expect(testCond(cond, 'http://example.net/www.example.com', false)).toBe(false);
+    });
+  });
+
+  describe('HostWildcardCondition', () => {
+    const cond: Condition = {
+      conditionType: 'HostWildcardCondition',
+      pattern: '*.example.com',
+    };
+    it('should match requests based on wildcard pattern', () => {
+      testCond(cond, 'http://www.example.com/', true);
+    });
+    it('should also match hostname without the optional level', () => {
+      // https://github.com/FelisCatus/SwitchyOmega/wiki/Host-wildcard-condition
+      testCond(cond, 'http://example.com/', true);
+    });
+    it('should process patterns like *.*example.com correctly', () => {
+      // https://github.com/FelisCatus/SwitchyOmega/issues/158
+      const con: Condition = {
+        conditionType: 'HostWildcardCondition',
+        pattern: '*.*example.com',
+      };
+      testCond(con, 'http://example.com/', true);
+      testCond(con, 'http://www.example.com/', true);
+      testCond(con, 'http://www.some-example.com/', true);
+      testCond(con, 'http://xample.com/', false);
+    });
+    it('should allow override of the magical behavior', () => {
+      const con: Condition = {
+        conditionType: 'HostWildcardCondition',
+        pattern: '**.example.com',
+      };
+      testCond(con, 'http://www.example.com/', true);
+      testCond(con, 'http://example.com/', false);
+    });
+    it('should not match URL parts other than the host', () => {
+      expect(testCond(cond, 'http://example.net/www.example.com', false)).toBe(false);
+    });
+    it('should support multiple patterns in one condition', () => {
+      const multi: Condition = {
+        conditionType: 'HostWildcardCondition',
+        pattern: '*.example.com|*.example.net',
+      };
+      testCond(multi, 'http://a.example.com/abc', true);
+      testCond(multi, 'http://example.net/def', true);
+      testCond(multi, 'http://c.example.org/ghi', false);
+    });
+  });
+
+  describe('BypassCondition', () => {
+    // See https://developer.chrome.com/docs/extensions/reference/api/proxy
+    it('should correctly support patterns containing hosts', () => {
+      testCond(
+        { conditionType: 'BypassCondition', pattern: '.example.com' },
+        'http://www.example.com/',
+        true,
+      );
+      testCond(
+        { conditionType: 'BypassCondition', pattern: '.example.com' },
+        'http://example.com/',
+        false,
+      );
+      testCond(
+        { conditionType: 'BypassCondition', pattern: '*.example.com' },
+        'http://www.example.com/',
+        true,
+      );
+      testCond(
+        { conditionType: 'BypassCondition', pattern: '*.example.com' },
+        'http://example.com/',
+        false,
+      );
+      testCond(
+        { conditionType: 'BypassCondition', pattern: 'example.com' },
+        'http://example.com/',
+        true,
+      );
+      testCond(
+        { conditionType: 'BypassCondition', pattern: 'example.com' },
+        'http://www.example.com/',
+        false,
+      );
+      testCond(
+        { conditionType: 'BypassCondition', pattern: '*example.com' },
+        'http://example.com/',
+        true,
+      );
+      testCond(
+        { conditionType: 'BypassCondition', pattern: '*example.com' },
+        'http://www.example.com/',
+        true,
+      );
+      testCond(
+        { conditionType: 'BypassCondition', pattern: '*example.com' },
+        'http://anotherexample.com/',
+        true,
+      );
+    });
+
+    it('should match the scheme specified in the pattern', () => {
+      const cond: Condition = {
+        conditionType: 'BypassCondition',
+        pattern: 'http://example.com',
+      };
+      testCond(cond, 'http://example.com/', true);
+      testCond(cond, 'https://example.com/', false);
+    });
+
+    it('should match the port specified in the pattern', () => {
+      const cond: Condition = {
+        conditionType: 'BypassCondition',
+        pattern: 'http://example.com:8080',
+      };
+      testCond(cond, 'http://example.com:8080/', true);
+      testCond(cond, 'http://example.com:888/', false);
+    });
+
+    it('should correctly support patterns using IPv4 literals', () => {
+      const cond: Condition = {
+        conditionType: 'BypassCondition',
+        pattern: 'http://127.0.0.1:8080',
+      };
+      testCond(cond, 'http://127.0.0.1:8080/', true);
+      testCond(cond, 'http://127.0.0.2:8080/', false);
+    });
+
+    it('should correctly support IPv6 canonicalization', () => {
+      const cond: Condition = {
+        conditionType: 'BypassCondition',
+        pattern: 'http://[0:0::1]:8080',
+      };
+      testCond(cond, 'http://[::1]:8080/', true);
+      testCond(cond, 'http://[1::1]:8080/', false);
+    });
+
+    it('should correctly support IPv6 canonicalization 2', () => {
+      const cond: Condition = { conditionType: 'BypassCondition', pattern: '[::1]' };
+      testCond(cond, 'http://[::1]:8080/', true);
+      testCond(cond, 'http://[1::1]:8080/', false);
+    });
+
+    it('should parse IPv4 CIDR notation', () => {
+      const cond: Condition = {
+        conditionType: 'BypassCondition',
+        pattern: '192.168.0.0/16',
+      };
+      const result = Conditions.analyze(cond) as { ip: unknown };
+      expect(result.ip).toBeTruthy();
+      expect(result.ip).toEqual({
+        conditionType: 'IpCondition',
+        ip: '192.168.0.0',
+        prefixLength: 16,
+      });
+    });
+
+    it('should parse IPv6 CIDR notation', () => {
+      const cond: Condition = {
+        conditionType: 'BypassCondition',
+        pattern: 'fefe:13::abc/33',
+      };
+      const result = Conditions.analyze(cond) as { ip: unknown };
+      expect(result.ip).toBeTruthy();
+      expect(result.ip).toEqual({
+        conditionType: 'IpCondition',
+        ip: 'fefe:13::abc',
+        prefixLength: 33,
+      });
+    });
+
+    it('should parse IPv6 CIDR notation with zero prefixLength', () => {
+      const cond: Condition = { conditionType: 'BypassCondition', pattern: '::/0' };
+      const result = Conditions.analyze(cond) as { ip: unknown };
+      expect(result.ip).toBeTruthy();
+      expect(result.ip).toEqual({
+        conditionType: 'IpCondition',
+        ip: '::',
+        prefixLength: 0,
+      });
+    });
+
+    it('should match 127.0.0.1 when <local> is used', () => {
+      testCond(
+        { conditionType: 'BypassCondition', pattern: '<local>' },
+        'http://127.0.0.1:8080/',
+        true,
+      );
+    });
+
+    it('should match [::1] when <local> is used', () => {
+      testCond(
+        { conditionType: 'BypassCondition', pattern: '<local>' },
+        'http://[::1]:8080/',
+        true,
+      );
+    });
+
+    it('should match any host without dots when <local> is used', () => {
+      const cond: Condition = { conditionType: 'BypassCondition', pattern: '<local>' };
+      testCond(cond, 'http://localhost:8080/', true);
+      testCond(cond, 'http://intranet:8080/', true);
+      testCond(cond, 'http://foobar/', true);
+      testCond(cond, 'http://example.com/', false);
+
+      // Intended: see the reasoning in the BypassCondition <local> handler.
+      testCond(cond, 'http://[::ffff:eeee]/', true);
+
+      // Behavior change from the CoffeeScript version. The old implementation
+      // parsed URLs with Node's legacy `url.parse`, which left `::1.2.3.4`
+      // untouched, so the embedded-IPv4 dots made this NOT match. Requests are
+      // now parsed with the WHATWG `URL`, which canonicalises the host to
+      // `::102:304` — exactly what Chrome passes to a PAC script — so it has no
+      // dots and does match. The new result reflects real browser behavior.
+      testCond(cond, 'http://[::1.2.3.4]/', true);
+    });
+  });
+
+  describe('IpCondition', () => {
+    // IpCondition compiles to isInNet/isInNetEx, which the PAC runner provides
+    // and the unit test does not, so testCond cannot be used directly here.
+    it('should support IPv4 subnet', () => {
+      const cond: Condition = {
+        conditionType: 'IpCondition',
+        ip: '192.168.1.1',
+        prefixLength: 16,
+      };
+      const request = Conditions.requestFromUrl('http://192.168.4.4/');
+      expect(Conditions.match(cond, request)).toBe(true);
+      expect(Conditions.compile(cond).code).toContain(
+        'isInNet(host,"192.168.1.1","255.255.0.0")',
+      );
+    });
+
+    it('should support IPv6 subnet', () => {
+      const cond: Condition = {
+        conditionType: 'IpCondition',
+        ip: 'fefe:13::abc',
+        prefixLength: 33,
+      };
+      const request = Conditions.requestFromUrl('http://[fefe:13::def]/');
+      expect(Conditions.match(cond, request)).toBe(true);
+
+      const compiled = Conditions.compile(cond).code;
+      expect(compiled).toContain('isInNet(host,"fefe:13::abc","ffff:ffff:8000::")');
+      expect(compiled).toContain('isInNetEx(host,"fefe:13::abc/33")');
+    });
+
+    it('should support IPv6 subnet with zero prefixLength', () => {
+      const cond: Condition = {
+        conditionType: 'IpCondition',
+        ip: '::',
+        prefixLength: 0,
+      };
+      const request = Conditions.requestFromUrl('http://[fefe:13::def]/');
+      expect(Conditions.match(cond, request)).toBe(true);
+      expect(Conditions.compile(cond).code.indexOf('indexOf(')).toBeGreaterThan(0);
+    });
+
+    it('should not match domain name to IP subnet', () => {
+      const cond: Condition = {
+        conditionType: 'IpCondition',
+        ip: '::',
+        prefixLength: 0,
+      };
+      const request = Conditions.requestFromUrl('http://www.example.com/');
+      expect(Conditions.match(cond, request)).toBe(false);
+    });
+
+    it('should not pass domain name to isInNet function', () => {
+      const ipToCompiledFunc = (ip: string, prefixLength: number) =>
+        compileWithStubIsInNet({ conditionType: 'IpCondition', ip, prefixLength });
+
+      let compiledFunc = ipToCompiledFunc('0.0.0.0', 0);
+      expect(compiledFunc(null, 'www.example.com')).toBe(false);
+      expect(compiledFunc(null, '127.0.0.1')).toBe(true);
+
+      compiledFunc = ipToCompiledFunc('0.0.0.0', 1);
+      expect(compiledFunc(null, 'www.example.com')).toBe(false);
+      expect(compiledFunc(null, '127.0.0.1')).toBe(true);
+
+      compiledFunc = ipToCompiledFunc('::', 0);
+      expect(compiledFunc(null, 'www.example.com')).toBe(false);
+      expect(compiledFunc(null, '::1')).toBe(true);
+
+      compiledFunc = ipToCompiledFunc('::', 1);
+      expect(compiledFunc(null, 'www.example.com')).toBe(false);
+      expect(compiledFunc(null, '::1')).toBe(true);
+    });
+  });
+
+  describe('KeywordCondition', () => {
+    const cond: Condition = {
+      conditionType: 'KeywordCondition',
+      pattern: 'example.com',
+    };
+    it('should match requests based on substring', () => {
+      testCond(cond, 'http://www.example.com/', true);
+      testCond(cond, 'http://www.example.net/', false);
+    });
+    it('should not match HTTPS requests', () => {
+      testCond(cond, 'https://example.com/', false);
+      testCond(cond, 'https://example.net/', false);
+    });
+  });
+
+  describe('WeekdayCondition', () => {
+    beforeAll(() => {
+      vi.useFakeTimers();
+    });
+    afterAll(() => {
+      vi.useRealTimers();
+    });
+
+    // Feb 2016 calendar used by these fixtures:
+    // Su Mo Tu We Th Fr Sa
+    // .. 01 02 03 04 05 06
+    // 07 08 09 10 11 12 13
+    const testCondDay = (cond: Condition, day: number, shouldMatch: boolean) => {
+      const date = day > 0 ? day : 7;
+      vi.setSystemTime(new Date(`2016-02-0${date}T00:00:00Z`));
+      testCond(cond, `http://weekday-${day}/`, shouldMatch);
+    };
+
+    it('should match requests based on date range', () => {
+      const cond: Condition = {
+        conditionType: 'WeekdayCondition',
+        startDay: 3,
+        endDay: 5,
+      };
+      testCondDay(cond, 0, false);
+      testCondDay(cond, 1, false);
+      testCondDay(cond, 2, false);
+      testCondDay(cond, 3, true);
+      testCondDay(cond, 4, true);
+      testCondDay(cond, 5, true);
+      testCondDay(cond, 6, false);
+    });
+
+    it('should match the day if startDay == endDay', () => {
+      const cond: Condition = {
+        conditionType: 'WeekdayCondition',
+        startDay: 3,
+        endDay: 3,
+      };
+      testCondDay(cond, 0, false);
+      testCondDay(cond, 1, false);
+      testCondDay(cond, 2, false);
+      testCondDay(cond, 3, true);
+      testCondDay(cond, 4, false);
+      testCondDay(cond, 5, false);
+      testCondDay(cond, 6, false);
+    });
+
+    it('should not match anything if startDay > endDay', () => {
+      const cond: Condition = {
+        conditionType: 'WeekdayCondition',
+        startDay: 4,
+        endDay: 3,
+      };
+      for (let day = 0; day <= 6; day++) {
+        testCondDay(cond, day, false);
+      }
+    });
+
+    it('should match according to .days', () => {
+      let cond: Condition = { conditionType: 'WeekdayCondition', days: 'SMTWtFs' };
+      for (let day = 0; day <= 6; day++) {
+        testCondDay(cond, day, true);
+      }
+
+      cond = { conditionType: 'WeekdayCondition', days: 'S-TW-F-' };
+      testCondDay(cond, 0, true);
+      testCondDay(cond, 1, false);
+      testCondDay(cond, 2, true);
+      testCondDay(cond, 3, true);
+      testCondDay(cond, 4, false);
+      testCondDay(cond, 5, true);
+      testCondDay(cond, 6, false);
+    });
+
+    it('should prefer .days to .startDay and .endDay', () => {
+      const cond: Condition = {
+        conditionType: 'WeekdayCondition',
+        days: '--TW---',
+        startDay: 0,
+        endDay: 0,
+      };
+      testCondDay(cond, 0, false);
+      testCondDay(cond, 1, false);
+      testCondDay(cond, 2, true);
+      testCondDay(cond, 3, true);
+      testCondDay(cond, 4, false);
+      testCondDay(cond, 5, false);
+      testCondDay(cond, 6, false);
+    });
+  });
+
+  describe('TimeCondition', () => {
+    beforeAll(() => {
+      vi.useFakeTimers();
+    });
+    afterAll(() => {
+      vi.useRealTimers();
+    });
+
+    // RFC 2822 format keeps these in the local time zone; ISO-8601 would be
+    // interpreted as UTC.
+    const testCondTime = (cond: Condition, time: string, shouldMatch: boolean) => {
+      vi.setSystemTime(new Date(`01 Feb 2016 ${time}`));
+      // Colons are not legal in a host, so they are dropped here. The URL is
+      // arbitrary for a TimeCondition; it only has to be a parseable one.
+      testCond(cond, `http://time-${time.replace(/:/g, '')}/`, shouldMatch);
+    };
+
+    it('should match requests based on hour range', () => {
+      const cond: Condition = {
+        conditionType: 'TimeCondition',
+        startHour: 7,
+        endHour: 9,
+      };
+      testCondTime(cond, '00:00:00', false);
+      testCondTime(cond, '06:00:00', false);
+      testCondTime(cond, '07:00:00', true);
+      testCondTime(cond, '08:00:00', true);
+      testCondTime(cond, '09:00:00', true);
+      testCondTime(cond, '09:59:59', true);
+      testCondTime(cond, '10:00:00', false);
+      testCondTime(cond, '19:00:00', false);
+      testCondTime(cond, '23:00:00', false);
+    });
+
+    it('should match the hour if startHour == endHour', () => {
+      const cond: Condition = {
+        conditionType: 'TimeCondition',
+        startHour: 7,
+        endHour: 7,
+      };
+      testCondTime(cond, '00:00:00', false);
+      testCondTime(cond, '06:00:00', false);
+      testCondTime(cond, '07:00:00', true);
+      testCondTime(cond, '07:00:01', true);
+      testCondTime(cond, '07:59:59', true);
+      testCondTime(cond, '08:00:00', false);
+      testCondTime(cond, '19:00:00', false);
+    });
+
+    it('should not match anything if startHour > endHour', () => {
+      const cond: Condition = {
+        conditionType: 'TimeCondition',
+        startHour: 7,
+        endHour: 6,
+      };
+      for (const time of [
+        '00:00:00',
+        '06:00:00',
+        '06:59:59',
+        '07:00:00',
+        '08:00:00',
+        '09:00:00',
+        '10:00:00',
+        '19:00:00',
+        '23:00:00',
+      ]) {
+        testCondTime(cond, time, false);
+      }
+    });
+  });
+
+  describe('#typeFromAbbr', () => {
+    it('should get condition types by abbrs', () => {
+      expect(Conditions.typeFromAbbr('True')).toBe('TrueCondition');
+      expect(Conditions.typeFromAbbr('HR')).toBe('HostRegexCondition');
+    });
+  });
+
+  describe('#str and #fromStr', () => {
+    it('should encode & decode TrueCondition correctly', () => {
+      const condition: Condition = { conditionType: 'TrueCondition' };
+      const result = Conditions.str(condition);
+      expect(result).toBe('True:');
+      expect(Conditions.fromStr(result)).toEqual(condition);
+    });
+
+    it('should encode & decode conditions with pattern correctly', () => {
+      const condition: Condition = {
+        conditionType: 'UrlWildcardCondition',
+        pattern: '*://*.example.com/*',
+      };
+      const result = Conditions.str(condition);
+      expect(result).toBe('UrlWildcard: ' + condition.pattern);
+      expect(Conditions.fromStr(result)).toEqual(condition);
+    });
+
+    it('should encode & decode False while preserving pattern', () => {
+      const condition: Condition = {
+        conditionType: 'FalseCondition',
+        pattern: 'a b c',
+      };
+      const result = Conditions.str(condition);
+      expect(result).toBe('Disabled: a b c');
+      expect(Conditions.fromStr(result)).toEqual(condition);
+    });
+
+    it('should encode & decode FalseCondition without any pattern', () => {
+      const condition: Condition = { conditionType: 'FalseCondition' };
+      const result = Conditions.str(condition);
+      expect(result).toBe('Disabled:');
+      expect(Conditions.fromStr(result)).toEqual(condition);
+    });
+
+    it('should encode & decode HostWildcardCondition using shorthand syntax', () => {
+      const condition: Condition = {
+        conditionType: 'HostWildcardCondition',
+        pattern: '*.example.com',
+      };
+      const result = Conditions.str(condition);
+      expect(result).toBe(condition.pattern);
+      expect(Conditions.fromStr(result)).toEqual(condition);
+    });
+
+    it('should encode & decode HostWildcardCondition ending with colon', () => {
+      const condition: Condition = {
+        conditionType: 'HostWildcardCondition',
+        pattern: 'bogus:',
+      };
+      const result = Conditions.str(condition);
+      expect(result).toBe('HostWildcard: ' + condition.pattern);
+      expect(Conditions.fromStr(result)).toEqual(condition);
+    });
+
+    it('should encode & decode BypassCondition correctly', () => {
+      const condition: Condition = {
+        conditionType: 'BypassCondition',
+        pattern: '127.0.0.1/16',
+      };
+      const result = Conditions.str(condition);
+      expect(result).toBe('Bypass: 127.0.0.1/16');
+      expect(Conditions.fromStr(result)).toEqual(condition);
+    });
+
+    it('should add brackets for IPv6 hosts in BypassCondition', () => {
+      const condition: Condition = { conditionType: 'BypassCondition', pattern: '::1' };
+      const result = Conditions.str(condition);
+      expect(result).toBe('Bypass: [::1]');
+      const cond = Conditions.fromStr(result)!;
+      expect(cond.conditionType).toBe('BypassCondition');
+      expect((cond as { pattern: string }).pattern).toBe('[::1]');
+    });
+
+    it('should add brackets for IPv6 hosts with scheme in BypassCondition', () => {
+      const condition: Condition = {
+        conditionType: 'BypassCondition',
+        pattern: 'http://::1',
+      };
+      const result = Conditions.str(condition);
+      expect(result).toBe('Bypass: http://[::1]');
+      const cond = Conditions.fromStr(result)!;
+      expect(cond.conditionType).toBe('BypassCondition');
+      expect((cond as { pattern: string }).pattern).toBe('http://[::1]');
+    });
+
+    it('should preserve the scheme of a host pattern in BypassCondition', () => {
+      // Regression test for a bug in the CoffeeScript implementation, which
+      // overwrote the accumulated normalized pattern instead of appending to it
+      // and so silently dropped the scheme from hostname patterns.
+      const condition: Condition = {
+        conditionType: 'BypassCondition',
+        pattern: 'http://*.example.com',
+      };
+      expect(Conditions.str(condition)).toBe('Bypass: http://*.example.com');
+    });
+
+    it('should encode & decode IpCondition correctly', () => {
+      const condition: Condition = {
+        conditionType: 'IpCondition',
+        ip: '127.0.0.1',
+        prefixLength: 16,
+      };
+      const result = Conditions.str(condition);
+      expect(result).toBe('Ip: 127.0.0.1/16');
+      expect(Conditions.fromStr(result)).toEqual(condition);
+    });
+
+    it('should provide sensible fallbacks for invalid IpCondition', () => {
+      expect(Conditions.fromStr('Ip: foo/-233')).toEqual({
+        conditionType: 'IpCondition',
+        ip: '0.0.0.0',
+        prefixLength: 0,
+      });
+      expect(Conditions.fromStr('Ip: nonsense stuff')).toEqual({
+        conditionType: 'IpCondition',
+        ip: '0.0.0.0',
+        prefixLength: 0,
+      });
+    });
+
+    it('should assume full match for IpCondition without prefixLength', () => {
+      expect(Conditions.fromStr('Ip: 127.0.0.1')).toEqual({
+        conditionType: 'IpCondition',
+        ip: '127.0.0.1',
+        prefixLength: 32,
+      });
+      expect(Conditions.fromStr('Ip: ::1')).toEqual({
+        conditionType: 'IpCondition',
+        ip: '::1',
+        prefixLength: 128,
+      });
+    });
+
+    it('should provide sensible fallbacks for negative prefixLength', () => {
+      expect(Conditions.fromStr('Ip: 0.0.0.0/-233')).toEqual({
+        conditionType: 'IpCondition',
+        ip: '0.0.0.0',
+        prefixLength: 0,
+      });
+    });
+
+    it('should encode & decode HostLevelsCondition correctly', () => {
+      const condition: Condition = {
+        conditionType: 'HostLevelsCondition',
+        minValue: 4,
+        maxValue: 7,
+      };
+      const result = Conditions.str(condition);
+      expect(result).toBe('HostLevels: 4~7');
+      expect(Conditions.fromStr(result)).toEqual(condition);
+    });
+
+    it('should provide sensible fallbacks for HostLevels out of range', () => {
+      expect(Conditions.fromStr('HostLevels: A~-1')).toEqual({
+        conditionType: 'HostLevelsCondition',
+        minValue: 1,
+        maxValue: 1,
+      });
+      expect(Conditions.fromStr('HostLevels: nonsense')).toEqual({
+        conditionType: 'HostLevelsCondition',
+        minValue: 1,
+        maxValue: 1,
+      });
+    });
+
+    it('should encode & decode WeekdayCondition correctly', () => {
+      const condition: Condition = {
+        conditionType: 'WeekdayCondition',
+        startDay: 3,
+        endDay: 6,
+      };
+      const result = Conditions.str(condition);
+      expect(result).toBe('Weekday: 3~6');
+      expect(Conditions.fromStr(result)).toEqual(condition);
+    });
+
+    it('should provide sensible fallbacks for Weekday out of range', () => {
+      expect(Conditions.fromStr('Weekday: -1~100')).toEqual({
+        conditionType: 'WeekdayCondition',
+        startDay: 0,
+        endDay: 0,
+      });
+      expect(Conditions.fromStr('Weekday: nonsense')).toEqual({
+        conditionType: 'WeekdayCondition',
+        startDay: 0,
+        endDay: 0,
+      });
+    });
+
+    it('should encode & decode WeekdayCondition with days', () => {
+      let condition: Condition = { conditionType: 'WeekdayCondition', days: 'SMTWtFs' };
+      let result = Conditions.str(condition);
+      expect(result).toBe('Weekday: SMTWtFs');
+      expect(Conditions.fromStr(result)).toEqual(condition);
+
+      condition = { conditionType: 'WeekdayCondition', days: 'SM-W-Fs' };
+      result = Conditions.str(condition);
+      expect(result).toBe('Weekday: SM-W-Fs');
+      expect(Conditions.fromStr(result)).toEqual(condition);
+    });
+
+    it('should encode & decode TimeCondition correctly', () => {
+      const condition: Condition = {
+        conditionType: 'TimeCondition',
+        startHour: 7,
+        endHour: 23,
+      };
+      const result = Conditions.str(condition);
+      expect(result).toBe('Hour: 7~23');
+      expect(Conditions.fromStr(result)).toEqual(condition);
+    });
+
+    it('should provide sensible fallbacks for Hour out of range', () => {
+      expect(Conditions.fromStr('Hour: -1~100')).toEqual({
+        conditionType: 'TimeCondition',
+        startHour: 0,
+        endHour: 0,
+      });
+      expect(Conditions.fromStr('Hour: nonsense')).toEqual({
+        conditionType: 'TimeCondition',
+        startHour: 0,
+        endHour: 0,
+      });
+    });
+
+    it('should parse conditions with extra spaces correctly', () => {
+      expect(Conditions.fromStr('url:    *abcde*   ')).toEqual({
+        conditionType: 'UrlWildcardCondition',
+        pattern: '*abcde*',
+      });
+    });
+
+    it('should parse abbreviated condition types correctly', () => {
+      expect(Conditions.fromStr('url: *://*.example.com/*')).toEqual({
+        conditionType: 'UrlWildcardCondition',
+        pattern: '*://*.example.com/*',
+      });
+    });
+
+    it('should parse escaped HostWildcardCondition starting with colon', () => {
+      expect(Conditions.fromStr(': :bogus:')).toEqual({
+        conditionType: 'HostWildcardCondition',
+        pattern: ':bogus:',
+      });
+    });
+  });
+});

--- a/packages/pac/test/domain-trie.test.ts
+++ b/packages/pac/test/domain-trie.test.ts
@@ -1,0 +1,366 @@
+import { describe, it, expect } from 'vitest';
+import { DomainTrie } from '../src/domain-trie.js';
+import * as Profiles from '../src/profiles.js';
+import * as Conditions from '../src/conditions.js';
+import type { Rule, SwitchProfile, Request as PacRequest } from '../src/types.js';
+
+describe('DomainTrie', () => {
+  describe('exact match', () => {
+    it('should match exact hosts only', () => {
+      const trie = new DomainTrie<number>();
+      trie.insert('example.com', 1);
+      expect(trie.search('example.com')).toBe(1);
+      expect(trie.search('www.example.com')).toBeUndefined();
+      expect(trie.search('foo.com')).toBeUndefined();
+    });
+  });
+
+  describe('star wildcard', () => {
+    it('should match exactly one label', () => {
+      const trie = new DomainTrie<number>();
+      trie.insert('*.example.com', 1);
+      expect(trie.search('www.example.com')).toBe(1);
+      expect(trie.search('foo.example.com')).toBe(1);
+      expect(trie.search('example.com')).toBeUndefined();
+      expect(trie.search('a.b.example.com')).toBeUndefined();
+    });
+  });
+
+  describe('dot wildcard', () => {
+    it('should match one or more labels under the suffix', () => {
+      const trie = new DomainTrie<number>();
+      trie.insert('.example.com', 1);
+      expect(trie.search('example.com')).toBeUndefined();
+      expect(trie.search('www.example.com')).toBe(1);
+      expect(trie.search('a.b.example.com')).toBe(1);
+    });
+  });
+
+  describe('plus wildcard', () => {
+    it('should match one or more labels under the suffix', () => {
+      const trie = new DomainTrie<number>();
+      trie.insert('+.example.com', 1);
+      expect(trie.search('www.example.com')).toBe(1);
+      expect(trie.search('a.b.example.com')).toBe(1);
+      expect(trie.search('example.com')).toBeUndefined();
+    });
+  });
+
+  describe('priority (search)', () => {
+    it('should prefer exact over wildcards', () => {
+      const trie = new DomainTrie<number>();
+      trie.insert('www.example.com', 1);
+      trie.insert('*.example.com', 2);
+      trie.insert('.example.com', 3);
+      expect(trie.search('www.example.com')).toBe(1);
+      expect(trie.search('foo.example.com')).toBe(2);
+      expect(trie.search('a.b.example.com')).toBe(3);
+    });
+  });
+
+  describe('searchMin', () => {
+    it('should fold the minimum value across all matching patterns', () => {
+      const trie = new DomainTrie<number>();
+      trie.insert('+.a.com', 1);
+      trie.insert('+.b.a.com', 3);
+      trie.insert('x.b.a.com', 7);
+      // Most-specific prefers exact/deepest.
+      expect(trie.search('x.b.a.com')).toBe(7);
+      // Min folds the earliest rule index among all matches.
+      expect(trie.searchMin('x.b.a.com')).toBe(1);
+      expect(trie.searchMin('y.b.a.com')).toBe(1);
+      expect(trie.searchMin('deep.y.b.a.com')).toBe(1);
+      expect(trie.searchMin('unrelated.com')).toBeUndefined();
+    });
+
+    it('should see star, dot, and exact values', () => {
+      const trie = new DomainTrie<number>();
+      trie.insert('exact.example.com', 9);
+      trie.insert('*.example.com', 4);
+      trie.insert('.example.com', 6);
+      expect(trie.searchMin('exact.example.com')).toBe(4);
+      expect(trie.searchMin('a.b.example.com')).toBe(6);
+      expect(trie.searchMin('example.com')).toBeUndefined();
+    });
+  });
+
+  describe('first-insert-wins', () => {
+    it('should keep the first value for the same pattern', () => {
+      const trie = new DomainTrie<number>();
+      trie.insert('*.example.com', 1);
+      trie.insert('*.example.com', 2);
+      expect(trie.search('foo.example.com')).toBe(1);
+    });
+  });
+
+  describe('case insensitivity', () => {
+    it('should match regardless of case', () => {
+      const trie = new DomainTrie<number>();
+      trie.insert('Example.COM', 1);
+      expect(trie.search('example.com')).toBe(1);
+      expect(trie.search('EXAMPLE.COM')).toBe(1);
+    });
+  });
+
+  describe('empty trie', () => {
+    it('should match nothing', () => {
+      const trie = new DomainTrie<number>();
+      expect(trie.isEmpty()).toBe(true);
+      expect(trie.search('anything.com')).toBeUndefined();
+      expect(trie.searchMin('anything.com')).toBeUndefined();
+    });
+  });
+});
+
+describe('DomainTrie integration with profiles', () => {
+  describe('_hostPatternToTrieKeys', () => {
+    // `hostPatternToTrieKeys` is now exported from src/profiles.ts as a
+    // deliberate testing seam, mirroring the CoffeeScript original's
+    // `Profiles._hostPatternToTrieKeys`.
+    const keys = Profiles.hostPatternToTrieKeys;
+
+    it('should map *.example.com to apex + subdomain keys', () => {
+      expect(keys('*.example.com')).toEqual(['example.com', '.example.com']);
+    });
+
+    it('should map .example.com like *.', () => {
+      expect(keys('.example.com')).toEqual(['example.com', '.example.com']);
+    });
+
+    it('should map **.example.com to subdomain-only key', () => {
+      expect(keys('**.example.com')).toEqual(['.example.com']);
+    });
+
+    it('should map exact domains', () => {
+      expect(keys('example.com')).toEqual(['example.com']);
+    });
+
+    it('should reject complex patterns', () => {
+      expect(keys('*.*example.com')).toBeNull();
+      expect(keys('test?.com')).toBeNull();
+      expect(keys('*')).toBeNull();
+    });
+  });
+
+  describe('_buildRulesAnalysis', () => {
+    it('should mark simple HostWildcard rules and build the trie', () => {
+      const rules: Rule[] = [
+        {
+          condition: { conditionType: 'HostWildcardCondition', pattern: '*.example.com' },
+          profileName: 'proxy',
+        },
+        {
+          condition: { conditionType: 'HostWildcardCondition', pattern: '*.test.org' },
+          profileName: 'proxy',
+        },
+      ];
+      const result = Profiles.buildRulesAnalysis(rules);
+      expect(result.simpleHost[0]).toBe(true);
+      expect(result.simpleHost[1]).toBe(true);
+      expect(result.domainTrie.isEmpty()).toBe(false);
+      expect(result.domainTrie.searchMin('www.example.com')).toBe(0);
+      expect(result.domainTrie.searchMin('www.test.org')).toBe(1);
+      expect(result.hasNonHostRules).toBe(false);
+    });
+
+    it('should detect non-host rules', () => {
+      const rules: Rule[] = [
+        {
+          condition: { conditionType: 'HostWildcardCondition', pattern: '*.example.com' },
+          profileName: 'proxy',
+        },
+        {
+          condition: { conditionType: 'KeywordCondition', pattern: 'test' },
+          profileName: 'proxy',
+        },
+      ];
+      const result = Profiles.buildRulesAnalysis(rules);
+      expect(result.simpleHost[0]).toBe(true);
+      expect(result.simpleHost[1]).toBe(false);
+      expect(result.hasNonHostRules).toBe(true);
+    });
+
+    it('should keep complex host patterns on the linear path', () => {
+      const rules: Rule[] = [
+        {
+          condition: { conditionType: 'HostWildcardCondition', pattern: '*.*example.com' },
+          profileName: 'proxy',
+        },
+      ];
+      const result = Profiles.buildRulesAnalysis(rules);
+      expect(result.simpleHost[0]).toBe(false);
+      expect(result.hasNonHostRules).toBe(true);
+    });
+
+    it('should not partially insert multi-pattern rules with a complex part', () => {
+      const rules: Rule[] = [
+        {
+          condition: {
+            conditionType: 'HostWildcardCondition',
+            pattern: '*.example.com|*.*other.com',
+          },
+          profileName: 'proxy',
+        },
+        {
+          condition: { conditionType: 'HostWildcardCondition', pattern: '*.example.com' },
+          profileName: 'proxy2',
+        },
+      ];
+      const result = Profiles.buildRulesAnalysis(rules);
+      expect(result.simpleHost[0]).toBe(false);
+      expect(result.simpleHost[1]).toBe(true);
+      // Rule 1 owns example.com; rule 0 must not have claimed it.
+      expect(result.domainTrie.searchMin('www.example.com')).toBe(1);
+    });
+
+    it('should handle multi-pattern simple conditions', () => {
+      const rules: Rule[] = [
+        {
+          condition: {
+            conditionType: 'HostWildcardCondition',
+            pattern: '*.example.com|*.test.org',
+          },
+          profileName: 'proxy',
+        },
+      ];
+      const result = Profiles.buildRulesAnalysis(rules);
+      expect(result.simpleHost[0]).toBe(true);
+      expect(result.domainTrie.searchMin('a.example.com')).toBe(0);
+      expect(result.domainTrie.searchMin('b.test.org')).toBe(0);
+    });
+
+    it('should handle empty rules', () => {
+      const result = Profiles.buildRulesAnalysis([]);
+      expect(result.domainTrie.isEmpty()).toBe(true);
+      expect(result.rules).toHaveLength(0);
+    });
+  });
+
+  describe('SwitchProfile with domain trie', () => {
+    function makeProfile(rules: Rule[], defaultProfile = 'direct'): SwitchProfile {
+      const profile = Profiles.create({
+        name: 'test',
+        profileType: 'SwitchProfile',
+        defaultProfileName: defaultProfile,
+        rules,
+      } as SwitchProfile) as SwitchProfile;
+      profile.revision = 'test-rev-' + Math.random();
+      return profile;
+    }
+
+    function makeRequest(url: string): PacRequest {
+      return Conditions.requestFromUrl(url);
+    }
+
+    it('should match domains via the trie', () => {
+      const profile = makeProfile([
+        {
+          condition: { conditionType: 'HostWildcardCondition', pattern: '*.example.com' },
+          profileName: 'proxy1',
+        },
+      ]);
+      let result = Profiles.match(profile, makeRequest('http://www.example.com/'));
+      expect((result as Rule).profileName).toBe('proxy1');
+      result = Profiles.match(profile, makeRequest('http://example.com/'));
+      expect((result as Rule).profileName).toBe('proxy1');
+    });
+
+    it('should honor **. subdomain-only patterns', () => {
+      const profile = makeProfile([
+        {
+          condition: { conditionType: 'HostWildcardCondition', pattern: '**.example.com' },
+          profileName: 'proxy1',
+        },
+      ]);
+      let result = Profiles.match(profile, makeRequest('http://www.example.com/'));
+      expect((result as Rule).profileName).toBe('proxy1');
+      result = Profiles.match(profile, makeRequest('http://example.com/'));
+      expect((result as [string, null])[0]).toBe('+direct');
+    });
+
+    it('should skip non-matching hosts without linear host checks', () => {
+      const profile = makeProfile([
+        {
+          condition: { conditionType: 'HostWildcardCondition', pattern: '*.example.com' },
+          profileName: 'proxy1',
+        },
+      ]);
+      const result = Profiles.match(profile, makeRequest('http://other.net/'));
+      expect((result as [string, null])[0]).toBe('+direct');
+    });
+
+    it('should still match non-host rules when host misses the trie', () => {
+      const profile = makeProfile([
+        {
+          condition: { conditionType: 'HostWildcardCondition', pattern: '*.example.com' },
+          profileName: 'proxy1',
+        },
+        {
+          condition: { conditionType: 'KeywordCondition', pattern: 'keyword' },
+          profileName: 'proxy2',
+        },
+      ]);
+      const result = Profiles.match(profile, makeRequest('http://other.net/path?keyword'));
+      expect((result as Rule).profileName).toBe('proxy2');
+    });
+
+    it('should preserve rule priority order', () => {
+      const profile = makeProfile([
+        {
+          condition: { conditionType: 'HostWildcardCondition', pattern: '*.example.com' },
+          profileName: 'proxy1',
+        },
+        {
+          condition: { conditionType: 'HostWildcardCondition', pattern: '*.example.com' },
+          profileName: 'proxy2',
+        },
+      ]);
+      const result = Profiles.match(profile, makeRequest('http://www.example.com/'));
+      expect((result as Rule).profileName).toBe('proxy1');
+    });
+
+    it('should let earlier non-host rules win over later host hits', () => {
+      const profile = makeProfile([
+        {
+          condition: { conditionType: 'KeywordCondition', pattern: 'special' },
+          profileName: 'proxy-kw',
+        },
+        {
+          condition: { conditionType: 'HostWildcardCondition', pattern: '*.example.com' },
+          profileName: 'proxy-host',
+        },
+      ]);
+      const result = Profiles.match(profile, makeRequest('http://www.example.com/special'));
+      expect((result as Rule).profileName).toBe('proxy-kw');
+    });
+
+    it('should handle complex patterns correctly via linear path', () => {
+      const profile = makeProfile([
+        {
+          condition: { conditionType: 'HostWildcardCondition', pattern: '*.*example.com' },
+          profileName: 'proxy1',
+        },
+      ]);
+      const result = Profiles.match(profile, makeRequest('http://www.some-example.com/'));
+      expect((result as Rule).profileName).toBe('proxy1');
+    });
+
+    it('should handle large rule sets', () => {
+      const rules: Rule[] = [];
+      for (let i = 0; i < 1000; i++) {
+        rules.push({
+          condition: { conditionType: 'HostWildcardCondition', pattern: `*.domain${i}.com` },
+          profileName: 'proxy',
+        });
+      }
+
+      const profile = makeProfile(rules);
+
+      let result = Profiles.match(profile, makeRequest('http://www.domain500.com/'));
+      expect((result as Rule).profileName).toBe('proxy');
+
+      result = Profiles.match(profile, makeRequest('http://www.nomatch.org/'));
+      expect((result as [string, null])[0]).toBe('+direct');
+    });
+  });
+});

--- a/packages/pac/test/pac-generator.test.ts
+++ b/packages/pac/test/pac-generator.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import * as PacGenerator from '../src/pac-generator.js';
+import type { FixedProfile, OptionsBag, SwitchProfile } from '../src/types.js';
+
+const options: OptionsBag = {
+  '+auto': {
+    name: 'auto',
+    profileType: 'SwitchProfile',
+    revision: 'test',
+    defaultProfileName: 'direct',
+    rules: [
+      {
+        profileName: 'proxy',
+        condition: {
+          conditionType: 'UrlRegexCondition',
+          pattern: '^http://(www|www2)\\.example\\.com/',
+        },
+      },
+      {
+        profileName: 'direct',
+        condition: {
+          conditionType: 'HostLevelsCondition',
+          minValue: 3,
+          maxValue: 8,
+        },
+      },
+      {
+        profileName: 'proxy',
+        condition: { conditionType: 'KeywordCondition', pattern: 'keyword' },
+      },
+      {
+        profileName: 'proxy',
+        condition: {
+          conditionType: 'UrlWildcardCondition',
+          pattern: 'https://ssl.example.com/*',
+        },
+      },
+    ],
+  } as SwitchProfile,
+  '+proxy': {
+    name: 'proxy',
+    profileType: 'FixedProfile',
+    revision: 'test',
+    fallbackProxy: { scheme: 'http', host: '127.0.0.1', port: 8888 },
+    bypassList: [
+      { conditionType: 'BypassCondition', pattern: '127.0.0.1:8080' },
+      { conditionType: 'BypassCondition', pattern: '127.0.0.1' },
+      { conditionType: 'BypassCondition', pattern: '<local>' },
+    ],
+  } as FixedProfile,
+};
+
+describe('PacGenerator', () => {
+  it('should generate pac scripts from options', () => {
+    const pac = PacGenerator.script(options, 'auto');
+    expect(pac.length).toBeGreaterThan(0);
+    const FindProxyForURL = new Function(pac + '; return FindProxyForURL;')() as (
+      url: string,
+      host: string,
+    ) => string;
+    const result = FindProxyForURL('http://www.example.com/', 'www.example.com');
+    expect(result).toBe('PROXY 127.0.0.1:8888');
+  });
+
+  // The UglifyJS-based `PacGenerator.compress()` step no longer exists: the
+  // generator now emits already-compact code directly (see pac-generator.ts),
+  // so there is nothing left to minify. This test keeps the same end-to-end
+  // intent as the original "should be able to compress pac scripts" test —
+  // verifying the generated script is non-empty and evaluates correctly —
+  // against the single script() output.
+  it('should generate compact pac scripts directly (no separate compress step)', () => {
+    const pac = PacGenerator.script(options, 'auto');
+    expect(pac.length).toBeGreaterThan(0);
+    const FindProxyForURL = new Function(pac + '; return FindProxyForURL;')() as (
+      url: string,
+      host: string,
+    ) => string;
+    const result = FindProxyForURL('http://www.example.com/', 'www.example.com');
+    expect(result).toBe('PROXY 127.0.0.1:8888');
+  });
+});

--- a/packages/pac/test/profiles.test.ts
+++ b/packages/pac/test/profiles.test.ts
@@ -1,0 +1,442 @@
+import { describe, it, expect } from 'vitest';
+import * as Profiles from '../src/profiles.js';
+import * as Conditions from '../src/conditions.js';
+import type {
+  FixedProfile,
+  PacProfile,
+  Profile,
+  Request,
+  Rule,
+  RuleListProfile,
+  SwitchProfile,
+} from '../src/types.js';
+
+function ruleListResult(profileName: string, source: string): { profileName: string; source: string } {
+  return { profileName, source };
+}
+
+/**
+ * Evaluate a compiled `Expr`'s code the same way the original test used
+ * `eval('(' + compiled.print_to_string() + ')')`: the result may itself be a
+ * plain PAC result string, or a function to be invoked with (url, host, scheme).
+ */
+function evalExpr(expr: { code: string }): unknown {
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+  return new Function('return (' + expr.code + ');')();
+}
+
+/**
+ * Mirrors the CoffeeScript `testProfile` helper exactly, including its use of
+ * loosely-typed fixtures (`expected` varies in shape across call sites: an
+ * array tuple, a Rule-like object, or null).
+ */
+function testProfile(
+  profile: Profile,
+  request: Request | string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  expected: any,
+  expectedCompiled?: unknown,
+): unknown {
+  const oRequest = request;
+  const req: Request = typeof request === 'string' ? Conditions.requestFromUrl(request) : request;
+
+  const compiled = Profiles.compile(profile);
+  let compileResult: unknown = evalExpr(compiled);
+  if (typeof compileResult === 'function') {
+    compileResult = (compileResult as (url: string, host: string, scheme: string) => unknown)(
+      req.url,
+      req.host,
+      req.scheme,
+    );
+  }
+
+  let resolvedExpectedCompiled = expectedCompiled;
+  if (resolvedExpectedCompiled === undefined) {
+    resolvedExpectedCompiled = expected?.[0] ?? Profiles.nameAsKey(expected?.profileName);
+  }
+
+  if (expected !== null && expected !== undefined) {
+    const matchResult = Profiles.match(profile, req);
+    if (expected.source !== undefined) {
+      expect((matchResult as Rule | undefined)?.profileName).toBe(expected.profileName);
+      expect((matchResult as Rule | undefined)?.source).toBe(expected.source);
+    } else {
+      expect(matchResult).toEqual(expected);
+    }
+  }
+
+  if (compileResult !== resolvedExpectedCompiled) {
+    throw new Error(
+      `expect COMPILED profile to return ${String(resolvedExpectedCompiled)} instead of ` +
+        `${String(compileResult)} for request ${String(oRequest)}`,
+    );
+  }
+
+  return expected;
+}
+
+describe('Profiles', () => {
+  describe('#pacResult', () => {
+    it('should return DIRECT for no proxy', () => {
+      expect(Profiles.pacResult()).toBe('DIRECT');
+    });
+
+    it('should return a valid PAC result for a proxy', () => {
+      const proxy = { scheme: 'http', host: '127.0.0.1', port: 8888 };
+      expect(Profiles.pacResult(proxy)).toBe('PROXY 127.0.0.1:8888');
+    });
+
+    it('should return special compatible result for SOCKS5', () => {
+      const proxy = { scheme: 'socks5', host: '127.0.0.1', port: 8888 };
+      const compatibleResult = 'SOCKS5 127.0.0.1:8888; SOCKS 127.0.0.1:8888';
+      expect(Profiles.pacResult(proxy)).toBe(compatibleResult);
+    });
+  });
+
+  describe('#byName', () => {
+    it('should get profiles from builtin profiles', () => {
+      const profile = Profiles.byName('direct', {});
+      expect(typeof profile).toBe('object');
+      expect(profile?.profileType).toBe('DirectProfile');
+    });
+
+    it('should get profiles from given options', () => {
+      let profile: Profile = {} as Profile;
+      profile = Profiles.byName('profile', { '+profile': profile }) as Profile;
+      expect(profile).toBe(profile);
+    });
+  });
+
+  describe('#allReferenceSet', () => {
+    const profile = Profiles.create('test', 'VirtualProfile') as SwitchProfile;
+    profile.defaultProfileName = 'bogus';
+
+    it('should throw if referenced profile does not exist', () => {
+      const getAllReferenceSet = () => Profiles.allReferenceSet(profile, {});
+      expect(getAllReferenceSet).toThrow(Error);
+    });
+
+    it('should process a dumb profile for each missing profile if requested', () => {
+      profile.defaultProfileName = 'bogus';
+      const refs = Profiles.allReferenceSet(profile, {}, { profileNotFound: 'dumb' });
+      expect(refs['+bogus']).toBe('bogus');
+    });
+  });
+
+  describe('SystemProfile', () => {
+    it('should be builtin with the name "system"', () => {
+      const profile = Profiles.byName('system', {});
+      expect(typeof profile).toBe('object');
+      expect(profile?.profileType).toBe('SystemProfile');
+    });
+
+    it('should not match request to profiles', () => {
+      const profile = Profiles.byName('system', {}) as Profile;
+      expect(Profiles.match(profile, {} as Request)).toBeUndefined();
+    });
+
+    it('should throw when trying to compile', () => {
+      const profile = Profiles.byName('system', {}) as Profile;
+      expect(() => Profiles.compile(profile)).toThrow();
+    });
+  });
+
+  describe('DirectProfile', () => {
+    it('should be builtin with the name "direct"', () => {
+      const profile = Profiles.byName('direct', {});
+      expect(typeof profile).toBe('object');
+      expect(profile?.profileType).toBe('DirectProfile');
+    });
+
+    it('should return "DIRECT" when compiled', () => {
+      const profile = Profiles.byName('direct', {}) as Profile;
+      testProfile(profile, {} as Request, null, 'DIRECT');
+    });
+  });
+
+  describe('FixedProfile', () => {
+    const profile = {
+      profileType: 'FixedProfile',
+      bypassList: [
+        {
+          conditionType: 'BypassCondition',
+          pattern: '<local>',
+        },
+      ],
+      proxyForHttp: {
+        scheme: 'socks4',
+        host: '127.0.0.1',
+        port: 1234,
+      },
+      proxyForHttps: {
+        scheme: 'http',
+        host: '127.0.0.1',
+        port: 2345,
+      },
+      fallbackProxy: {
+        scheme: 'socks4',
+        host: '127.0.0.1',
+        port: 3456,
+      },
+      auth: {
+        proxyForHttps: { username: 'test', password: 'cheesecake' },
+      },
+    } as unknown as FixedProfile;
+
+    it('should use protocol-specific proxies if suitable', () => {
+      testProfile(profile, 'https://www.example.com/', [
+        'PROXY 127.0.0.1:2345',
+        'https',
+        profile.proxyForHttps,
+        profile.auth?.proxyForHttps,
+      ]);
+    });
+
+    it('should use fallback proxies for other protocols', () => {
+      testProfile(profile, 'ftp://www.example.com/', [
+        'SOCKS 127.0.0.1:3456',
+        '',
+        profile.fallbackProxy,
+        undefined,
+      ]);
+    });
+
+    it('should not return authentication if not provided for protocol', () => {
+      testProfile(profile, 'http://www.example.com/', [
+        'SOCKS 127.0.0.1:1234',
+        'http',
+        profile.proxyForHttp,
+        undefined,
+      ]);
+    });
+
+    it('should not use any proxy for requests matching the bypassList', () => {
+      testProfile(profile, 'ftp://localhost/', [
+        'DIRECT',
+        profile.bypassList?.[0],
+        { scheme: 'direct' },
+        undefined,
+      ]);
+    });
+  });
+
+  describe('PacProfile', () => {
+    const profile = Profiles.create('test', 'PacProfile') as PacProfile;
+    profile.pacScript =
+      'function FindProxyForURL(url, host) {\n  return "PROXY " + host + ":8080";\n}';
+
+    it('should return the result of the pac script', () => {
+      testProfile(profile, 'ftp://www.example.com:9999/abc', null, 'PROXY www.example.com:8080');
+    });
+
+    it('should not fail for PAC with trailing comments', () => {
+      let p = Profiles.create('test', 'PacProfile') as PacProfile;
+      p.pacScript = profile.pacScript + '\n// This is a trailing line comment.\n';
+      testProfile(p, 'ftp://www.example.com:9999/abc', null, 'PROXY www.example.com:8080');
+
+      p = Profiles.create('test', 'PacProfile') as PacProfile;
+      p.pacScript =
+        profile.pacScript + '\n/* This is a multiline comment which is not properly closed.\n';
+      testProfile(p, 'ftp://www.example.com:9999/abc', null, 'PROXY www.example.com:8080');
+    });
+
+    it('should return includable for non-file pacUrl', () => {
+      expect(Profiles.isIncludable(profile)).toBe(true);
+    });
+
+    it('should return not includable for file: pacUrl', () => {
+      const p = Profiles.create('test', 'PacProfile') as PacProfile;
+      p.pacUrl = 'file:///proxy.pac';
+      expect(Profiles.isIncludable(p)).toBe(false);
+    });
+  });
+
+  describe('SwitchProfile', () => {
+    const profile = Profiles.create('test', 'SwitchProfile') as SwitchProfile;
+    profile.rules = [
+      {
+        condition: {
+          conditionType: 'HostWildcardCondition',
+          pattern: 'company.abc.example.com',
+        },
+        profileName: 'company',
+      },
+      {
+        condition: {
+          conditionType: 'HostWildcardCondition',
+          pattern: '*.example.com',
+        },
+        profileName: 'example',
+      },
+      {
+        condition: {
+          conditionType: 'HostWildcardCondition',
+          pattern: '*.abc.example.com',
+        },
+        profileName: 'abc',
+      },
+    ];
+    profile.defaultProfileName = 'default';
+
+    it('should match requests based on rules', () => {
+      testProfile(profile, 'http://company.abc.example.com:998/abc', profile.rules[0]);
+    });
+
+    it('should respect the order of rules', () => {
+      testProfile(profile, 'http://abc.example.com:9999/abc', profile.rules[1]);
+      testProfile(profile, 'http://www.example.com:9999/abc', profile.rules[1]);
+    });
+
+    it('should return defaultProfileName when no rules match', () => {
+      testProfile(profile, 'http://www.example.org:9999/abc', ['+default', null]);
+    });
+
+    it('should calulate directly referenced profiles correctly', () => {
+      const set = Profiles.directReferenceSet(profile);
+      expect(set).toEqual({
+        '+company': 'company',
+        '+example': 'example',
+        '+abc': 'abc',
+        '+default': 'default',
+      });
+    });
+
+    it('should clear the reference cache on profile revision change', () => {
+      profile.revision = 'a';
+      Profiles.directReferenceSet(profile);
+      // Remove 'default' from references.
+      profile.defaultProfileName = 'abc';
+      profile.revision = 'b';
+      const newSet = Profiles.directReferenceSet(profile);
+      expect(newSet).toEqual({
+        '+company': 'company',
+        '+example': 'example',
+        '+abc': 'abc',
+      });
+    });
+
+    it('should clear the reference cache if explicitly requested', () => {
+      profile.revision = 'a';
+      Profiles.directReferenceSet(profile);
+      // Remove 'default' from references.
+      profile.defaultProfileName = 'abc';
+      Profiles.dropCache(profile);
+      const newSet = Profiles.directReferenceSet(profile);
+      expect(newSet).toEqual({
+        '+company': 'company',
+        '+example': 'example',
+        '+abc': 'abc',
+      });
+    });
+  });
+
+  describe('VirtualProfile', () => {
+    const profile = Profiles.create('test', 'VirtualProfile') as SwitchProfile;
+    profile.defaultProfileName = 'default';
+
+    it('should always return defaultProfileName', () => {
+      testProfile(profile, 'http://www.example.com/abc', ['+default', null]);
+    });
+  });
+
+  describe('RulelistProfile', () => {
+    let profile = Profiles.create('test', 'AutoProxyRuleListProfile') as RuleListProfile;
+    profile.defaultProfileName = 'default';
+    profile.matchProfileName = 'example';
+    profile.ruleList = 'example.com';
+    profile.revision = 'a';
+
+    it('should calulate directly referenced profiles correctly', () => {
+      const set = Profiles.directReferenceSet(profile);
+      expect(set).toEqual({
+        '+example': 'example',
+        '+default': 'default',
+      });
+    });
+
+    it('should calulate referenced profiles for rule list with results', () => {
+      const set = Profiles.directReferenceSet({
+        profileType: 'RuleListProfile',
+        format: 'Switchy',
+        matchProfileName: 'ignored',
+        defaultProfileName: 'alsoIgnored',
+        ruleList: `[SwitchyDelta Conditions]
+@with result
+!*.example.org
+*.example.com +ABC
+* +DEF`,
+      } as RuleListProfile);
+      expect(set).toEqual({
+        '+ABC': 'ABC',
+        '+DEF': 'DEF',
+      });
+    });
+
+    it('should accept legacy SwitchyOmega rule list headers', () => {
+      const set = Profiles.directReferenceSet({
+        profileType: 'RuleListProfile',
+        format: 'Switchy',
+        matchProfileName: 'ignored',
+        defaultProfileName: 'alsoIgnored',
+        ruleList: `[SwitchyOmega Conditions]
+@with result
+!*.example.org
+*.example.com +ABC
+* +DEF`,
+      } as RuleListProfile);
+      expect(set).toEqual({
+        '+ABC': 'ABC',
+        '+DEF': 'DEF',
+      });
+    });
+
+    it('should match requests based on the rule list', () => {
+      testProfile(
+        profile,
+        'http://localhost/example.com',
+        ruleListResult('example', 'example.com'),
+      );
+      testProfile(profile, 'http://localhost/example.org', ['+default', null]);
+    });
+
+    it('should update rule list on update', () => {
+      Profiles.update(profile, 'example.org');
+      profile.revision = 'b';
+      testProfile(profile, 'http://localhost/example.com', ['+default', null]);
+      testProfile(
+        profile,
+        'http://localhost/example.org',
+        ruleListResult('example', 'example.org'),
+      );
+    });
+
+    it('should not fail when ruleList is not provided', () => {
+      const p = {
+        profileType: 'RuleListProfile',
+        format: 'Switchy',
+        matchProfileName: 'match',
+        defaultProfileName: 'default',
+      } as RuleListProfile;
+      expect(typeof Profiles.directReferenceSet(p)).toBe('object');
+      testProfile(p, 'http://localhost/example.com', ['+default', null]);
+    });
+
+    it('should switch to AutoProxy format on update if detected', () => {
+      profile = Profiles.create('test2', 'RuleListProfile') as RuleListProfile;
+      profile.format = 'Switchy';
+      profile.defaultProfileName = 'default';
+      profile.matchProfileName = 'example';
+
+      expect(profile.format).toBe('Switchy');
+      Profiles.update(profile, '[AutoProxy]\nexample.org');
+      expect(profile.format).toBe('AutoProxy');
+
+      testProfile(profile, 'http://localhost/example.com', ['+default', null]);
+      testProfile(
+        profile,
+        'http://localhost/example.org',
+        ruleListResult('example', 'example.org'),
+      );
+    });
+  });
+});

--- a/packages/pac/test/rule-list.test.ts
+++ b/packages/pac/test/rule-list.test.ts
@@ -1,0 +1,502 @@
+import { describe, it, expect } from 'vitest';
+import * as RuleList from '../src/rule-list.js';
+import type { Rule } from '../src/types.js';
+
+describe('RuleList', () => {
+  describe('AutoProxy', () => {
+    const parse = RuleList.AutoProxy.parse;
+
+    it('should parse keyword conditions', () => {
+      const line = 'example.com';
+      const result = parse(line, 'match', 'notmatch');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        source: line,
+        profileName: 'match',
+        condition: {
+          conditionType: 'KeywordCondition',
+          pattern: 'example.com',
+        },
+      });
+    });
+
+    it('should parse keyword conditions with asterisks', () => {
+      const line = 'example*.com';
+      const result = parse(line, 'match', 'notmatch');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        source: line,
+        profileName: 'match',
+        condition: {
+          conditionType: 'UrlWildcardCondition',
+          pattern: 'http://*example*.com*',
+        },
+      });
+    });
+
+    it('should parse host conditions', () => {
+      const line = '||example.com';
+      const result = parse(line, 'match', 'notmatch');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        source: line,
+        profileName: 'match',
+        condition: {
+          conditionType: 'HostWildcardCondition',
+          pattern: '*.example.com',
+        },
+      });
+    });
+
+    it('should parse "starts-with" conditions', () => {
+      const line = '|https://ssl.example.com';
+      const result = parse(line, 'match', 'notmatch');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        source: line,
+        profileName: 'match',
+        condition: {
+          conditionType: 'UrlWildcardCondition',
+          pattern: 'https://ssl.example.com*',
+        },
+      });
+    });
+
+    it('should parse "starts-with" conditions for the HTTP scheme', () => {
+      const line = '|http://example.com';
+      const result = parse(line, 'match', 'notmatch');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        source: line,
+        profileName: 'match',
+        condition: {
+          conditionType: 'UrlWildcardCondition',
+          pattern: 'http://example.com*',
+        },
+      });
+    });
+
+    it('should parse url regex conditions', () => {
+      const line = '/^https?:\\/\\/[^\\/]+example\.com/';
+      const result = parse(line, 'match', 'notmatch');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        source: line,
+        profileName: 'match',
+        condition: {
+          conditionType: 'UrlRegexCondition',
+          pattern: '^https?:\\/\\/[^\\/]+example\.com',
+        },
+      });
+    });
+
+    it('should ignore comment lines', () => {
+      const result = parse('!example.com', 'match', 'notmatch');
+      expect(result).toHaveLength(0);
+    });
+
+    it('should parse multiple lines', () => {
+      const result = parse('example.com\n!comment\n||example.com', 'match', 'notmatch');
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        source: 'example.com',
+        profileName: 'match',
+        condition: {
+          conditionType: 'KeywordCondition',
+          pattern: 'example.com',
+        },
+      });
+      expect(result[1]).toEqual({
+        source: '||example.com',
+        profileName: 'match',
+        condition: {
+          conditionType: 'HostWildcardCondition',
+          pattern: '*.example.com',
+        },
+      });
+    });
+
+    it('should put exclusive rules first', () => {
+      const result = parse('example.com\n@@||example.com', 'match', 'notmatch');
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        source: '@@||example.com',
+        profileName: 'notmatch',
+        condition: {
+          conditionType: 'HostWildcardCondition',
+          pattern: '*.example.com',
+        },
+      });
+      expect(result[1]).toEqual({
+        source: 'example.com',
+        profileName: 'match',
+        condition: {
+          conditionType: 'KeywordCondition',
+          pattern: 'example.com',
+        },
+      });
+    });
+  });
+
+  describe('Switchy', () => {
+    const parse = RuleList.Switchy.parse;
+
+    function compose(sections: Record<string, string[]>): string {
+      let list = '#BEGIN\r\n\r\n';
+      for (const [sec, rules] of Object.entries(sections)) {
+        list += `[${sec}]\r\n`;
+        for (const rule of rules) {
+          list += rule;
+          list += '\r\n';
+        }
+      }
+      list += '\r\n\r\n#END\r\n';
+      return list;
+    }
+
+    it('should parse empty rule lists', () => {
+      const list = compose({});
+      const result = parse(list, 'match', 'notmatch');
+      expect(result).toHaveLength(0);
+    });
+
+    it('should ignore stuff before #BEGIN or after #END.', () => {
+      let list = compose({});
+      list += '[RegExp]\r\ntest\r\n';
+      list = '[Wildcard]\r\ntest\r\n' + list;
+      const result = parse(list, 'match', 'notmatch');
+      expect(result).toHaveLength(0);
+    });
+
+    it('should parse wildcard rules', () => {
+      const list = compose({ Wildcard: ['*://example.com/abc/*'] });
+      const result = parse(list, 'match', 'notmatch');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        source: '*://example.com/abc/*',
+        profileName: 'match',
+        condition: {
+          conditionType: 'UrlWildcardCondition',
+          pattern: '*://example.com/abc/*',
+        },
+      });
+    });
+
+    it('should parse RegExp rules', () => {
+      const list = compose({ RegExp: ['^http://www\.example\.com/.*'] });
+      const result = parse(list, 'match', 'notmatch');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        source: '^http://www\.example\.com/.*',
+        profileName: 'match',
+        condition: {
+          conditionType: 'UrlRegexCondition',
+          pattern: '^http://www\.example\.com/.*',
+        },
+      });
+    });
+
+    it('should parse exclusive rules', () => {
+      const list = compose({ RegExp: ['!^http://www\.example\.com/.*'] });
+      const result = parse(list, 'match', 'notmatch');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        source: '!^http://www\.example\.com/.*',
+        profileName: 'notmatch',
+        condition: {
+          conditionType: 'UrlRegexCondition',
+          pattern: '^http://www\.example\.com/.*',
+        },
+      });
+    });
+
+    it('should parse multiple rules in multiple sections', () => {
+      const list = compose({
+        Wildcard: ['http://www.example.com/*', 'http://example.com/*'],
+        RegExp: ['^http://www\.example\.com/.*', '^http://example\.com/.*'],
+      });
+      const result = parse(list, 'match', 'notmatch');
+      expect(result).toHaveLength(4);
+      expect(result[0]).toEqual({
+        source: 'http://www.example.com/*',
+        profileName: 'match',
+        condition: {
+          conditionType: 'UrlWildcardCondition',
+          pattern: 'http://www.example.com/*',
+        },
+      });
+      expect(result[1]).toEqual({
+        source: 'http://example.com/*',
+        profileName: 'match',
+        condition: {
+          conditionType: 'UrlWildcardCondition',
+          pattern: 'http://example.com/*',
+        },
+      });
+      expect(result[2]).toEqual({
+        source: '^http://www\.example\.com/.*',
+        profileName: 'match',
+        condition: {
+          conditionType: 'UrlRegexCondition',
+          pattern: '^http://www\.example\.com/.*',
+        },
+      });
+      expect(result[3]).toEqual({
+        source: '^http://example\.com/.*',
+        profileName: 'match',
+        condition: {
+          conditionType: 'UrlRegexCondition',
+          pattern: '^http://example\.com/.*',
+        },
+      });
+    });
+
+    it('should put exclusive rules first', () => {
+      const list = compose({
+        Wildcard: ['http://www\.example\.com/*'],
+        RegExp: ['!^http://www\.example\.com/.*'],
+      });
+      const result = parse(list, 'match', 'notmatch');
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        source: '!^http://www\.example\.com/.*',
+        profileName: 'notmatch',
+        condition: {
+          conditionType: 'UrlRegexCondition',
+          pattern: '^http://www.example\.com/.*',
+        },
+      });
+      expect(result[1]).toEqual({
+        source: 'http://www\.example\.com/*',
+        profileName: 'match',
+        condition: {
+          conditionType: 'UrlWildcardCondition',
+          pattern: 'http://www.example.com/*',
+        },
+      });
+    });
+  });
+
+  describe('Switchy (omega format)', () => {
+    const parse = RuleList.Switchy.parse;
+    const compose = RuleList.Switchy.compose;
+
+    it('should parse empty rule lists', () => {
+      const list = compose({ rules: [], defaultProfileName: '' });
+      const result = parse(list, 'match', 'notmatch');
+      expect(result).toHaveLength(0);
+    });
+
+    it('should ignore comment lines.', () => {
+      let list = compose({ rules: [], defaultProfileName: '' });
+      list += ';*.example.com \r\n';
+      const result = parse(list, 'match', 'notmatch');
+      expect(result).toHaveLength(0);
+    });
+
+    it('should compose and parse HostWildcardCondition', () => {
+      const rule: Rule = {
+        source: '*.example.com',
+        condition: {
+          conditionType: 'HostWildcardCondition',
+          pattern: '*.example.com',
+        },
+        profileName: 'match',
+      };
+      const list = compose({ rules: [rule], defaultProfileName: 'notmatch' });
+      const result = parse(list, 'match', 'notmatch');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(rule);
+    });
+
+    it('should compose and parse HostRegexCondition', () => {
+      const rule: Rule = {
+        source: 'HostRegex: ^http://www\.example\.com/.*',
+        condition: {
+          conditionType: 'HostRegexCondition',
+          pattern: '^http://www\.example\.com/.*',
+        },
+        profileName: 'match',
+      };
+      const list = compose({ rules: [rule], defaultProfileName: 'notmatch' });
+      const result = parse(list, 'match', 'notmatch');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(rule);
+    });
+
+    it('should compose and parse disabled rules', () => {
+      const rule: Rule = {
+        source: 'Disabled: *.example.com',
+        condition: {
+          conditionType: 'FalseCondition',
+          pattern: '*.example.com',
+        },
+        profileName: 'match',
+      };
+      const list = compose({ rules: [rule], defaultProfileName: 'notmatch' });
+      const result = parse(list, 'match', 'notmatch');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(rule);
+    });
+
+    it('should compose and parse exclusive rules', () => {
+      const rule: Rule = {
+        source: '!*.example.com',
+        condition: {
+          conditionType: 'HostWildcardCondition',
+          pattern: '*.example.com',
+        },
+        profileName: 'notmatch',
+      };
+      const list = compose({ rules: [rule], defaultProfileName: 'notmatch' });
+      const result = parse(list, 'match', 'notmatch');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(rule);
+    });
+
+    it('should compose and parse conditions starting with special chars', () => {
+      const rule: Rule = {
+        source: ': ;abc',
+        condition: {
+          conditionType: 'HostWildcardCondition',
+          pattern: ';abc',
+        },
+        profileName: 'match',
+      };
+      const list = compose({ rules: [rule], defaultProfileName: 'notmatch' });
+      const result = parse(list, 'match', 'notmatch');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(rule);
+    });
+
+    it('should parse multiple conditions', () => {
+      const rules: Rule[] = [
+        {
+          source: '*.example.com',
+          condition: {
+            conditionType: 'HostWildcardCondition',
+            pattern: '*.example.com',
+          },
+          profileName: 'match',
+        },
+        {
+          source: '*.example.org',
+          condition: {
+            conditionType: 'HostWildcardCondition',
+            pattern: '*.example.org',
+          },
+          profileName: 'match',
+        },
+      ];
+      const list = compose({ rules, defaultProfileName: 'notmatch' });
+      const result = parse(list, 'match', 'notmatch');
+      expect(result).toEqual(rules);
+    });
+
+    it('should respect the top-down order of conditions', () => {
+      const rules: Rule[] = [
+        {
+          source: 'b.example.com',
+          condition: {
+            conditionType: 'HostWildcardCondition',
+            pattern: 'b.example.com',
+          },
+          profileName: 'match',
+        },
+        {
+          source: '!a.example.org',
+          condition: {
+            conditionType: 'HostWildcardCondition',
+            pattern: 'a.example.org',
+          },
+          profileName: 'notmatch',
+        },
+      ];
+      const list = compose({ rules, defaultProfileName: 'notmatch' });
+      const result = parse(list, 'match', 'notmatch');
+      expect(result).toEqual(rules);
+    });
+
+    it('should add a default rule when results are enabled', () => {
+      const list = compose({ rules: [], defaultProfileName: 'notmatch' }, { withResult: true });
+      expect(list.split(/\r|\n/)).toContain('@with result');
+      const result = parse(list, 'ignored', 'alsoIgnored');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        source: '*',
+        condition: {
+          conditionType: 'HostWildcardCondition',
+          pattern: '*',
+        },
+        profileName: 'notmatch',
+      });
+    });
+
+    it('should compose and parse conditions with results', () => {
+      const rules: Rule[] = [
+        {
+          source: 'b.example.com',
+          condition: {
+            conditionType: 'HostWildcardCondition',
+            pattern: 'b.example.com',
+          },
+          profileName: 'abc',
+        },
+        {
+          source: 'a.example.org',
+          condition: {
+            conditionType: 'HostWildcardCondition',
+            pattern: 'a.example.org',
+          },
+          profileName: 'def',
+        },
+      ];
+      const list = compose({ rules, defaultProfileName: 'ghi' }, { withResult: true });
+      const result = parse(list, 'ignored', 'alsoIgnored');
+      rules.push({
+        source: '*',
+        condition: {
+          conditionType: 'HostWildcardCondition',
+          pattern: '*',
+        },
+        profileName: 'ghi',
+      });
+      expect(result).toEqual(rules);
+    });
+
+    it('should compose and parse exclusive conditions with results', () => {
+      const rules: Rule[] = [
+        {
+          source: '!b.example.com',
+          condition: {
+            conditionType: 'HostWildcardCondition',
+            pattern: 'b.example.com',
+          },
+          profileName: 'default profile',
+        },
+        {
+          source: 'a.example.org',
+          condition: {
+            conditionType: 'HostWildcardCondition',
+            pattern: 'a.example.org',
+          },
+          profileName: 'some profile',
+        },
+      ];
+      const list = compose(
+        { rules, defaultProfileName: 'default profile' },
+        { withResult: true, useExclusive: true },
+      );
+      const result = parse(list, 'ignored', 'alsoIgnored');
+      rules.push({
+        source: '*',
+        condition: {
+          conditionType: 'HostWildcardCondition',
+          pattern: '*',
+        },
+        profileName: 'default profile',
+      });
+      expect(result).toEqual(rules);
+    });
+  });
+});

--- a/packages/pac/test/shexp.test.ts
+++ b/packages/pac/test/shexp.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { shExp2RegExp, escapeSlash } from '../src/shexp.js';
+
+describe('ShexpUtils', () => {
+  describe('#escapeSlash', () => {
+    it('should escape all forward slashes', () => {
+      const regex = escapeSlash('/test/');
+      expect(regex).toBe('\\/test\\/');
+    });
+    it('should not escape slashes that are already escaped', () => {
+      const regex = escapeSlash('\\/test\\/');
+      expect(regex).toBe('\\/test\\/');
+    });
+    it('should know the difference between escaped and unescaped slashes', () => {
+      const regex = escapeSlash('\\\\/\\/test\\/');
+      expect(regex).toBe('\\\\\\/\\/test\\/');
+    });
+  });
+  describe('#shExp2RegExp', () => {
+    it('should escape regex meta chars and back slashes', () => {
+      const regex = shExp2RegExp('this.is|a\\test+');
+      expect(regex).toBe('^this\\.is\\|a\\\\test\\+$');
+    });
+  });
+});

--- a/packages/pac/test/utils.test.ts
+++ b/packages/pac/test/utils.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+// getBaseDomain moved from utils.js to the psl.js entry point in the port
+// (kept separate because the public-suffix list is a large data table).
+import { getBaseDomain } from '../src/psl.js';
+
+describe('getBaseDomain', () => {
+  it('should return domains with zero level unchanged', () => {
+    expect(getBaseDomain('someinternaldomain')).toBe('someinternaldomain');
+  });
+  it('should return domains with one level unchanged', () => {
+    expect(getBaseDomain('example.com')).toBe('example.com');
+    expect(getBaseDomain('e.test')).toBe('e.test');
+    expect(getBaseDomain('a.b')).toBe('a.b');
+  });
+  it('should treat two-segment TLD as one component', () => {
+    expect(getBaseDomain('images.google.co.uk')).toBe('google.co.uk');
+    expect(getBaseDomain('images.google.co.jp')).toBe('google.co.jp');
+    expect(getBaseDomain('example.com.cn')).toBe('example.com.cn');
+  });
+  it('should not mistake short domains with two-segment TLDs', () => {
+    expect(getBaseDomain('a.bc.com')).toBe('bc.com');
+    expect(getBaseDomain('i.t.co')).toBe('t.co');
+  });
+  it('should not try to modify IP address literals', () => {
+    expect(getBaseDomain('127.0.0.1')).toBe('127.0.0.1');
+    expect(getBaseDomain('[::1]')).toBe('[::1]');
+    expect(getBaseDomain('::f')).toBe('::f');
+  });
+});

--- a/packages/pac/tsconfig.json
+++ b/packages/pac/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/target/package.json
+++ b/packages/target/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@switchydelta/target",
+  "version": "3.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Platform-independent core logic for SwitchyDelta",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc --build",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@switchydelta/pac": "*",
+    "jsondiffpatch": "^0.6.0"
+  }
+}

--- a/packages/target/src/browser-storage.ts
+++ b/packages/target/src/browser-storage.ts
@@ -1,0 +1,251 @@
+/**
+ * State storage backed by `chrome.storage` (service-worker safe).
+ *
+ * Keys carry a string prefix so that state can share an area with options data
+ * without clashing. Two constructions are supported:
+ *
+ *     new BrowserStorage('omega.local.')            // chrome.storage.local
+ *     new BrowserStorage('omega.local.', 'sync')    // chrome.storage.sync
+ *     new BrowserStorage(localStorage, 'omega.local.')  // legacy pages / tests
+ */
+
+import { Storage } from './storage.js';
+import type { StorageItems } from './storage.js';
+
+/** The subset of the `Storage` DOM interface the legacy path relies on. */
+export interface LegacyStorageArea {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+  key(index: number): string | null;
+  clear(): void;
+}
+
+type ChromeArea = chrome.storage.StorageArea;
+
+function lastErrorMessage(): string | undefined {
+  if (typeof chrome === 'undefined') return undefined;
+  return chrome.runtime?.lastError?.message;
+}
+
+/**
+ * Run one `chrome.storage` call and normalise its failure modes.
+ *
+ * MV3 rejects the returned promise, but some hosts resolve and only report the
+ * failure through `runtime.lastError`, so both are checked.
+ */
+async function chromeCall<T>(operation: () => Promise<T>): Promise<T> {
+  let result: T;
+  try {
+    result = await operation();
+  } catch (e) {
+    throw e instanceof Error ? e : new Error(String(e));
+  }
+  const message = lastErrorMessage();
+  if (message) throw new Error(message);
+  return result;
+}
+
+export class BrowserStorage extends Storage {
+  readonly prefix: string;
+  readonly areaName: string;
+  private readonly _legacy: LegacyStorageArea | null;
+  /**
+   * The prototype of the legacy storage object. Calls go through it rather than
+   * through the instance so that a page overwriting `localStorage.getItem`
+   * (or a key literally named `getItem`) cannot hijack them.
+   */
+  private readonly _proto: LegacyStorageArea | null;
+
+  constructor(prefix: string, areaName?: string);
+  constructor(legacy: LegacyStorageArea, prefix?: string);
+  constructor(storageOrPrefix: string | LegacyStorageArea, prefixOrArea?: string) {
+    super();
+    if (typeof storageOrPrefix === 'string') {
+      this.prefix = storageOrPrefix;
+      this.areaName = prefixOrArea || 'local';
+      this._legacy = null;
+      this._proto = null;
+    } else {
+      this._legacy = storageOrPrefix;
+      this.prefix = prefixOrArea || 'omega.local.';
+      this.areaName = 'local';
+      this._proto = storageOrPrefix
+        ? (Object.getPrototypeOf(storageOrPrefix) as LegacyStorageArea)
+        : null;
+    }
+  }
+
+  private _chromeArea(): ChromeArea | undefined {
+    if (typeof chrome === 'undefined' || !chrome.storage) return undefined;
+    const areas = chrome.storage as unknown as Record<string, ChromeArea | undefined>;
+    return areas[this.areaName];
+  }
+
+  /** The legacy path is only taken when chrome.storage is genuinely absent. */
+  private _isLegacy(): boolean {
+    return !!(this._legacy && this._proto?.getItem && !this._chromeArea());
+  }
+
+  override async get(keys?: string | string[] | null | StorageItems): Promise<StorageItems> {
+    if (this._isLegacy()) return this._legacyGet(keys);
+    const area = this._chromeArea();
+    if (!area) return {};
+
+    if (keys == null) {
+      const items = await chromeCall(() => area.get(null));
+      const map: StorageItems = {};
+      for (const [fullKey, value] of Object.entries(items ?? {})) {
+        if (fullKey.startsWith(this.prefix)) {
+          map[fullKey.slice(this.prefix.length)] = value;
+        }
+      }
+      return map;
+    }
+
+    // The object form of `keys` carries default values, returned for keys that
+    // are missing from storage.
+    const defaults: StorageItems = {};
+    let keyList: string[];
+    if (typeof keys === 'string') {
+      keyList = [keys];
+      defaults[keys] = undefined;
+    } else if (Array.isArray(keys)) {
+      keyList = keys;
+      for (const key of keys) defaults[key] = undefined;
+    } else {
+      Object.assign(defaults, keys);
+      keyList = Object.keys(keys);
+    }
+
+    const items =
+      (await chromeCall(() => area.get(keyList.map((key) => this.prefix + key)))) ?? {};
+    const result: StorageItems = {};
+    for (const key of keyList) {
+      const full = this.prefix + key;
+      if (Object.prototype.hasOwnProperty.call(items, full)) {
+        result[key] = items[full];
+      } else if (defaults[key] !== undefined) {
+        result[key] = defaults[key];
+      }
+    }
+    return result;
+  }
+
+  override async set(items: StorageItems): Promise<StorageItems> {
+    if (this._isLegacy()) return this._legacySet(items);
+    const area = this._chromeArea();
+    if (!area) return items;
+
+    const packed: StorageItems = {};
+    for (const [key, value] of Object.entries(items)) {
+      if (typeof value === 'undefined') continue;
+      packed[this.prefix + key] = value;
+    }
+    if (Object.keys(packed).length === 0) return items;
+
+    await chromeCall(() => area.set(packed));
+    return items;
+  }
+
+  override async remove(keys?: string | string[] | null): Promise<void> {
+    if (this._isLegacy()) return this._legacyRemove(keys);
+    const area = this._chromeArea();
+    if (!area) return;
+
+    if (keys == null) {
+      // Never `clear()`: the area is shared with options data and possibly with
+      // other prefixes, so enumerate and drop only what belongs to us.
+      const items = await chromeCall(() => area.get(null));
+      const toRemove = Object.keys(items ?? {}).filter((key) => key.startsWith(this.prefix));
+      if (toRemove.length === 0) return;
+      await chromeCall(() => area.remove(toRemove));
+      return;
+    }
+
+    if (typeof keys === 'string') {
+      await chromeCall(() => area.remove(this.prefix + keys));
+      return;
+    }
+    await chromeCall(() => area.remove(keys.map((key) => this.prefix + key)));
+  }
+
+  // --- legacy localStorage path (tests / old MV2 pages) ---------------------
+
+  private async _legacyGet(
+    keys?: string | string[] | null | StorageItems,
+  ): Promise<StorageItems> {
+    const map: StorageItems = {};
+    if (typeof keys === 'string') {
+      map[keys] = undefined;
+    } else if (Array.isArray(keys)) {
+      for (const key of keys) map[key] = undefined;
+    } else if (keys != null && typeof keys === 'object') {
+      Object.assign(map, keys);
+    }
+
+    const legacy = this._legacy;
+    const proto = this._proto;
+    if (!legacy || !proto) return map;
+
+    for (const key of Object.keys(map)) {
+      let value: unknown;
+      try {
+        const raw = proto.getItem.call(legacy, this.prefix + key);
+        value = JSON.parse(raw as unknown as string);
+      } catch {
+        // Unparsable entry: fall through and keep whatever default was given.
+      }
+      if (value != null) map[key] = value;
+      if (typeof map[key] === 'undefined') delete map[key];
+    }
+    return map;
+  }
+
+  private async _legacySet(items: StorageItems): Promise<StorageItems> {
+    const legacy = this._legacy;
+    const proto = this._proto;
+    if (!legacy || !proto) return items;
+    for (const [key, value] of Object.entries(items)) {
+      proto.setItem.call(legacy, this.prefix + key, JSON.stringify(value));
+    }
+    return items;
+  }
+
+  private async _legacyRemove(keys?: string | string[] | null): Promise<void> {
+    const legacy = this._legacy;
+    const proto = this._proto;
+    if (!legacy || !proto) return;
+
+    if (keys == null) {
+      if (!this.prefix) {
+        proto.clear.call(legacy);
+        return;
+      }
+      // Scan the whole area, dropping only prefixed keys. The index is not
+      // advanced after a removal because removing shifts the remaining keys
+      // down into the slot just consumed.
+      let index = 0;
+      for (;;) {
+        const key = proto.key.call(legacy, index);
+        if (key === null) break;
+        if (key.startsWith(this.prefix)) {
+          proto.removeItem.call(legacy, key);
+        } else {
+          index++;
+        }
+      }
+      return;
+    }
+
+    if (typeof keys === 'string') {
+      proto.removeItem.call(legacy, this.prefix + keys);
+      return;
+    }
+    for (const key of keys) {
+      proto.removeItem.call(legacy, this.prefix + key);
+    }
+  }
+}
+
+export default BrowserStorage;

--- a/packages/target/src/default-options.ts
+++ b/packages/target/src/default-options.ts
@@ -1,0 +1,63 @@
+/**
+ * The options a fresh installation starts with.
+ *
+ * This is a factory rather than a constant because callers mutate what they get
+ * back (profiles are edited in place), so every caller needs its own copy.
+ */
+
+import type { FixedProfile, OptionsBag, SwitchProfile } from '@switchydelta/pac';
+
+export function defaultOptions(): OptionsBag {
+  return {
+    schemaVersion: 2,
+    '-enableQuickSwitch': false,
+    '-refreshOnProfileChange': true,
+    '-startupProfileName': '',
+    '-quickSwitchProfiles': [],
+    '-revertProxyChanges': true,
+    '-confirmDeletion': true,
+    '-showInspectMenu': true,
+    '-addConditionsToBottom': false,
+    '-showExternalProfile': true,
+    '-downloadInterval': 1440,
+    '+proxy': {
+      bypassList: [
+        { pattern: '127.0.0.1', conditionType: 'BypassCondition' },
+        { pattern: '::1', conditionType: 'BypassCondition' },
+        { pattern: 'localhost', conditionType: 'BypassCondition' },
+      ],
+      profileType: 'FixedProfile',
+      name: 'proxy',
+      color: '#99ccee',
+      fallbackProxy: {
+        port: 8080,
+        scheme: 'http',
+        host: 'proxy.example.com',
+      },
+    } satisfies FixedProfile,
+    '+auto switch': {
+      profileType: 'SwitchProfile',
+      rules: [
+        {
+          condition: {
+            pattern: 'internal.example.com',
+            conditionType: 'HostWildcardCondition',
+          },
+          profileName: 'direct',
+        },
+        {
+          condition: {
+            pattern: '*.example.com',
+            conditionType: 'HostWildcardCondition',
+          },
+          profileName: 'proxy',
+        },
+      ],
+      name: 'auto switch',
+      color: '#99dd99',
+      defaultProfileName: 'direct',
+    } satisfies SwitchProfile,
+  };
+}
+
+export default defaultOptions;

--- a/packages/target/src/errors.ts
+++ b/packages/target/src/errors.ts
@@ -1,0 +1,53 @@
+/**
+ * Error types shared across the target layer.
+ *
+ * `name` is part of the messaging wire format: errors crossing the
+ * service-worker boundary are flattened to plain objects and reconstructed by
+ * name on the other side, so these strings must stay stable.
+ */
+
+export class NetworkError extends Error {
+  override readonly name: string = 'NetworkError';
+  override readonly cause: unknown;
+
+  constructor(cause?: unknown, message?: string) {
+    super(message ?? 'Network request failed');
+    this.cause = cause;
+  }
+}
+
+export class HttpError extends NetworkError {
+  override readonly name: string = 'HttpError';
+  readonly statusCode: number | undefined;
+
+  constructor(cause?: unknown, message?: string) {
+    super(cause, message);
+    this.statusCode = (cause as { statusCode?: number } | undefined)?.statusCode;
+  }
+}
+
+export class HttpNotFoundError extends HttpError {
+  override readonly name: string = 'HttpNotFoundError';
+}
+
+export class HttpServerError extends HttpError {
+  override readonly name: string = 'HttpServerError';
+}
+
+export class ContentTypeRejectedError extends Error {
+  override readonly name: string = 'ContentTypeRejectedError';
+}
+
+export class ProfileNotExistError extends Error {
+  override readonly name: string = 'ProfileNotExistError';
+  readonly profileName: string;
+
+  constructor(profileName: string) {
+    super(`Profile ${profileName} does not exist!`);
+    this.profileName = profileName;
+  }
+}
+
+export class NoOptionsError extends Error {
+  override readonly name: string = 'NoOptionsError';
+}

--- a/packages/target/src/index.ts
+++ b/packages/target/src/index.ts
@@ -28,6 +28,7 @@ export { OptionsSync } from './options-sync.js';
 export { TokenBucket } from './token-bucket.js';
 export { defaultOptions } from './default-options.js';
 export { Options } from './options.js';
+export type { OmegaOptions, ProxyImpl } from './options.js';
 
 export {
   NetworkError,

--- a/packages/target/src/index.ts
+++ b/packages/target/src/index.ts
@@ -1,0 +1,40 @@
+/**
+ * @switchydelta/target — browser-agnostic core.
+ *
+ * Chrome-specific behaviour lives in the extension package, which subclasses
+ * `Options` and `Storage`.
+ */
+
+export { Log, setTracing, isTracing } from './log.js';
+export type { Logger } from './log.js';
+
+export {
+  Storage,
+  RateLimitExceededError,
+  QuotaExceededError,
+  StorageUnavailableError,
+} from './storage.js';
+export type {
+  StorageItems,
+  WriteOperations,
+  ChangeOperations,
+  MergeFn,
+  WatchCallback,
+  Unwatch,
+} from './storage.js';
+
+export { BrowserStorage } from './browser-storage.js';
+export { OptionsSync } from './options-sync.js';
+export { TokenBucket } from './token-bucket.js';
+export { defaultOptions } from './default-options.js';
+export { Options } from './options.js';
+
+export {
+  NetworkError,
+  HttpError,
+  HttpNotFoundError,
+  HttpServerError,
+  ContentTypeRejectedError,
+  ProfileNotExistError,
+  NoOptionsError,
+} from './errors.js';

--- a/packages/target/src/log.ts
+++ b/packages/target/src/log.ts
@@ -1,0 +1,73 @@
+/**
+ * Logging helpers.
+ *
+ * Call tracing (`Log.method`) is off by default. The CoffeeScript version ran
+ * it on every storage operation, and because it pretty-prints its subject with
+ * `JSON.stringify(..., 4)` that meant serialising the whole options object on
+ * every read and write. It is now opt-in via {@link setTracing}.
+ */
+
+const SECRET_KEYS = new Set(['username', 'password', 'host', 'port']);
+
+function replacer(key: string, value: unknown): unknown {
+  return SECRET_KEYS.has(key) ? '<secret>' : value;
+}
+
+let tracing = false;
+
+export interface Logger {
+  str(obj: unknown): string;
+  log(...args: unknown[]): void;
+  error(...args: unknown[]): void;
+  func(name: string, args: ArrayLike<unknown>): void;
+  method(name: string, self: unknown, args: ArrayLike<unknown>): void;
+}
+
+/** Enable or disable call tracing. */
+export function setTracing(enabled: boolean): void {
+  tracing = enabled;
+}
+
+export function isTracing(): boolean {
+  return tracing;
+}
+
+export const Log: Logger = {
+  /** Pretty-print a value, redacting keys with privacy implications. */
+  str(obj: unknown): string {
+    if (typeof obj === 'object' && obj !== null) {
+      const debugStr = (obj as { debugStr?: unknown }).debugStr;
+      if (debugStr !== undefined) {
+        return typeof debugStr === 'function' ? String(debugStr.call(obj)) : String(debugStr);
+      }
+      if (obj instanceof Error) {
+        return obj.stack || obj.message;
+      }
+      return JSON.stringify(obj, replacer, 4);
+    }
+    if (typeof obj === 'function') {
+      return obj.name ? `<f: ${obj.name}>` : obj.toString();
+    }
+    return '' + obj;
+  },
+
+  log(...args: unknown[]): void {
+    console.log(...args);
+  },
+
+  error(...args: unknown[]): void {
+    console.error(...args);
+  },
+
+  func(name: string, args: ArrayLike<unknown>): void {
+    if (!tracing) return;
+    this.log(name, '(', Array.prototype.slice.call(args), ')');
+  },
+
+  method(name: string, self: unknown, args: ArrayLike<unknown>): void {
+    if (!tracing) return;
+    this.log(this.str(self), '<<', name, Array.prototype.slice.call(args));
+  },
+};
+
+export default Log;

--- a/packages/target/src/options-sync.ts
+++ b/packages/target/src/options-sync.ts
@@ -1,0 +1,308 @@
+/**
+ * Two-way synchronisation between a local storage and a remote (sync) storage.
+ *
+ * Writes are debounced and rate limited: `chrome.storage.sync` enforces both a
+ * write-per-minute budget and a per-item quota, and blowing either one costs
+ * the whole batch, so pushes are coalesced and gated by a token bucket.
+ */
+
+import { Log } from './log.js';
+import { QuotaExceededError, RateLimitExceededError, Storage } from './storage.js';
+import type { MergeFn, StorageItems, Unwatch, WriteOperations } from './storage.js';
+import { TokenBucket } from './token-bucket.js';
+import { Revision } from '@switchydelta/pac';
+
+/** The minimum a rate bucket must provide; see {@link TokenBucket}. */
+export interface RateBucket {
+  content: number;
+  tryRemoveTokens(count: number): boolean;
+  removeTokens(count: number): Promise<void>;
+  clear?(): void;
+}
+
+/** Internal signal: the bucket ran dry between the set and the remove. */
+class BucketEmptyError extends Error {
+  override readonly name: string = 'BucketEmptyError';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/**
+ * Structural equality, used only as an "is this write a no-op?" test.
+ *
+ * Key order must not matter, which rules out comparing JSON.stringify output.
+ * The CoffeeScript version called jsondiffpatch purely for this, which meant
+ * building a full delta just to throw it away.
+ */
+export function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (!isRecord(a) || !isRecord(b)) return false;
+
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b) || a.length !== b.length) return false;
+    return a.every((value, i) => deepEqual(value, b[i]));
+  }
+  if (Array.isArray(b)) return false;
+
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
+  if (keysA.length !== keysB.length) return false;
+  return keysA.every(
+    (key) => Object.prototype.hasOwnProperty.call(b, key) && deepEqual(a[key], b[key]),
+  );
+}
+
+export class OptionsSync {
+  static readonly TokenBucket = TokenBucket;
+
+  /** The debounce timeout (ms) for requestPush scheduling. See requestPush. */
+  debounce = 1000;
+
+  /** The throttling timeout (ms) for watchAndPull. See watchAndPull. */
+  pullThrottle = 1000;
+
+  /** Whether syncing is enabled or not. See requestPush for the effect. */
+  enabled = true;
+
+  /** The remote storage of syncing. */
+  readonly storage: Storage;
+
+  private readonly _bucket: RateBucket;
+  private readonly _clearBucket: () => void;
+  private _pending: StorageItems = {};
+  private _timeout: ReturnType<typeof setTimeout> | null = null;
+  private _waiting = false;
+
+  constructor(storage: Storage, bucket?: RateBucket) {
+    this.storage = storage;
+    this._bucket = bucket ?? new TokenBucket(10, 10, 'minute', null);
+    // Buckets are allowed to come from outside without a clear(); draining by
+    // taking everything currently in it is the same thing.
+    const bucketClear = this._bucket.clear;
+    this._clearBucket = bucketClear
+      ? bucketClear.bind(this._bucket)
+      : () => {
+          this._bucket.tryRemoveTokens(this._bucket.content);
+        };
+  }
+
+  /**
+   * Transform storage values for syncing. The default implementation applies no
+   * transformation, but the behavior can be altered by assigning to this field.
+   * Note: Transformation is applied before merging.
+   */
+  transformValue: (value: unknown, key: string) => unknown = (value) => value;
+
+  /**
+   * Merge newVal and oldVal of a given key, choosing between them by:
+   * 1. Choose oldVal if syncOptions is 'disabled' in either oldVal or newVal.
+   * 2. Choose oldVal if it has a revision newer than or equal to that of newVal.
+   * 3. Choose oldVal if it deeply equals newVal.
+   * 4. Otherwise, choose newVal.
+   *
+   * The order is load-bearing: the revision test runs before the equality test
+   * so that an equal-but-older value still loses on revision alone, and the
+   * 'disabled' test runs first so a profile opted out of syncing is never
+   * overwritten by whatever stale copy the remote still holds.
+   */
+  merge: MergeFn = (_key, newVal, oldVal) => {
+    if (newVal === oldVal) return oldVal;
+
+    const oldRec = isRecord(oldVal) ? oldVal : undefined;
+    const newRec = isRecord(newVal) ? newVal : undefined;
+    if (oldRec?.['syncOptions'] === 'disabled' || newRec?.['syncOptions'] === 'disabled') {
+      return oldVal;
+    }
+
+    const oldRev = oldRec?.['revision'];
+    const newRev = newRec?.['revision'];
+    if (oldRev != null && newRev != null) {
+      if (Revision.compare(String(oldRev), String(newRev)) >= 0) return oldVal;
+    }
+
+    if (deepEqual(oldVal, newVal)) return oldVal;
+    return newVal;
+  };
+
+  /**
+   * Request pushing the changes to remote storage. The changes are cached first,
+   * and then the actual write operations are scheduled if enabled is true.
+   * The actual operation is delayed and debounced, combining continuous writes
+   * in a short period into a single write operation.
+   */
+  requestPush(changes: StorageItems): void {
+    if (this._timeout != null) clearTimeout(this._timeout);
+    for (const key of Object.keys(changes)) {
+      let value = changes[key];
+      if (typeof value !== 'undefined') {
+        value = this.transformValue(value, key);
+        // A transform returning undefined means "do not sync this key at all",
+        // which is not the same as the undefined that means "delete".
+        if (typeof value === 'undefined') continue;
+      }
+      this._pending[key] = value;
+    }
+    if (!this.enabled) return;
+    this._timeout = setTimeout(() => {
+      void this._doPush();
+    }, this.debounce);
+  }
+
+  /** The pending changes not yet written to the remote storage. */
+  pendingChanges(): StorageItems {
+    return this._pending;
+  }
+
+  private async _doPush(): Promise<void> {
+    this._timeout = null;
+    if (this._waiting) return;
+    this._waiting = true;
+
+    let base: StorageItems;
+    let changes: StorageItems;
+    try {
+      await this._bucket.removeTokens(1);
+      base = await this.storage.get(null);
+      // Pending changes are only consumed once the base read has succeeded, so
+      // a failure above leaves them queued for the next attempt.
+      changes = this._pending;
+      this._pending = {};
+    } catch (e) {
+      // The CoffeeScript original cleared this latch only on the success path,
+      // so one transient read failure left it set and every later push
+      // returned early — syncing stayed wedged for the life of the object.
+      this._waiting = false;
+      Log.error('OptionsSync::push could not read remote state', e);
+      return;
+    }
+    this._waiting = false;
+
+    const { set, remove } = Storage.operationsForChanges(changes, { base, merge: this.merge });
+
+    // Values still owed to the remote. Emptied as soon as the write lands, so
+    // that a later failure only re-queues what actually failed.
+    let unwritten: StorageItems = set;
+    try {
+      let cost = 0;
+      if (Object.keys(set).length > 0) {
+        Log.log('OptionsSync::set', set);
+        await this.storage.set(set);
+        cost = 1;
+      }
+      unwritten = {};
+      if (remove.length > 0) {
+        // The removal is a second write against the same budget; give up rather
+        // than overrun it, and retry from the top.
+        if (!this._bucket.tryRemoveTokens(cost)) throw new BucketEmptyError();
+        Log.log('OptionsSync::remove', remove);
+        await this.storage.remove(remove);
+      }
+    } catch (e) {
+      // Re-submit the changes for syncing, but with lower priority: anything
+      // already queued again by a newer requestPush wins over these.
+      for (const key of Object.keys(unwritten)) {
+        if (!(key in this._pending)) this._pending[key] = unwritten[key];
+      }
+      for (const key of remove) {
+        if (!(key in this._pending)) this._pending[key] = undefined;
+      }
+
+      if (e instanceof BucketEmptyError) {
+        await this._doPush();
+        return;
+      }
+      if (e instanceof RateLimitExceededError) {
+        Log.log('OptionsSync::rateLimitExceeded');
+        // Drain the bucket so the retry waits out a full refill instead of
+        // spending the tokens that are already accrued on a doomed write.
+        this._clearBucket();
+        this.requestPush({});
+        return;
+      }
+      if (e instanceof QuotaExceededError) {
+        // A single profile is too large for the per-item quota, and we cannot
+        // tell which, so every profile in the failed batch opts out of syncing.
+        // TODO(catus): Remove the largest profile each time and retry.
+        // The values are the same objects just re-queued above, so marking them
+        // here is what gets pushed on the next round.
+        let valuesAffected = 0;
+        for (const key of Object.keys(unwritten)) {
+          const value = unwritten[key];
+          if (key[0] === '+' && isRecord(value) && value['syncOptions'] !== 'disabled') {
+            value['syncOptions'] = 'disabled';
+            value['syncError'] = { reason: 'quotaPerItem' };
+            valuesAffected++;
+          }
+        }
+        if (valuesAffected > 0) {
+          this.requestPush({});
+        } else {
+          // Nothing to disable, so the batch is unfixable: drop it.
+          this._pending = {};
+        }
+        return;
+      }
+      throw e;
+    }
+  }
+
+  private _logOperations(text: string, operations: WriteOperations): void {
+    if (Object.keys(operations.set).length) {
+      Log.log(text + '::set', operations.set);
+    }
+    if (operations.remove.length) {
+      Log.log(text + '::remove', operations.remove);
+    }
+  }
+
+  /**
+   * Copy the remote storage over the local one, merging per key.
+   * @param local The local storage to be written to
+   */
+  async copyTo(local: Storage): Promise<void> {
+    const [base, changes] = await Promise.all([local.get(null), this.storage.get(null)]);
+    // The CoffeeScript version also tried to delete local profiles absent from
+    // the remote here, guarded by `not base[key]?.syncOptions == 'disabled'`.
+    // CoffeeScript parses that as `(!syncOptions) === 'disabled'`, which is
+    // always false, so that pass never ran. It is left out rather than
+    // "repaired": enabling it now would start deleting local profiles that were
+    // simply never uploaded.
+    const operations = await local.apply({ changes, base, merge: this.merge });
+    this._logOperations('OptionsSync::copyTo', operations);
+  }
+
+  /**
+   * Watch the remote storage for changes, and write them to local.
+   * The actual writing is throttled by pullThrottle with initial delay.
+   * @param local The local storage to be written to
+   * @returns Calling the returned function will stop watching.
+   */
+  watchAndPull(local: Storage): Unwatch {
+    let pullScheduled: ReturnType<typeof setTimeout> | null = null;
+    let pull: StorageItems = {};
+
+    const doPull = async (): Promise<void> => {
+      const base = await local.get(null);
+      const changes = pull;
+      pull = {};
+      pullScheduled = null;
+      const operations = Storage.operationsForChanges(changes, { base, merge: this.merge });
+      this._logOperations('OptionsSync::pull', operations);
+      await local.apply(operations);
+    };
+
+    return this.storage.watch(null, (changes) => {
+      for (const key of Object.keys(changes)) {
+        pull[key] = changes[key];
+      }
+      if (pullScheduled != null) return;
+      pullScheduled = setTimeout(() => {
+        void doPull();
+      }, this.pullThrottle);
+    });
+  }
+}
+
+export default OptionsSync;

--- a/packages/target/src/options.ts
+++ b/packages/target/src/options.ts
@@ -1,0 +1,1354 @@
+/**
+ * The central controller.
+ *
+ * `Options` owns the in-memory options bag, keeps it in sync with local
+ * storage (and optionally with remote sync storage), decides which profile is
+ * currently applied, and pushes the resulting proxy settings through a
+ * platform-specific `ProxyImpl`.
+ *
+ * Everything a platform needs to specialise is a plain method on this class,
+ * because the Chromium build subclasses it heavily and overrides those hooks.
+ */
+
+import { Conditions, PacGenerator, Profiles, Revision } from '@switchydelta/pac';
+import type {
+  MatchResult,
+  OptionsBag,
+  Condition,
+  Profile,
+  Request,
+  Rule,
+  SwitchProfile,
+} from '@switchydelta/pac';
+import { patch as applyJsonPatch } from 'jsondiffpatch';
+import type { Delta } from 'jsondiffpatch';
+
+import { NoOptionsError, ProfileNotExistError } from './errors.js';
+import { Log } from './log.js';
+import type { Logger } from './log.js';
+import { Storage, StorageUnavailableError } from './storage.js';
+import type { StorageItems, Unwatch, WatchCallback } from './storage.js';
+import type { OptionsSync } from './options-sync.js';
+import getDefaultOptions from './default-options.js';
+
+/** The persisted options bag, keyed by `+profileName` and `-settingName`. */
+export type OmegaOptions = OptionsBag;
+
+/** The platform hook that actually programs the browser's proxy settings. */
+export interface ProxyImpl {
+  applyProfile(profile: Profile, meta: Profile, options: OmegaOptions): Promise<unknown>;
+}
+
+export interface ApplyProfileOptions {
+  /** Set the browser proxy for the applied profile. Defaults to true. */
+  proxy?: boolean;
+  /** Update this profile and the profiles it references. Defaults to true. */
+  update?: boolean;
+  /** Whether options are in system mode. */
+  system?: boolean;
+  /** Passed through to {@link Options.currentProfileChanged}. */
+  reason?: string;
+}
+
+export interface SetOptionsArgs {
+  /**
+   * Skip incoming profiles that are not newer than the local copy. Used for
+   * changes arriving from storage, which may be stale echoes of our own write.
+   */
+  checkRevision?: boolean;
+  /** Write the changes back to storage. Defaults to true. */
+  persist?: boolean;
+}
+
+export interface SetExternalProfileArgs {
+  /** Do not revert the external change even if `-revertProxyChanges` is set. */
+  noRevert?: boolean;
+  /** Treat the change as caused by us rather than by another extension. */
+  internal?: boolean;
+}
+
+export interface SetOptionsSyncArgs {
+  /** Overwrite local options with sync storage even when they conflict. */
+  force?: boolean;
+}
+
+export interface MatchProfileResult {
+  profile: Profile | null | undefined;
+  results: MatchResult[];
+}
+
+/** A rule that only lives in memory, created by {@link Options.addTempRule}. */
+interface TempRule extends Rule {
+  isTempRule: true;
+}
+
+/** The summary of a profile published to the UI via state storage. */
+interface AvailableProfile {
+  name: string;
+  profileType: string;
+  color: string | undefined;
+  desc: string | null;
+  builtin: true | undefined;
+  defaultProfileName?: string;
+  validResultProfiles?: string[];
+}
+
+export class Options {
+  /** All the options, in a map from key to value. */
+  protected _options: OmegaOptions = {};
+  protected _storage: Storage;
+  protected _state: Storage;
+  protected _currentProfileName: string | null = null;
+  protected _revertToProfileName: string | null = null;
+  /**
+   * Every profile the current profile transitively depends on, keyed by
+   * `+name`. A change to any of them invalidates the applied proxy settings.
+   *
+   * Note: these used to be CoffeeScript prototype-level defaults, i.e. a
+   * single object shared by every instance. They are per-instance now.
+   */
+  protected _watchingProfiles: Record<string, string> = {};
+  protected _tempProfile: SwitchProfile | null = null;
+  protected _tempProfileActive = false;
+  protected _tempProfileRules: Record<string, TempRule | undefined> = {};
+  protected _tempProfileRulesByProfile: Record<string, TempRule[] | undefined> = {};
+  protected _externalProfile: Profile | null = null;
+  protected _isSystem = false;
+  protected _watchStop: Unwatch | null = null;
+  protected _syncWatchStop: Unwatch | null = null;
+
+  fallbackProfileName = 'system';
+  debugStr = 'Options';
+
+  log: Logger;
+  sync: OptionsSync | null;
+  proxyImpl: ProxyImpl;
+
+  /** Resolves with the options once the first profile has been applied. */
+  ready!: Promise<OmegaOptions>;
+  /** Resolves with the options once they have been loaded from storage. */
+  optionsLoaded!: Promise<OmegaOptions>;
+
+  /**
+   * Transform options values (especially profiles) for syncing.
+   *
+   * Downloaded payloads are dropped: they can be re-fetched from their source
+   * URL, and they are large enough to blow the per-item sync quota.
+   */
+  static transformValueForSync(value: unknown, key: string): unknown {
+    if (key[0] === '+') {
+      const profile = value as Profile | undefined;
+      if (profile && Profiles.updateUrl(profile)) {
+        const stripped: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(profile as unknown as Record<string, unknown>)) {
+          if (k === 'lastUpdate' || k === 'ruleList' || k === 'pacScript') continue;
+          stripped[k] = v;
+        }
+        return stripped;
+      }
+    }
+    return value;
+  }
+
+  constructor(
+    options: OmegaOptions | null | undefined,
+    storage?: Storage | null,
+    state?: Storage | null,
+    log?: Logger | null,
+    sync?: OptionsSync | null,
+    proxyImpl?: ProxyImpl,
+  ) {
+    // The CoffeeScript version called `Storage()` without `new`, which yields
+    // undefined for a class; these fall back to a real in-memory Storage.
+    this._storage = storage ?? new Storage();
+    this._state = state ?? new Storage();
+    this.log = log ?? Log;
+    this.sync = sync ?? null;
+    this.proxyImpl = proxyImpl as ProxyImpl;
+
+    if (options == null) {
+      this.init();
+    } else {
+      // Bound to a local so the closure does not defeat definite-assignment
+      // analysis on the field.
+      const storageRef = this._storage;
+      this.ready = (async () => {
+        await storageRef.remove();
+        await storageRef.set(options);
+        return this.init();
+      })();
+    }
+  }
+
+  toString(): string {
+    return '<Options>';
+  }
+
+  /** Read a single value from state storage, with a default. */
+  protected async _stateGet<T>(key: string, fallback: T): Promise<T> {
+    const items = await this._state.get({ [key]: fallback });
+    return items[key] as T;
+  }
+
+  /** Read a single options value, narrowed by the caller. */
+  protected _get<T>(key: string): T | undefined {
+    return this._options[key] as T | undefined;
+  }
+
+  // --- Loading --------------------------------------------------------------
+
+  /**
+   * Read the raw options, either straight from local storage or after pulling
+   * the remote sync storage into it.
+   */
+  private _loadRawOptions(): Promise<StorageItems> {
+    if (!this.sync?.enabled) {
+      if (!this.sync) {
+        void this._state.set({ syncOptions: 'unsupported' });
+      }
+      return this._storage.get(null);
+    }
+
+    void this._state.set({ syncOptions: 'sync' });
+    const sync = this.sync;
+    this._syncWatchStop = sync.watchAndPull(this._storage);
+    return sync
+      .copyTo(this._storage)
+      .catch(async (e: unknown) => {
+        // Only StorageUnavailableError disables syncing; anything else is a
+        // real failure and must keep propagating.
+        if (!(e instanceof StorageUnavailableError)) throw e;
+        console.error(
+          'Warning: Sync storage is not available in this browser! Disabling options sync.',
+        );
+        this._syncWatchStop?.();
+        this._syncWatchStop = null;
+        this.sync = null;
+        await this._state.set({ syncOptions: 'unsupported' });
+      })
+      .then(() => this._storage.get(null));
+  }
+
+  /**
+   * Attempt to load options from local and remote storage.
+   *
+   * On failure this wipes local storage, installs a fallback set of options
+   * (from sync storage if it looks usable, otherwise the defaults) and retries.
+   */
+  loadOptions(args: { retry?: number } = {}): Promise<OmegaOptions> {
+    const retry = args.retry ?? 3;
+    this._syncWatchStop?.();
+    this._syncWatchStop = null;
+    this._watchStop?.();
+    this._watchStop = null;
+
+    const loadRaw = this._loadRawOptions();
+
+    this.optionsLoaded = loadRaw
+      .then((raw) => this.upgrade(raw))
+      .then(async ([options, changes]) => {
+        await this._storage.apply({ changes });
+        return options;
+      })
+      .then(async (options) => {
+        this._options = options;
+        this._watchStop = this._watch();
+        // Try to set syncOptions to some value if not initialized. A sync
+        // storage with no schemaVersion has never been written to, so adopting
+        // the local options later will not clobber anything ('pristine').
+        const syncOptions = await this._stateGet('syncOptions', '');
+        if (!syncOptions) {
+          await this._state.set({ syncOptions: 'conflict' });
+          const { schemaVersion } = await this.sync!.storage.get('schemaVersion');
+          if (!schemaVersion) await this._state.set({ syncOptions: 'pristine' });
+        }
+        return options;
+      })
+      .catch(async (e: unknown): Promise<OmegaOptions> => {
+        if (!(retry > 0)) throw e;
+
+        let fallbackOptions: OmegaOptions | null | undefined = null;
+        if (e instanceof NoOptionsError) {
+          void this._state
+            .get({ firstRun: 'new', 'web.switchGuide': 'showOnFirstUse' })
+            .then((items) => this._state.set(items));
+          if (this.sync) {
+            const syncOptions = await this._stateGet('syncOptions', '');
+            if (syncOptions !== 'conflict') {
+              // Nothing locally, so try to adopt whatever sync storage has.
+              try {
+                const remote = await this.sync.storage.get(null);
+                if (!remote['schemaVersion']) {
+                  void this._state.set({ syncOptions: 'pristine' });
+                  fallbackOptions = null;
+                } else {
+                  void this._state.set({ syncOptions: 'sync' });
+                  this.sync.enabled = true;
+                  this.log.log('Options#loadOptions::fromSync', remote);
+                  fallbackOptions = remote;
+                }
+              } catch {
+                fallbackOptions = null;
+              }
+            }
+          }
+        } else {
+          this.log.error((e as Error | undefined)?.stack);
+          // Some serious error happened when loading options. Disable syncing
+          // and use fallback options.
+          void this._state.remove(['syncOptions']);
+          fallbackOptions = null;
+        }
+
+        const options = fallbackOptions ?? this.parseOptions(this.getDefaultOptions());
+        let prevEnabled: boolean | undefined;
+        if (this.sync) {
+          prevEnabled = this.sync.enabled;
+          this.sync.enabled = false;
+        }
+        await this._storage.remove();
+        await this._storage.set(options);
+        if (this.sync && prevEnabled !== undefined) this.sync.enabled = prevEnabled;
+        return this.loadOptions({ retry: retry - 1 });
+      });
+
+    return this.optionsLoaded;
+  }
+
+  /** Attempt to initialize (or reinitialize) options. */
+  init(): Promise<OmegaOptions> {
+    this.ready = this.loadOptions()
+      .then(async () => {
+        const startup = this._get<string>('-startupProfileName');
+        if (startup) {
+          return this.applyProfile(startup);
+        }
+        const st = await this._state.get({
+          currentProfileName: this.fallbackProfileName,
+          isSystemProfile: false,
+        });
+        if (st['isSystemProfile']) {
+          return this.applyProfile('system');
+        }
+        return this.applyProfile(
+          (st['currentProfileName'] as string) || this.fallbackProfileName,
+        );
+      })
+      .catch((err: unknown) => {
+        // FIX: was `if not err instanceof ProfileNotExistError`, which
+        // CoffeeScript parsed as `(not err) instanceof ...` — always false, so
+        // real errors were silently swallowed instead of logged.
+        if (!(err instanceof ProfileNotExistError)) {
+          this.log.error(err);
+        }
+        return this.applyProfile(this.fallbackProfileName);
+      })
+      .catch((err: unknown) => {
+        this.log.error(err);
+      })
+      .then(() => this.getAll());
+
+    void this.ready.then(async () => {
+      if (this.sync?.enabled) this.sync.requestPush(this._options);
+
+      void this._stateGet('firstRun', '').then((firstRun) => {
+        if (firstRun) this.onFirstRun(firstRun);
+      });
+
+      const interval = this._get<number>('-downloadInterval');
+      if (interval !== undefined && interval > 0) {
+        void this.updateProfile();
+      }
+    });
+
+    return this.ready;
+  }
+
+  /**
+   * Upgrade options from previous versions.
+   *
+   * Only schemaVersion 1 and 2 are handled here; 1 is migrated to 2 and 2 is
+   * current. Derived classes are expected to call super() at the beginning and
+   * at the end of their implementation.
+   */
+  async upgrade(
+    options: OmegaOptions | null | undefined,
+    changes?: StorageItems,
+  ): Promise<[OmegaOptions, StorageItems]> {
+    const pending: StorageItems = changes ?? {};
+    let version = options?.['schemaVersion'];
+    if (version === 1) {
+      const opts = options as OmegaOptions;
+      let autoDetectUsed = false;
+      Profiles.each(opts, (_key, profile) => {
+        if (!autoDetectUsed) {
+          const refs = Profiles.directReferenceSet(profile);
+          if (refs['+auto_detect']) autoDetectUsed = true;
+        }
+      });
+      if (autoDetectUsed) {
+        opts['+auto_detect'] = Profiles.create({
+          name: 'auto_detect',
+          profileType: 'PacProfile',
+          pacUrl: 'http://wpad/wpad.dat',
+          color: '#00cccc',
+        } as Profile);
+      }
+      version = 2;
+      pending['schemaVersion'] = 2;
+      opts['schemaVersion'] = 2;
+    }
+    if (version === 2) {
+      // Current schemaVersion.
+      return [options as OmegaOptions, pending];
+    }
+    throw new Error(`Invalid schemaVerion ${String(version)}!`);
+  }
+
+  /** Parse options in various formats (including JSON & base64). */
+  parseOptions(options: OmegaOptions | string | null | undefined): OmegaOptions {
+    let parsed: unknown = options;
+    if (typeof options === 'string') {
+      let text: string | null = options;
+      if (options[0] !== '{') {
+        try {
+          // The original used Node's `new Buffer(str, 'base64').toString('utf8')`.
+          // atob yields raw bytes, so decode them as UTF-8 explicitly; this also
+          // works in a service worker, where Buffer does not exist.
+          const binary = atob(options);
+          const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+          text = new TextDecoder('utf-8').decode(bytes);
+        } catch {
+          text = null;
+        }
+      }
+      try {
+        parsed = text === null ? null : JSON.parse(text);
+      } catch {
+        parsed = undefined;
+      }
+    }
+    if (!parsed) {
+      throw new Error('Invalid options!');
+    }
+    return parsed as OmegaOptions;
+  }
+
+  /** Reset the options to the given options or the initial options. */
+  async reset(options?: OmegaOptions | string | null): Promise<OmegaOptions> {
+    this.log.method('Options#reset', this, arguments);
+    const source = options ?? this.getDefaultOptions();
+    const [opt] = await this.upgrade(this.parseOptions(source));
+    // Disable syncing when resetting to avoid affecting sync storage.
+    if (this.sync) this.sync.enabled = false;
+    void this._state.remove(['syncOptions']);
+    await this._storage.remove();
+    await this._storage.set(opt);
+    return this.init();
+  }
+
+  /** Called on the first initialization of options. */
+  onFirstRun(reason: string): void {
+    void reason;
+  }
+
+  /** Return the default options used initially and on resets. */
+  getDefaultOptions(): OmegaOptions {
+    return getDefaultOptions();
+  }
+
+  /** Return all options. */
+  getAll(): OmegaOptions {
+    return this._options;
+  }
+
+  /** Get profile by name. */
+  profile(name: string): Profile | undefined {
+    return Profiles.byName(name, this._options);
+  }
+
+  /**
+   * Apply a jsondiffpatch delta to the current options.
+   *
+   * The delta format is the wire protocol used by the options UI, so it stays
+   * even though nothing else here uses jsondiffpatch.
+   */
+  patch(patch: Delta): Promise<OmegaOptions> | undefined {
+    if (!patch) return undefined;
+    this.log.method('Options#patch', this, arguments);
+
+    this._options = applyJsonPatch(this._options, patch) as OmegaOptions;
+    // Only set the keys whose values have changed.
+    const changes: StorageItems = {};
+    for (const [key, delta] of Object.entries(patch as Record<string, unknown>)) {
+      if (Array.isArray(delta) && delta.length === 3 && delta[1] === 0 && delta[2] === 0) {
+        // [previousValue, 0, 0] indicates that the key was removed.
+        changes[key] = undefined;
+      } else {
+        changes[key] = this._options[key];
+      }
+    }
+
+    return this._setOptions(changes);
+  }
+
+  /**
+   * Merge `changes` into the in-memory options, react to what changed and
+   * (unless `persist` is false) write them back.
+   */
+  protected _setOptions(
+    changes: StorageItems,
+    args?: SetOptionsArgs,
+  ): Promise<OmegaOptions> | undefined {
+    const removed: string[] = [];
+    const checkRev = args?.checkRevision ?? false;
+    let profilesChanged = false;
+    let currentProfileAffected: false | 'removed' | 'changed' = false;
+
+    for (const key of Object.keys(changes)) {
+      const value = changes[key];
+      if (typeof value === 'undefined') {
+        delete this._options[key];
+        removed.push(key);
+        if (key[0] === '+') {
+          profilesChanged = true;
+          if (key === '+' + this._currentProfileName) {
+            currentProfileAffected = 'removed';
+          }
+        }
+      } else {
+        if (key[0] === '+') {
+          const existing = this._options[key] as Profile | undefined;
+          if (checkRev && existing) {
+            // Storage echoes and sync pulls can be stale; ignore anything that
+            // is not strictly newer than what we already hold.
+            const result = Revision.compare(existing.revision, (value as Profile).revision);
+            if (result >= 0) continue;
+          }
+          profilesChanged = true;
+        }
+        this._options[key] = value;
+      }
+      if (!currentProfileAffected && this._watchingProfiles[key]) {
+        currentProfileAffected = 'changed';
+      }
+    }
+
+    switch (currentProfileAffected) {
+      case 'removed':
+        void this.applyProfile(this.fallbackProfileName);
+        break;
+      case 'changed':
+        void this.applyProfile(this._currentProfileName, { update: false });
+        break;
+      default:
+        if (profilesChanged) this._setAvailableProfiles();
+        break;
+    }
+
+    if (args?.persist ?? true) {
+      if (this.sync?.enabled) this.sync.requestPush(changes);
+      for (const key of removed) {
+        delete changes[key];
+      }
+      return this._storage.set(changes).then(() => {
+        void this._storage.remove(removed);
+        return this._options;
+      });
+    }
+    return undefined;
+  }
+
+  protected _watch(): Unwatch {
+    const handler = (changes?: StorageItems): void => {
+      let source: StorageItems;
+      if (changes) {
+        this._setOptions(changes, { checkRevision: true, persist: false });
+        source = changes;
+      } else {
+        // Initial update.
+        source = this._options;
+      }
+      const initial = source === this._options;
+
+      const refresh = source['-refreshOnProfileChange'];
+      if (refresh != null) {
+        void this._state.set({ refreshOnProfileChange: refresh });
+      }
+
+      if (Object.prototype.hasOwnProperty.call(source, '-showExternalProfile')) {
+        let showExternal = source['-showExternalProfile'];
+        if (showExternal == null) {
+          showExternal = true;
+          this._setOptions({ '-showExternalProfile': true }, { persist: true });
+        }
+        void this._state.set({ showExternalProfile: showExternal });
+      }
+
+      const quickSwitchProfiles = this._cleanUpQuickSwitchProfiles(
+        source['-quickSwitchProfiles'] as string[] | undefined,
+      );
+      if (source['-enableQuickSwitch'] != null || quickSwitchProfiles != null) {
+        void this.reloadQuickSwitch();
+      }
+      if (source['-downloadInterval'] != null) {
+        void this.schedule('updateProfile', this._get<number>('-downloadInterval') as number, () => {
+          void this.updateProfile();
+        });
+      }
+      if (source['-showInspectMenu'] != null || initial) {
+        let showMenu = this._get<boolean>('-showInspectMenu');
+        if (showMenu == null) {
+          showMenu = true;
+          this._setOptions({ '-showInspectMenu': true }, { persist: true });
+        }
+        void this.setInspect({ showMenu });
+      }
+      if (source['-monitorWebRequests'] != null || initial) {
+        let monitorWebRequests = this._get<boolean>('-monitorWebRequests');
+        if (monitorWebRequests == null) {
+          monitorWebRequests = true;
+          this._setOptions({ '-monitorWebRequests': true }, { persist: true });
+        }
+        void this.setMonitorWebRequests(monitorWebRequests);
+      }
+    };
+
+    handler();
+    return this._storage.watch(null, handler as WatchCallback);
+  }
+
+  /** Drop empty, duplicate and dangling entries from the quick switch list. */
+  protected _cleanUpQuickSwitchProfiles(
+    quickSwitchProfiles: string[] | undefined | null,
+  ): string[] | undefined {
+    if (quickSwitchProfiles == null) return undefined;
+    const seen: Record<string, boolean | undefined> = {};
+    const valid = quickSwitchProfiles.filter((name) => {
+      if (!name) return false;
+      const key = Profiles.nameAsKey(name);
+      if (seen[key]) return false;
+      if (!Profiles.byName(name, this._options)) return false;
+      seen[key] = true;
+      return true;
+    });
+    if (valid.length !== quickSwitchProfiles.length) {
+      this._setOptions({ '-quickSwitchProfiles': valid }, { persist: true });
+    }
+    return valid;
+  }
+
+  /** Reload the quick switch according to settings. */
+  reloadQuickSwitch(): Promise<void> {
+    const configured = this._get<string[]>('-quickSwitchProfiles') as string[];
+    const profiles = configured.length < 2 ? null : configured;
+    if (this._get<boolean>('-enableQuickSwitch')) {
+      return this.setQuickSwitch(profiles, !!profiles);
+    }
+    return this.setQuickSwitch(null, !!profiles);
+  }
+
+  /**
+   * Apply the settings related to element proxy inspection.
+   * Not implemented in the base class.
+   */
+  setInspect(settings: { showMenu: boolean }): Promise<void> {
+    void settings;
+    return Promise.resolve();
+  }
+
+  /**
+   * Apply the settings related to web request monitoring.
+   * Not implemented in the base class.
+   */
+  setMonitorWebRequests(enabled: boolean): Promise<void> {
+    void enabled;
+    return Promise.resolve();
+  }
+
+  /** Watch for any changes to the options. */
+  watch(callback: WatchCallback): Unwatch {
+    return this._storage.watch(null, callback);
+  }
+
+  protected _profileNotFound(name: string): Profile {
+    this.log.error(`Profile ${name} not found! Things may go very, very wrong.`);
+    return Profiles.create({
+      name,
+      profileType: 'VirtualProfile',
+      defaultProfileName: 'direct',
+    } as Profile);
+  }
+
+  /**
+   * Get the PAC script for a profile.
+   *
+   * `compress` is kept for call-site compatibility only: the generator now
+   * always emits compact output, and the separate "full compiler" bundle that
+   * `_pacWithCompiler()` used to load on demand no longer exists.
+   */
+  pacForProfile(profile: string | Profile, compress = false): string {
+    void compress;
+    return PacGenerator.script(this._options, profile, {
+      profileNotFound: (name) => this._profileNotFound(name),
+    });
+  }
+
+  /** Publish the profile list (and valid switch targets) to the UI. */
+  protected _setAvailableProfiles(): void {
+    const profile = this._currentProfileName ? this.currentProfile() : null;
+    const profiles: Record<string, AvailableProfile> = {};
+    const currentIncludable = !!profile && Profiles.isIncludable(profile);
+    let allReferenceSet: Record<string, string> | null = null;
+    let results: string[] | undefined;
+    if (!profile || !Profiles.isInclusive(profile)) {
+      results = [];
+    }
+    Profiles.each(this._options, (key, p) => {
+      const entry: AvailableProfile = {
+        name: p.name,
+        profileType: p.profileType,
+        color: p.color,
+        desc: this.printProfile(p),
+        builtin: p.builtin ? true : undefined,
+      };
+      profiles[key] = entry;
+      if (p.profileType === 'VirtualProfile') {
+        entry.defaultProfileName = (p as SwitchProfile).defaultProfileName;
+        allReferenceSet ??= profile
+          ? Profiles.allReferenceSet(profile, this._options, {
+              profileNotFound: (name) => this._profileNotFound(name),
+            })
+          : {};
+        if (allReferenceSet[key]) {
+          entry.validResultProfiles = Profiles.validResultProfilesFor(p, this._options).map(
+            (result) => result.name,
+          );
+        }
+      }
+      if (currentIncludable && Profiles.isIncludable(p)) {
+        results?.push(p.name);
+      }
+    });
+    if (profile && Profiles.isInclusive(profile)) {
+      results = Profiles.validResultProfilesFor(profile, this._options).map((p) => p.name);
+    }
+    void this._state.set({
+      availableProfiles: profiles,
+      validResultProfiles: results,
+    });
+  }
+
+  /** Apply the profile by name. */
+  applyProfile(
+    name: string | Profile | null | undefined,
+    options?: ApplyProfileOptions,
+  ): Promise<unknown> {
+    this.log.method('Options#applyProfile', this, arguments);
+    const profile = Profiles.byName(name ?? undefined, this._options);
+    if (!profile) {
+      return Promise.reject(new ProfileNotExistError(name as string));
+    }
+
+    this._currentProfileName = profile.name;
+    this._isSystem = options?.system || profile.profileType === 'SystemProfile';
+    this._watchingProfiles = Profiles.allReferenceSet(profile, this._options, {
+      profileNotFound: (n) => this._profileNotFound(n),
+    });
+
+    void this._state.set({
+      currentProfileName: this._currentProfileName,
+      isSystemProfile: this._isSystem,
+      currentProfileCanAddRule:
+        (profile as SwitchProfile).rules != null && profile.profileType !== 'VirtualProfile',
+    });
+    this._setAvailableProfiles();
+
+    this.currentProfileChanged(options?.reason);
+    if (options && options.proxy === false) {
+      return Promise.resolve();
+    }
+
+    this._tempProfileActive = false;
+    let applyProxy: Promise<unknown>;
+    if (this._tempProfile != null && Profiles.isIncludable(profile)) {
+      // Temp rules are layered on top of the real profile: the temp profile is
+      // a SwitchProfile whose default result is the profile being applied, so
+      // anything not matched by a temp rule behaves exactly as before.
+      const temp = this._tempProfile;
+      this._tempProfileActive = true;
+      if (temp.defaultProfileName !== profile.name) {
+        temp.defaultProfileName = profile.name;
+        temp.color = profile.color;
+        Profiles.updateRevision(temp);
+      }
+
+      // Drop temp rules pointing at profiles that no longer exist.
+      const removedKeys: string[] = [];
+      for (const key of Object.keys(this._tempProfileRulesByProfile)) {
+        const list = this._tempProfileRulesByProfile[key];
+        if (!list) continue;
+        if (!Profiles.byKey(key, this._options)) {
+          removedKeys.push(key);
+          for (const rule of list) {
+            rule.profileName = null;
+            temp.rules.splice(temp.rules.indexOf(rule), 1);
+          }
+        }
+      }
+      if (removedKeys.length > 0) {
+        for (const key of removedKeys) {
+          delete this._tempProfileRulesByProfile[key];
+        }
+        Profiles.updateRevision(temp);
+      }
+
+      this._watchingProfiles = Profiles.allReferenceSet(temp, this._options, {
+        profileNotFound: (n) => this._profileNotFound(n),
+      });
+
+      applyProxy = this.proxyImpl.applyProfile(temp, profile, this._options);
+    } else {
+      applyProxy = this.proxyImpl.applyProfile(profile, profile, this._options);
+    }
+
+    if (options && options.update === false) return applyProxy;
+
+    void applyProxy.then(() => {
+      const interval = this._get<number>('-downloadInterval');
+      if (!(interval !== undefined && interval > 0)) return;
+      if (this._currentProfileName !== profile.name) return;
+      const updateProfiles = Object.values(this._watchingProfiles);
+      if (updateProfiles.length > 0) {
+        void this.updateProfile(updateProfiles);
+      }
+    });
+    return applyProxy;
+  }
+
+  /** Get the currently applied profile. */
+  currentProfile(): Profile | null | undefined {
+    if (this._currentProfileName) {
+      return Profiles.byName(this._currentProfileName, this._options);
+    }
+    return this._externalProfile;
+  }
+
+  /** Return true if in system mode. */
+  isSystem(): boolean {
+    return this._isSystem;
+  }
+
+  /**
+   * Called when the current profile has changed.
+   * Not implemented in the base class.
+   */
+  currentProfileChanged(reason?: string): void {
+    void reason;
+  }
+
+  /**
+   * Set or disable the quick switch profiles.
+   * Not implemented in the base class.
+   */
+  setQuickSwitch(quickSwitch: string[] | null, canEnable: boolean): Promise<void> {
+    void quickSwitch;
+    void canEnable;
+    return Promise.resolve();
+  }
+
+  /**
+   * Schedule a task that runs every periodInMinutes, replacing any previous
+   * schedule with the same name. Not implemented in the base class.
+   */
+  schedule(name: string, periodInMinutes: number, callback: () => void): Promise<void> {
+    void name;
+    void periodInMinutes;
+    void callback;
+    return Promise.resolve();
+  }
+
+  /** True if the match result of the current profile does not depend on the URL. */
+  isCurrentProfileStatic(): boolean {
+    if (!this._currentProfileName) return true;
+    if (this._tempProfileActive) return false;
+    const currentProfile = this.currentProfile();
+    if (currentProfile && Profiles.isInclusive(currentProfile)) return false;
+    return true;
+  }
+
+  /**
+   * Update the profiles with the given name (or all profiles when null).
+   *
+   * Resolves with a map from profile key to either the updated profile or the
+   * Error that prevented the update.
+   */
+  updateProfile(
+    name?: string | string[] | null,
+    optBypassCache?: boolean,
+  ): Promise<Record<string, Profile | Error>> {
+    this.log.method('Options#updateProfile', this, arguments);
+    const results: Record<string, Promise<Profile | Error>> = {};
+    Profiles.each(this._options, (key, profile) => {
+      if (name != null) {
+        if (Array.isArray(name)) {
+          if (name.indexOf(profile.name) < 0) return;
+        } else if (profile.name !== name) {
+          return;
+        }
+      }
+      const url = Profiles.updateUrl(profile);
+      if (!url) return;
+      const typeHints = Profiles.updateContentTypeHints(profile);
+      const fetchResult = this.fetchUrl(url, optBypassCache, typeHints);
+      results[key] = fetchResult
+        .then(async (data): Promise<Profile> => {
+          // Errors and unsuccessful response codes should have been rejected
+          // by fetchUrl already, so empty data means success without any
+          // update (e.g. a 304).
+          if (!data) return profile;
+          const current = Profiles.byKey(key, this._options)!;
+          (current as Profile & { lastUpdate?: string }).lastUpdate = new Date().toISOString();
+          if (Profiles.update(current, data)) {
+            Profiles.dropCache(current);
+            await this._setOptions({ [key]: current });
+            return current;
+          }
+          return current;
+        })
+        .catch((reason: unknown) =>
+          reason instanceof Error ? reason : new Error(String(reason)),
+        );
+    });
+
+    return this._allProps(results);
+  }
+
+  /** Native replacement for bluebird's Promise.props. */
+  private async _allProps<T>(map: Record<string, Promise<T>>): Promise<Record<string, T>> {
+    const keys = Object.keys(map);
+    const values = await Promise.all(keys.map((key) => map[key] as Promise<T>));
+    const result: Record<string, T> = {};
+    keys.forEach((key, i) => {
+      result[key] = values[i] as T;
+    });
+    return result;
+  }
+
+  /**
+   * Make an HTTP GET request to fetch the content of the url.
+   * Not implemented in the base class; always rejects.
+   */
+  fetchUrl(url: string, optBypassCache?: boolean, optTypeHints?: string[]): Promise<string> {
+    void url;
+    void optBypassCache;
+    void optTypeHints;
+    return Promise.reject(new Error('not implemented'));
+  }
+
+  protected _replaceRefChanges(
+    fromName: string,
+    toName: string,
+    changes?: StorageItems,
+  ): StorageItems {
+    const result: StorageItems = changes ?? {};
+
+    Profiles.each(this._options, (_key, p) => {
+      if (p.name === fromName || p.name === toName) return;
+      if (Profiles.replaceRef(p, fromName, toName)) {
+        Profiles.updateRevision(p);
+        result[Profiles.nameAsKey(p)] = p;
+      }
+    });
+
+    if (this._options['-startupProfileName'] === fromName) {
+      result['-startupProfileName'] = toName;
+    }
+    const quickSwitch = this._get<string[]>('-quickSwitchProfiles') as string[];
+    // Change fromName to toName in Quick Switch, but only if it does not
+    // contain toName already. Otherwise it may cause duplicates.
+    if (quickSwitch.indexOf(toName) < 0) {
+      for (let i = 0; i < quickSwitch.length; i++) {
+        if (quickSwitch[i] === fromName) {
+          quickSwitch[i] = toName;
+          result['-quickSwitchProfiles'] = quickSwitch;
+        }
+      }
+    }
+
+    return result;
+  }
+
+  /** Replace all references of profile fromName to toName. */
+  replaceRef(fromName: string, toName: string): Promise<OmegaOptions> | undefined {
+    this.log.method('Options#replaceRef', this, arguments);
+    const profile = Profiles.byName(fromName, this._options);
+    if (!profile) {
+      return Promise.reject(new ProfileNotExistError(fromName)) as Promise<OmegaOptions>;
+    }
+
+    const changes = this._replaceRefChanges(fromName, toName);
+    for (const key of Object.keys(changes)) {
+      this._options[key] = changes[key];
+    }
+
+    const fromKey = Profiles.nameAsKey(fromName);
+    if (this._watchingProfiles[fromKey]) {
+      if (this._currentProfileName === fromName) {
+        this._currentProfileName = toName;
+      }
+      void this.applyProfile(this._currentProfileName);
+    }
+
+    return this._setOptions(changes);
+  }
+
+  /** Rename a profile and update references and options. */
+  renameProfile(fromName: string, toName: string): Promise<OmegaOptions> | undefined {
+    this.log.method('Options#renameProfile', this, arguments);
+    if (Profiles.byName(toName, this._options)) {
+      // FIX: the message used to interpolate an undeclared `name`, which
+      // resolved to the global `name` (an empty string) instead of `toName`.
+      return Promise.reject(
+        new Error(`Target name ${toName} already taken!`),
+      ) as Promise<OmegaOptions>;
+    }
+    const profile = Profiles.byName(fromName, this._options);
+    if (!profile) {
+      return Promise.reject(new ProfileNotExistError(fromName)) as Promise<OmegaOptions>;
+    }
+
+    profile.name = toName;
+    const changes: StorageItems = {};
+    changes[Profiles.nameAsKey(profile)] = profile;
+
+    this._replaceRefChanges(fromName, toName, changes);
+    for (const key of Object.keys(changes)) {
+      this._options[key] = changes[key];
+    }
+
+    const fromKey = Profiles.nameAsKey(fromName);
+    changes[fromKey] = undefined;
+    delete this._options[fromKey];
+
+    if (this._watchingProfiles[fromKey]) {
+      if (this._currentProfileName === fromName) {
+        this._currentProfileName = toName;
+      }
+      void this.applyProfile(this._currentProfileName);
+    }
+
+    return this._setOptions(changes);
+  }
+
+  /** Add a temp rule mapping a domain to a profile. */
+  addTempRule(domain: string, profileName: string): Promise<unknown> {
+    this.log.method('Options#addTempRule', this, arguments);
+    if (!this._currentProfileName) return Promise.resolve();
+    const profile = Profiles.byName(profileName, this._options);
+    if (!profile) {
+      return Promise.reject(new ProfileNotExistError(profileName));
+    }
+    if (this._tempProfile == null) {
+      const created = Profiles.create('', 'SwitchProfile') as SwitchProfile;
+      const currentProfile = this.currentProfile() as Profile;
+      created.color = currentProfile.color;
+      created.defaultProfileName = currentProfile.name;
+      this._tempProfile = created;
+    }
+    const tempProfile = this._tempProfile;
+
+    let changed = false;
+    let rule = this._tempProfileRules[domain];
+    if (rule && rule.profileName) {
+      if (rule.profileName !== profileName) {
+        const oldKey = Profiles.nameAsKey(rule.profileName);
+        const list = this._tempProfileRulesByProfile[oldKey] as TempRule[];
+        list.splice(list.indexOf(rule), 1);
+
+        rule.profileName = profileName;
+        changed = true;
+      }
+    } else {
+      rule = {
+        condition: {
+          conditionType: 'HostWildcardCondition',
+          pattern: '*.' + domain,
+        },
+        profileName,
+        isTempRule: true,
+      };
+      tempProfile.rules.push(rule);
+      this._tempProfileRules[domain] = rule;
+      changed = true;
+    }
+
+    const key = Profiles.nameAsKey(profileName);
+    let rulesByProfile = this._tempProfileRulesByProfile[key];
+    if (rulesByProfile == null) {
+      rulesByProfile = [];
+      this._tempProfileRulesByProfile[key] = rulesByProfile;
+    }
+    rulesByProfile.push(rule);
+
+    if (changed) {
+      Profiles.updateRevision(tempProfile);
+      return this.applyProfile(this._currentProfileName);
+    }
+    return Promise.resolve();
+  }
+
+  /** Find a temp rule by domain, returning its result profile name. */
+  queryTempRule(domain: string): string | null {
+    const rule = this._tempProfileRules[domain];
+    if (rule) {
+      if (rule.profileName) {
+        return rule.profileName;
+      }
+      delete this._tempProfileRules[domain];
+    }
+    return null;
+  }
+
+  /** Add one or more conditions to the current active switch profile. */
+  addCondition(
+    condition: Condition | Condition[],
+    profileName: string,
+  ): Promise<OmegaOptions> | undefined {
+    this.log.method('Options#addCondition', this, arguments);
+    if (!this._currentProfileName) return Promise.resolve(this._options);
+    const profile = Profiles.byName(this._currentProfileName, this._options) as
+      | SwitchProfile
+      | undefined;
+    if (!profile?.rules) {
+      // FIX: the original interpolated `@profile.name` (the *method* named
+      // `profile`, so always the string "profile") and `profile.type`, which
+      // does not exist.
+      return Promise.reject(
+        new Error(
+          `Cannot add condition to Profile ${String(profile?.name)} (${String(
+            profile?.profileType,
+          )})`,
+        ),
+      ) as Promise<OmegaOptions>;
+    }
+    const target = Profiles.byName(profileName, this._options);
+    if (target == null) {
+      return Promise.reject(new ProfileNotExistError(profileName)) as Promise<OmegaOptions>;
+    }
+    const conditions = Array.isArray(condition) ? condition : [condition];
+
+    for (const cond of conditions) {
+      // Try to remove rules with the same condition first.
+      const tag = Conditions.tag(cond);
+      for (let i = 0; i < profile.rules.length; i++) {
+        const existing = profile.rules[i];
+        if (existing && Conditions.tag(existing.condition) === tag) {
+          profile.rules.splice(i, 1);
+          break;
+        }
+      }
+
+      const rule: Rule = { condition: cond, profileName };
+      if (this._options['-addConditionsToBottom']) {
+        profile.rules.push(rule);
+      } else {
+        profile.rules.unshift(rule);
+      }
+    }
+
+    Profiles.updateRevision(profile);
+    return this._setOptions({ [Profiles.nameAsKey(profile)]: profile });
+  }
+
+  /** Set the defaultProfileName of a profile. */
+  setDefaultProfile(
+    profileName: string,
+    defaultProfileName: string,
+  ): Promise<OmegaOptions> | undefined {
+    this.log.method('Options#setDefaultProfile', this, arguments);
+    const profile = Profiles.byName(profileName, this._options) as SwitchProfile | undefined;
+    if (profile == null) {
+      return Promise.reject(new ProfileNotExistError(profileName)) as Promise<OmegaOptions>;
+    }
+    if (profile.defaultProfileName == null) {
+      // FIX: same broken interpolation as in addCondition (`@profile.name` and
+      // a literal `@{profile.type}` that was never interpolated at all).
+      return Promise.reject(
+        new Error(
+          `Profile ${profile.name} (${profile.profileType}) does not have defaultProfileName!`,
+        ),
+      ) as Promise<OmegaOptions>;
+    }
+    const target = Profiles.byName(defaultProfileName, this._options);
+    if (target == null) {
+      return Promise.reject(
+        new ProfileNotExistError(defaultProfileName),
+      ) as Promise<OmegaOptions>;
+    }
+
+    profile.defaultProfileName = defaultProfileName;
+    Profiles.updateRevision(profile);
+    return this._setOptions({ [Profiles.nameAsKey(profile)]: profile });
+  }
+
+  /** Add a profile to the options. */
+  addProfile(profile: Profile): Promise<OmegaOptions> | undefined {
+    this.log.method('Options#addProfile', this, arguments);
+    if (Profiles.byName(profile.name, this._options)) {
+      return Promise.reject(
+        new Error(`Target name ${profile.name} already taken!`),
+      ) as Promise<OmegaOptions>;
+    }
+    return this._setOptions({ [Profiles.nameAsKey(profile)]: profile });
+  }
+
+  /**
+   * Get the matching results of a request: the profile finally selected plus
+   * every intermediate match along the profile chain.
+   */
+  matchProfile(request: Request): Promise<MatchProfileResult> {
+    if (!this._currentProfileName) {
+      return Promise.resolve({ profile: this._externalProfile, results: [] });
+    }
+    const results: MatchResult[] = [];
+    let profile: Profile | undefined = this._tempProfileActive
+      ? (this._tempProfile as SwitchProfile)
+      : Profiles.byName(this._currentProfileName, this._options);
+    let lastProfile: Profile | undefined;
+    while (profile) {
+      lastProfile = profile;
+      const result = Profiles.match(profile, request);
+      if (result == null) break;
+      results.push(result);
+      let next: string;
+      if (Array.isArray(result)) {
+        next = result[0];
+      } else if (result.profileName) {
+        next = Profiles.nameAsKey(result.profileName);
+      } else {
+        break;
+      }
+      profile = Profiles.byKey(next, this._options);
+    }
+    return Promise.resolve({ profile: lastProfile, results });
+  }
+
+  /**
+   * Notify Options that the proxy settings were set externally.
+   *
+   * With `-revertProxyChanges` on, an external change is undone by re-applying
+   * the profile we were on before the *first* such change (`_revertToProfileName`),
+   * which is recorded while `noRevert` is set (i.e. while the proxy is under
+   * someone else's control and reverting would be futile).
+   */
+  setExternalProfile(profile: Profile, args?: SetExternalProfileArgs): void {
+    if (this._options['-revertProxyChanges'] && !this._isSystem) {
+      if (profile.name !== this._currentProfileName && this._currentProfileName) {
+        if (!args?.noRevert) {
+          void this.applyProfile(this._revertToProfileName);
+          this._revertToProfileName = null;
+          return;
+        }
+        this._revertToProfileName ??= this._currentProfileName;
+      }
+    }
+    const p = Profiles.byName(profile.name, this._options);
+    if (p) {
+      if (args?.internal) {
+        void this.applyProfile(p.name, { proxy: false });
+      } else {
+        void this.applyProfile(p.name, {
+          proxy: false,
+          system: this._isSystem,
+          reason: 'external',
+        });
+      }
+    } else {
+      this._currentProfileName = null;
+      this._externalProfile = profile;
+      profile.color ??= '#49afcd';
+      void this._state.set({
+        currentProfileName: '',
+        externalProfile: profile,
+        validResultProfiles: [],
+        currentProfileCanAddRule: false,
+      });
+      this.currentProfileChanged('external');
+    }
+  }
+
+  /**
+   * Switch options syncing on and off.
+   *
+   * 'conflict' means local options and sync storage both hold real data and
+   * one of them must lose; enabling sync from that state requires `force`, and
+   * resolves by wiping local storage and re-initialising from sync.
+   */
+  async setOptionsSync(enabled: boolean, args?: SetOptionsSyncArgs): Promise<unknown> {
+    this.log.method('Options#setOptionsSync', this, arguments);
+    if (this.sync == null) {
+      throw new Error('Options syncing is unsupported.');
+    }
+    const sync = this.sync;
+    const syncOptions = await this._stateGet('syncOptions', '');
+
+    if (!enabled) {
+      if (syncOptions === 'sync') {
+        void this._state.set({ syncOptions: 'conflict' });
+      }
+      sync.enabled = false;
+      this._syncWatchStop?.();
+      this._syncWatchStop = null;
+      return undefined;
+    }
+
+    if (syncOptions === 'conflict' && !args?.force) {
+      throw new Error(
+        'Syncing not enabled due to conflict. Retry with force to overwrite ' +
+          'local options and enable syncing.',
+      );
+    }
+    if (syncOptions === 'sync') return undefined;
+
+    await this._state.set({ syncOptions: 'sync' });
+    if (syncOptions === 'conflict') {
+      // Try to re-init options from sync.
+      sync.enabled = false;
+      await this._storage.remove();
+      sync.enabled = true;
+      return this.init();
+    }
+    sync.enabled = true;
+    this._syncWatchStop?.();
+    sync.requestPush(this._options);
+    this._syncWatchStop = sync.watchAndPull(this._storage);
+    return undefined;
+  }
+
+  /** Clear the sync storage, resetting the syncing state to pristine. */
+  async resetOptionsSync(): Promise<void> {
+    this.log.method('Options#resetOptionsSync', this, arguments);
+    if (this.sync == null) {
+      throw new Error('Options syncing is unsupported.');
+    }
+    this.sync.enabled = false;
+    this._syncWatchStop?.();
+    this._syncWatchStop = null;
+    void this._state.set({ syncOptions: 'conflict' });
+
+    await this.sync.storage.remove();
+    await this._state.set({ syncOptions: 'pristine' });
+  }
+
+  /**
+   * Return a localized, human-readable description of the given profile.
+   * Not implemented in the base class.
+   */
+  printProfile(profile: Profile | null | undefined): string | null {
+    void profile;
+    return null;
+  }
+}
+
+export default Options;

--- a/packages/target/src/options.ts
+++ b/packages/target/src/options.ts
@@ -257,9 +257,15 @@ export class Options {
         // storage with no schemaVersion has never been written to, so adopting
         // the local options later will not clobber anything ('pristine').
         const syncOptions = await this._stateGet('syncOptions', '');
-        if (!syncOptions) {
+        // FIX: the original dereferenced sync unconditionally. The write that
+        // would have set 'unsupported' is fire-and-forget, so with no sync
+        // available there is a window where this key is still empty and the
+        // dereference throws. That TypeError lands in the retry catch below,
+        // which treats it as a serious failure and reinstalls default options
+        // over the user's real ones.
+        if (!syncOptions && this.sync) {
           await this._state.set({ syncOptions: 'conflict' });
-          const { schemaVersion } = await this.sync!.storage.get('schemaVersion');
+          const { schemaVersion } = await this.sync.storage.get('schemaVersion');
           if (!schemaVersion) await this._state.set({ syncOptions: 'pristine' });
         }
         return options;
@@ -348,7 +354,9 @@ export class Options {
       })
       .then(() => this.getAll());
 
-    void this.ready.then(async () => {
+    // Deliberately not chained into `ready`: these are follow-up side effects,
+    // and callers must not wait on a profile download to consider us ready.
+    void this.ready.then(() => {
       if (this.sync?.enabled) this.sync.requestPush(this._options);
 
       void this._stateGet('firstRun', '').then((firstRun) => {
@@ -551,10 +559,12 @@ export class Options {
       for (const key of removed) {
         delete changes[key];
       }
-      return this._storage.set(changes).then(() => {
-        void this._storage.remove(removed);
-        return this._options;
-      });
+      // FIX: the removal was not chained, so the returned promise could resolve
+      // before the keys were actually gone from storage.
+      return this._storage
+        .set(changes)
+        .then(() => this._storage.remove(removed))
+        .then(() => this._options);
     }
     return undefined;
   }
@@ -640,7 +650,8 @@ export class Options {
 
   /** Reload the quick switch according to settings. */
   reloadQuickSwitch(): Promise<void> {
-    const configured = this._get<string[]>('-quickSwitchProfiles') as string[];
+    // FIX: this key can be absent; the original dereferenced it unguarded.
+    const configured = this._get<string[]>('-quickSwitchProfiles') ?? [];
     const profiles = configured.length < 2 ? null : configured;
     if (this._get<boolean>('-enableQuickSwitch')) {
       return this.setQuickSwitch(profiles, !!profiles);
@@ -792,7 +803,10 @@ export class Options {
           removedKeys.push(key);
           for (const rule of list) {
             rule.profileName = null;
-            temp.rules.splice(temp.rules.indexOf(rule), 1);
+            // FIX: guard the index. splice(-1, 1) would remove the last,
+            // unrelated rule when the rule is not present.
+            const index = temp.rules.indexOf(rule);
+            if (index >= 0) temp.rules.splice(index, 1);
           }
         }
       }
@@ -964,7 +978,8 @@ export class Options {
     if (this._options['-startupProfileName'] === fromName) {
       result['-startupProfileName'] = toName;
     }
-    const quickSwitch = this._get<string[]>('-quickSwitchProfiles') as string[];
+    // FIX: this key can be absent; the original dereferenced it unguarded.
+    const quickSwitch = this._get<string[]>('-quickSwitchProfiles') ?? [];
     // Change fromName to toName in Quick Switch, but only if it does not
     // contain toName already. Otherwise it may cause duplicates.
     if (quickSwitch.indexOf(toName) < 0) {
@@ -1063,8 +1078,10 @@ export class Options {
     if (rule && rule.profileName) {
       if (rule.profileName !== profileName) {
         const oldKey = Profiles.nameAsKey(rule.profileName);
-        const list = this._tempProfileRulesByProfile[oldKey] as TempRule[];
-        list.splice(list.indexOf(rule), 1);
+        const list = this._tempProfileRulesByProfile[oldKey];
+        // FIX: guard the index; splice(-1, 1) would drop an unrelated rule.
+        const index = list ? list.indexOf(rule) : -1;
+        if (list && index >= 0) list.splice(index, 1);
 
         rule.profileName = profileName;
         changed = true;
@@ -1083,13 +1100,21 @@ export class Options {
       changed = true;
     }
 
-    const key = Profiles.nameAsKey(profileName);
-    let rulesByProfile = this._tempProfileRulesByProfile[key];
-    if (rulesByProfile == null) {
-      rulesByProfile = [];
-      this._tempProfileRulesByProfile[key] = rulesByProfile;
+    // FIX: only index the rule when it is new or has just moved profile. The
+    // CoffeeScript pushed unconditionally, so calling addTempRule twice with
+    // the same domain and profile appended the same rule object again. The
+    // stale-rule cleanup in applyProfile then spliced by indexOf once per
+    // duplicate, and after the first removal indexOf returns -1 — splice(-1, 1)
+    // deletes the last, unrelated rule.
+    if (changed) {
+      const key = Profiles.nameAsKey(profileName);
+      let rulesByProfile = this._tempProfileRulesByProfile[key];
+      if (rulesByProfile == null) {
+        rulesByProfile = [];
+        this._tempProfileRulesByProfile[key] = rulesByProfile;
+      }
+      if (!rulesByProfile.includes(rule)) rulesByProfile.push(rule);
     }
-    rulesByProfile.push(rule);
 
     if (changed) {
       Profiles.updateRevision(tempProfile);
@@ -1246,8 +1271,16 @@ export class Options {
     if (this._options['-revertProxyChanges'] && !this._isSystem) {
       if (profile.name !== this._currentProfileName && this._currentProfileName) {
         if (!args?.noRevert) {
-          void this.applyProfile(this._revertToProfileName);
+          // FIX: on the first external change nothing has been remembered yet,
+          // so this passed null and rejected with ProfileNotExistError — which
+          // nothing awaited, so the revert silently never happened. Fall back
+          // to the profile currently applied, which is what we are reverting
+          // to by definition.
+          const revertTo = this._revertToProfileName ?? this._currentProfileName;
           this._revertToProfileName = null;
+          this.applyProfile(revertTo).catch((err: unknown) => {
+            this.log.error('Options#setExternalProfile::revert', err);
+          });
           return;
         }
         this._revertToProfileName ??= this._currentProfileName;

--- a/packages/target/src/storage.ts
+++ b/packages/target/src/storage.ts
@@ -1,0 +1,152 @@
+/** Abstract asynchronous key-value storage. */
+
+import { Log } from './log.js';
+
+/** Operations that failed because a write rate limit was hit. */
+export class RateLimitExceededError extends Error {
+  override readonly name: string = 'RateLimitExceededError';
+  perHour?: boolean;
+  perMinute?: boolean;
+  sustained?: boolean;
+}
+
+/** Operations that failed because a storage quota was exhausted. */
+export class QuotaExceededError extends Error {
+  override readonly name: string = 'QuotaExceededError';
+  perItem?: boolean;
+  maxItems?: boolean;
+}
+
+/**
+ * The storage cannot be used at all. This is fatal and unrecoverable for the
+ * lifetime of the process; callers should stop touching this storage.
+ */
+export class StorageUnavailableError extends Error {
+  override readonly name: string = 'StorageUnavailableError';
+}
+
+export type StorageItems = Record<string, unknown>;
+
+/** A set of writes to perform against a storage. */
+export interface WriteOperations {
+  set: StorageItems;
+  remove: string[];
+}
+
+export interface ChangeOperations {
+  changes: StorageItems;
+  base?: StorageItems | undefined;
+  merge?: MergeFn | undefined;
+}
+
+export type MergeFn = (key: string, newVal: unknown, oldVal: unknown) => unknown;
+
+export type WatchCallback = (changes: StorageItems) => void;
+
+export type Unwatch = () => void;
+
+export class Storage {
+  static readonly RateLimitExceededError = RateLimitExceededError;
+  static readonly QuotaExceededError = QuotaExceededError;
+  static readonly StorageUnavailableError = StorageUnavailableError;
+
+  protected _items: StorageItems | undefined;
+
+  /**
+   * Reduce a set of desired changes to the writes actually needed.
+   *
+   * When `base` is given, values equal to what is already stored are dropped.
+   * `merge` may substitute a different value, which is how sync conflict
+   * resolution hooks in.
+   */
+  static operationsForChanges(
+    changes: StorageItems,
+    { base, merge }: { base?: StorageItems | undefined; merge?: MergeFn | undefined } = {},
+  ): WriteOperations {
+    const set: StorageItems = {};
+    const remove: string[] = [];
+
+    for (const key of Object.keys(changes)) {
+      let newVal = changes[key];
+      const oldVal = base != null ? base[key] : newVal;
+      if (merge) {
+        newVal = merge(key, newVal, oldVal);
+      }
+      if (base != null && newVal === oldVal) continue;
+      if (typeof newVal === 'undefined') {
+        if (typeof oldVal !== 'undefined' || base == null) {
+          remove.push(key);
+        }
+      } else {
+        set[key] = newVal;
+      }
+    }
+
+    return { set, remove };
+  }
+
+  /** Read values by key, or everything when `keys` is null. */
+  async get(keys?: string | string[] | null | StorageItems): Promise<StorageItems> {
+    Log.method('Storage#get', this, arguments);
+    if (!this._items) return {};
+
+    const items = this._items;
+    const map: StorageItems = {};
+    const source = keys ?? items;
+
+    if (typeof source === 'string') {
+      map[source] = items[source];
+    } else if (Array.isArray(source)) {
+      for (const key of source) map[key] = items[key];
+    } else if (typeof source === 'object') {
+      for (const [key, fallback] of Object.entries(source)) {
+        map[key] = items[key] ?? fallback;
+      }
+    }
+    return map;
+  }
+
+  /** Write multiple values, returning the items just written. */
+  async set(items: StorageItems): Promise<StorageItems> {
+    Log.method('Storage#set', this, arguments);
+    this._items ??= {};
+    for (const [key, value] of Object.entries(items)) {
+      this._items[key] = value;
+    }
+    return items;
+  }
+
+  /** Remove values by key, or everything when `keys` is null. */
+  async remove(keys?: string | string[] | null): Promise<void> {
+    Log.method('Storage#remove', this, arguments);
+    if (!this._items) return;
+    if (keys == null) {
+      this._items = {};
+    } else if (Array.isArray(keys)) {
+      for (const key of keys) delete this._items[key];
+    } else {
+      delete this._items[keys];
+    }
+  }
+
+  /** Observe changes. The returned function stops watching. */
+  watch(keys: string | string[] | null, callback: WatchCallback): Unwatch {
+    Log.method('Storage#watch', this, arguments);
+    void keys;
+    void callback;
+    return () => undefined;
+  }
+
+  /** Apply writes, or a set of changes to be reduced to writes first. */
+  async apply(operations: WriteOperations | ChangeOperations): Promise<WriteOperations> {
+    const resolved: WriteOperations =
+      'changes' in operations
+        ? Storage.operationsForChanges(operations.changes, operations)
+        : operations;
+    await this.set(resolved.set);
+    await this.remove(resolved.remove);
+    return resolved;
+  }
+}
+
+export default Storage;

--- a/packages/target/src/token-bucket.ts
+++ b/packages/target/src/token-bucket.ts
@@ -1,0 +1,86 @@
+/**
+ * A minimal token bucket, replacing the `limiter` npm package.
+ *
+ * Refills are lazy: no timer runs in the background, tokens are credited from
+ * the elapsed wall clock the moment someone asks for them. That matters in a
+ * service worker, where a periodic timer would keep the worker alive (or be
+ * killed and silently stop refilling).
+ */
+
+export type TokenBucketInterval = 'second' | 'minute' | 'hour' | 'day' | number;
+
+const INTERVAL_MS: Record<string, number> = {
+  second: 1000,
+  minute: 60_000,
+  hour: 3_600_000,
+  day: 86_400_000,
+};
+
+export class TokenBucket {
+  readonly bucketSize: number;
+  readonly tokensPerInterval: number;
+  /** Length of one refill interval, in milliseconds. */
+  readonly interval: number;
+  /** Tokens currently available. Fractional between drips. */
+  content: number;
+  private lastDrip: number;
+
+  constructor(
+    bucketSize: number,
+    tokensPerInterval: number,
+    interval: TokenBucketInterval = 'second',
+    _parent: unknown = null,
+  ) {
+    this.bucketSize = bucketSize;
+    this.tokensPerInterval = tokensPerInterval;
+    const ms = typeof interval === 'number' ? interval : INTERVAL_MS[interval];
+    if (!ms || ms < 0) throw new Error(`Invalid interval ${String(interval)}`);
+    this.interval = ms;
+    // Start full. `limiter` started empty, which under MV2 cost one refill wait
+    // per browser session; under MV3 the worker is recycled constantly, so that
+    // would delay the first write after every wake-up for no benefit.
+    this.content = bucketSize;
+    this.lastDrip = Date.now();
+  }
+
+  /** Credit the tokens accrued since the last drip, capped at bucketSize. */
+  private drip(): void {
+    if (!this.tokensPerInterval) {
+      this.content = this.bucketSize;
+      return;
+    }
+    const now = Date.now();
+    const elapsed = Math.max(now - this.lastDrip, 0);
+    this.lastDrip = now;
+    const dripped = elapsed * (this.tokensPerInterval / this.interval);
+    this.content = Math.min(this.content + dripped, this.bucketSize);
+  }
+
+  /** Take `count` tokens if that many are available right now. */
+  tryRemoveTokens(count: number): boolean {
+    if (count > this.bucketSize) return false;
+    this.drip();
+    if (count > this.content) return false;
+    this.content -= count;
+    return true;
+  }
+
+  /** Take `count` tokens, waiting for them to accrue when the bucket is short. */
+  async removeTokens(count: number): Promise<void> {
+    if (count > this.bucketSize) {
+      throw new Error(`Requested tokens ${count} exceeds bucket size ${this.bucketSize}`);
+    }
+    while (!this.tryRemoveTokens(count)) {
+      const wait = Math.ceil((count - this.content) * (this.interval / this.tokensPerInterval));
+      await new Promise<void>((resolve) => setTimeout(resolve, wait));
+    }
+  }
+
+  /** Drop every token, forcing a full wait before the next removal succeeds. */
+  clear(): void {
+    this.drip();
+    this.content = 0;
+  }
+}
+
+export default TokenBucket;

--- a/packages/target/tsconfig.json
+++ b/packages/target/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": ["src/**/*.ts"],
+  "references": [{ "path": "../pac" }]
+}

--- a/packages/ui/options.html
+++ b/packages/ui/options.html
@@ -35,6 +35,9 @@
           <span data-i18n="options_discard">Discard</span>
         </button>
         <span id="om-status" class="om-status" role="status"></span>
+        <button type="button" id="om-open-tab" class="om-btn" data-i18n="options_openInTab">
+          Open in tab
+        </button>
       </header>
 
       <section id="om-view" class="om-view"></section>

--- a/packages/ui/options.html
+++ b/packages/ui/options.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title data-i18n="options_title">SwitchyDelta Options</title>
+    <link rel="stylesheet" href="./src/options/options.css" />
+  </head>
+  <body class="om-options">
+    <aside class="om-sidebar">
+      <h1 class="om-brand" data-i18n="appNameShort">SwitchyDelta</h1>
+
+      <nav aria-label="Sections">
+        <p class="om-group-label" data-i18n="options_group_setting">Settings</p>
+        <ul class="om-list" id="om-nav-settings">
+          <li><a class="om-item" href="#/ui" data-i18n="options_navInterface">Interface</a></li>
+          <li><a class="om-item" href="#/general" data-i18n="options_navGeneral">General</a></li>
+          <li><a class="om-item" href="#/io" data-i18n="options_navImportExport">Import / Export</a></li>
+        </ul>
+
+        <p class="om-group-label" data-i18n="options_group_profiles">Profiles</p>
+        <ul class="om-list" id="om-nav-profiles"></ul>
+
+        <ul class="om-list">
+          <li><a class="om-item" href="#/about" data-i18n="options_navAbout">About</a></li>
+        </ul>
+      </nav>
+    </aside>
+
+    <main class="om-main">
+      <header class="om-toolbar">
+        <button type="button" id="om-apply" class="om-btn om-btn-primary" disabled>
+          <span data-i18n="options_apply">Apply changes</span>
+        </button>
+        <button type="button" id="om-revert" class="om-btn" disabled>
+          <span data-i18n="options_discard">Discard</span>
+        </button>
+        <span id="om-status" class="om-status" role="status"></span>
+      </header>
+
+      <section id="om-view" class="om-view"></section>
+    </main>
+
+    <script type="module" src="./src/options/main.ts"></script>
+  </body>
+</html>

--- a/packages/ui/options.html
+++ b/packages/ui/options.html
@@ -10,19 +10,16 @@
       <h1 class="om-brand" data-i18n="appNameShort">SwitchyDelta</h1>
 
       <nav aria-label="Sections">
-        <p class="om-group-label" data-i18n="options_group_setting">Settings</p>
+        <p class="om-group-label" data-i18n="options_navHeader_setting">Settings</p>
         <ul class="om-list" id="om-nav-settings">
-          <li><a class="om-item" href="#/ui" data-i18n="options_navInterface">Interface</a></li>
-          <li><a class="om-item" href="#/general" data-i18n="options_navGeneral">General</a></li>
-          <li><a class="om-item" href="#/io" data-i18n="options_navImportExport">Import / Export</a></li>
+          <li><a class="om-item" href="#/ui" data-i18n="options_tab_ui">Interface</a></li>
+          <li><a class="om-item" href="#/general" data-i18n="options_tab_general">General</a></li>
+          <li><a class="om-item" href="#/io" data-i18n="options_tab_importExport">Import / Export</a></li>
+          <li><a class="om-item" href="#/about" data-i18n="about_title">About</a></li>
         </ul>
 
-        <p class="om-group-label" data-i18n="options_group_profiles">Profiles</p>
+        <p class="om-group-label" data-i18n="options_navHeader_profiles">Profiles</p>
         <ul class="om-list" id="om-nav-profiles"></ul>
-
-        <ul class="om-list">
-          <li><a class="om-item" href="#/about" data-i18n="options_navAbout">About</a></li>
-        </ul>
       </nav>
     </aside>
 
@@ -35,9 +32,8 @@
           <span data-i18n="options_discard">Discard</span>
         </button>
         <span id="om-status" class="om-status" role="status"></span>
-        <button type="button" id="om-open-tab" class="om-btn" data-i18n="options_openInTab">
-          Open in tab
-        </button>
+        <!-- No catalogue string exists for this (side-panel-only feature). -->
+        <button type="button" id="om-open-tab" class="om-btn">Open in tab</button>
       </header>
 
       <section id="om-view" class="om-view"></section>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@switchydelta/ui",
+  "version": "3.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Options and popup UI for SwitchyDelta",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@switchydelta/pac": "*"
+  },
+  "devDependencies": {
+    "vite": "^5.4.2"
+  }
+}

--- a/packages/ui/popup.html
+++ b/packages/ui/popup.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title data-i18n="appNameShort">SwitchyDelta</title>
+    <link rel="stylesheet" href="./src/popup/popup.css" />
+  </head>
+  <body class="om-popup">
+    <div id="om-not-controllable" class="om-notice" hidden>
+      <p class="om-notice-title" id="om-not-controllable-title"></p>
+      <p class="om-notice-detail" id="om-not-controllable-detail"></p>
+    </div>
+
+    <nav id="om-root" aria-label="Profiles">
+      <ul id="om-profiles" class="om-list"></ul>
+
+      <hr class="om-sep" />
+
+      <ul class="om-list om-actions">
+        <li>
+          <button type="button" class="om-item" id="om-add-rule" hidden>
+            <span class="om-icon" aria-hidden="true">+</span>
+            <span data-i18n="popup_addCondition">Add condition</span>
+          </button>
+        </li>
+        <li>
+          <button type="button" class="om-item" id="om-options">
+            <span class="om-icon" aria-hidden="true">⚙</span>
+            <span data-i18n="popup_options">Options</span>
+          </button>
+        </li>
+      </ul>
+    </nav>
+
+    <p id="om-error" class="om-error" hidden></p>
+
+    <script type="module" src="./src/popup/main.ts"></script>
+  </body>
+</html>

--- a/packages/ui/popup.html
+++ b/packages/ui/popup.html
@@ -26,7 +26,7 @@
         <li>
           <button type="button" class="om-item" id="om-options">
             <span class="om-icon" aria-hidden="true">⚙</span>
-            <span data-i18n="popup_options">Options</span>
+            <span data-i18n="popup_showOptions">Options</span>
           </button>
         </li>
       </ul>

--- a/packages/ui/src/lib/dom.ts
+++ b/packages/ui/src/lib/dom.ts
@@ -14,7 +14,10 @@ type Attrs<K extends keyof HTMLElementTagNameMap> = {
   html?: string;
   dataset?: Record<string, string>;
   style?: Partial<CSSStyleDeclaration>;
-} & Partial<Omit<HTMLElementTagNameMap[K], 'style' | 'dataset' | 'children'>>;
+} & Partial<Omit<HTMLElementTagNameMap[K], 'style' | 'dataset' | 'children'>> & {
+    // Hyphenated names are attributes, not properties; see the note in h().
+    [key: `aria-${string}`]: string | undefined;
+  } & { role?: string };
 
 /**
  * Create an element.
@@ -50,6 +53,11 @@ export function h<K extends keyof HTMLElementTagNameMap>(
       default:
         if (key.startsWith('on') && typeof value === 'function') {
           el.addEventListener(key.slice(2).toLowerCase(), value as EventListener);
+        } else if (key.includes('-')) {
+          // aria-* / data-* have no matching IDL property, so assigning them
+          // would silently create a plain JS property and the attribute
+          // selectors that style them would never match.
+          el.setAttribute(key, String(value));
         } else {
           (el as unknown as Record<string, unknown>)[key] = value;
         }

--- a/packages/ui/src/lib/dom.ts
+++ b/packages/ui/src/lib/dom.ts
@@ -1,0 +1,122 @@
+/**
+ * Minimal typed DOM helpers.
+ *
+ * The previous UI carried AngularJS, jQuery, jQuery UI and Bootstrap's JS to
+ * do what amounts to element creation, event binding and list rendering. These
+ * few functions cover the same ground with no runtime dependency.
+ */
+
+type Child = Node | string | number | false | null | undefined;
+
+type Attrs<K extends keyof HTMLElementTagNameMap> = {
+  class?: string;
+  text?: string;
+  html?: string;
+  dataset?: Record<string, string>;
+  style?: Partial<CSSStyleDeclaration>;
+} & Partial<Omit<HTMLElementTagNameMap[K], 'style' | 'dataset' | 'children'>>;
+
+/**
+ * Create an element.
+ *
+ * Falsy children are skipped so `cond && h(...)` reads naturally.
+ */
+export function h<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  attrs: Attrs<K> = {},
+  ...children: Child[]
+): HTMLElementTagNameMap[K] {
+  const el = document.createElement(tag);
+
+  for (const [key, value] of Object.entries(attrs)) {
+    if (value === undefined || value === null) continue;
+    switch (key) {
+      case 'class':
+        el.className = value as string;
+        break;
+      case 'text':
+        el.textContent = String(value);
+        break;
+      case 'html':
+        // Only ever used with trusted translated markup.
+        el.innerHTML = value as string;
+        break;
+      case 'dataset':
+        Object.assign(el.dataset, value);
+        break;
+      case 'style':
+        Object.assign(el.style, value);
+        break;
+      default:
+        if (key.startsWith('on') && typeof value === 'function') {
+          el.addEventListener(key.slice(2).toLowerCase(), value as EventListener);
+        } else {
+          (el as unknown as Record<string, unknown>)[key] = value;
+        }
+    }
+  }
+
+  append(el, children);
+  return el;
+}
+
+export function append(parent: Node, children: Child[]): void {
+  for (const child of children) {
+    if (child === null || child === undefined || child === false) continue;
+    parent.appendChild(typeof child === 'object' ? child : document.createTextNode(String(child)));
+  }
+}
+
+/** Query a single element, throwing when it is missing rather than returning null. */
+export function must<E extends Element = HTMLElement>(
+  selector: string,
+  root: ParentNode = document,
+): E {
+  const el = root.querySelector<E>(selector);
+  if (!el) throw new Error(`Element not found: ${selector}`);
+  return el;
+}
+
+export function all<E extends Element = HTMLElement>(
+  selector: string,
+  root: ParentNode = document,
+): E[] {
+  return Array.from(root.querySelectorAll<E>(selector));
+}
+
+/** Replace an element's children in one operation. */
+export function render(parent: Element, children: Child[]): void {
+  parent.replaceChildren();
+  append(parent, children);
+}
+
+/**
+ * Delegated event binding.
+ *
+ * Lets list containers be rendered wholesale without rebinding handlers per
+ * row.
+ */
+export function on<K extends keyof HTMLElementEventMap>(
+  root: Element | Document,
+  type: K,
+  selector: string,
+  handler: (event: HTMLElementEventMap[K], target: HTMLElement) => void,
+): void {
+  root.addEventListener(type, (event) => {
+    const target = (event.target as Element | null)?.closest<HTMLElement>(selector);
+    if (target && root.contains(target)) {
+      handler(event as HTMLElementEventMap[K], target);
+    }
+  });
+}
+
+/** Trigger a file download from in-memory content. */
+export function downloadFile(filename: string, content: BlobPart, type = 'text/plain'): void {
+  const url = URL.createObjectURL(new Blob([content], { type }));
+  const link = h('a', { href: url, download: filename });
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  // Revoking immediately can cancel the download in some browsers.
+  setTimeout(() => URL.revokeObjectURL(url), 10_000);
+}

--- a/packages/ui/src/lib/equal.ts
+++ b/packages/ui/src/lib/equal.ts
@@ -1,0 +1,27 @@
+/**
+ * Structural equality.
+ *
+ * Key order must not matter, which rules out comparing JSON strings — the
+ * options bag is rebuilt from storage on every load and key order is not
+ * stable.
+ */
+export function deepEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (typeof a !== typeof b) return false;
+  if (a === null || b === null || typeof a !== 'object') return false;
+
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
+    return a.every((item, i) => deepEqual(item, b[i]));
+  }
+
+  const objA = a as Record<string, unknown>;
+  const objB = b as Record<string, unknown>;
+  const keysA = Object.keys(objA);
+  const keysB = Object.keys(objB);
+  if (keysA.length !== keysB.length) return false;
+
+  return keysA.every(
+    (key) => Object.prototype.hasOwnProperty.call(objB, key) && deepEqual(objA[key], objB[key]),
+  );
+}

--- a/packages/ui/src/lib/i18n.ts
+++ b/packages/ui/src/lib/i18n.ts
@@ -1,0 +1,43 @@
+/**
+ * Message lookup.
+ *
+ * Translations stay in the existing gettext catalogues under `omega-locales`,
+ * compiled to `_locales/<lang>/messages.json` at build time, so `chrome.i18n`
+ * remains the source of truth and no translation work is lost.
+ */
+
+/** Look up a message, falling back to the key so missing strings are visible. */
+export function t(key: string, substitutions?: string | string[]): string {
+  const message = chrome.i18n.getMessage(key, substitutions);
+  return message || key;
+}
+
+/**
+ * The display name of a profile.
+ *
+ * Only the built-in profiles are translated (`profile_direct`,
+ * `profile_system`); user-created profiles show their literal name.
+ */
+export function profileDisplayName(name: string): string {
+  return chrome.i18n.getMessage('profile_' + name) || name;
+}
+
+/**
+ * Replace `data-i18n` placeholders in static markup.
+ *
+ * `data-i18n="key"` sets text content; `data-i18n-attr="title:key"` sets an
+ * attribute. Running this once on load keeps the HTML free of English strings
+ * without a template runtime.
+ */
+export function localizeDocument(root: ParentNode = document): void {
+  for (const el of root.querySelectorAll<HTMLElement>('[data-i18n]')) {
+    const key = el.dataset['i18n'];
+    if (key) el.textContent = t(key);
+  }
+  for (const el of root.querySelectorAll<HTMLElement>('[data-i18n-attr]')) {
+    for (const pair of (el.dataset['i18nAttr'] ?? '').split(',')) {
+      const [attr, key] = pair.split(':');
+      if (attr && key) el.setAttribute(attr.trim(), t(key.trim()));
+    }
+  }
+}

--- a/packages/ui/src/lib/messaging.ts
+++ b/packages/ui/src/lib/messaging.ts
@@ -1,0 +1,182 @@
+/**
+ * Typed RPC client for talking to the MV3 service worker.
+ *
+ * Replaces the AngularJS `omegaTarget` factory and the parallel plain-JS
+ * `OmegaTargetPopup` shim with one implementation shared by both pages.
+ *
+ * The wire format is fixed by the background dispatcher: a request is
+ * `{method, args}` and the reply is `{result}` or `{error}`. Errors cannot
+ * cross `chrome.runtime.sendMessage` intact, so they travel as plain objects
+ * and are rebuilt here.
+ */
+
+import type { OptionsBag, Profile } from '@switchydelta/pac';
+
+/** An Error flattened for structured cloning across the message channel. */
+interface EncodedError {
+  _error: 'error';
+  name?: string;
+  message?: string;
+  stack?: string;
+  original?: unknown;
+}
+
+function isEncodedError(value: unknown): value is EncodedError {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as { _error?: unknown })._error === 'error'
+  );
+}
+
+/** Rebuild a real Error from the background's flattened representation. */
+export function decodeError(value: unknown): unknown {
+  if (!isEncodedError(value)) return value;
+  const err = new Error(value.message ?? 'Unknown error');
+  if (value.name) err.name = value.name;
+  if (value.stack) err.stack = value.stack;
+  if (value.original !== undefined) {
+    (err as Error & { original?: unknown }).original = value.original;
+  }
+  return err;
+}
+
+interface BackgroundResponse<T> {
+  result?: T;
+  error?: unknown;
+}
+
+/** Invoke a method on the background page and await its result. */
+export async function callBackground<T = unknown>(
+  method: string,
+  ...args: unknown[]
+): Promise<T> {
+  const response = (await chrome.runtime.sendMessage({
+    method,
+    args,
+  })) as BackgroundResponse<T> | undefined;
+
+  if (response?.error !== undefined) {
+    throw decodeError(response.error);
+  }
+  return response?.result as T;
+}
+
+/**
+ * Invoke a method without waiting for a reply.
+ *
+ * Used where the page is about to close and awaiting the round trip would
+ * lose the call.
+ */
+export function callBackgroundNoReply(method: string, ...args: unknown[]): void {
+  void chrome.runtime.sendMessage({ method, args, noReply: true });
+}
+
+// --- State ------------------------------------------------------------------
+
+export type StateValues = Record<string, unknown>;
+
+/** Read one or more ephemeral state keys from the service worker. */
+export async function getState(keys: string | string[] | StateValues): Promise<StateValues> {
+  return callBackground<StateValues>('getState', keys);
+}
+
+export async function setState(values: StateValues): Promise<void> {
+  await callBackground('setState', values);
+}
+
+/**
+ * Page-local memory, deliberately NOT shared with the service worker.
+ *
+ * The options page uses this to reopen on the screen you left; it is a
+ * property of this tab, not of the extension.
+ */
+export const localState = {
+  get(key: string): string | null {
+    return localStorage.getItem('omega.local.' + key);
+  },
+  set(key: string, value: string): void {
+    localStorage.setItem('omega.local.' + key, value);
+  },
+};
+
+// --- Options ----------------------------------------------------------------
+
+export interface PageInfo {
+  url: string;
+  domain: string;
+  tempRuleProfileName?: string;
+}
+
+export const api = {
+  getAll: () => callBackground<OptionsBag>('getAll'),
+  patch: (delta: unknown) => callBackground<OptionsBag>('patch', delta),
+  reset: (options: unknown) => callBackground<OptionsBag>('reset', options),
+
+  applyProfile: (name: string) => callBackground('applyProfile', name),
+  applyProfileNoReply: (name: string) => callBackgroundNoReply('applyProfile', name),
+
+  addProfile: (profile: Profile) => callBackground<Profile>('addProfile', profile),
+  renameProfile: (from: string, to: string) => callBackground('renameProfile', from, to),
+  replaceRef: (from: string, to: string) => callBackground('replaceRef', from, to),
+  setDefaultProfile: (profileName: string, defaultProfileName: string) =>
+    callBackground('setDefaultProfile', profileName, defaultProfileName),
+
+  addTempRule: (domain: string, profileName: string) =>
+    callBackground('addTempRule', domain, profileName),
+  addCondition: (condition: unknown, profileName: string) =>
+    callBackground('addCondition', condition, profileName),
+
+  updateProfile: (name?: string, bypassCache?: boolean) =>
+    callBackground<Record<string, unknown>>('updateProfile', name, bypassCache),
+
+  getPageInfo: (info: { tabId?: number; url?: string }) =>
+    callBackground<PageInfo | null>('getPageInfo', info),
+
+  setOptionsSync: (enabled: boolean, args?: { force?: boolean }) =>
+    callBackground('setOptionsSync', enabled, args),
+  resetOptionsSync: () => callBackground('resetOptionsSync'),
+};
+
+// --- Tabs -------------------------------------------------------------------
+
+const INTERNAL_URL = /^(chrome|about|moz-|edge|chrome-extension):/;
+
+export function isInternalUrl(url: string | undefined): boolean {
+  return !!url && INTERNAL_URL.test(url);
+}
+
+/** The active tab, or undefined when it is a page we cannot act on. */
+export async function getActiveTab(): Promise<chrome.tabs.Tab | undefined> {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  return tab;
+}
+
+export async function refreshActivePage(): Promise<void> {
+  const tab = await getActiveTab();
+  if (!tab?.id || isInternalUrl(tab.url)) return;
+  await chrome.tabs.reload(tab.id, { bypassCache: true });
+}
+
+/** Focus the existing options tab if there is one, otherwise open it. */
+export async function openOptions(hash = ''): Promise<void> {
+  const url = chrome.runtime.getURL('options.html');
+  const tabs = await chrome.tabs.query({ url });
+  const existing = tabs[0];
+  if (existing?.id) {
+    await chrome.tabs.update(existing.id, { active: true, url: url + hash });
+    if (existing.windowId !== undefined) {
+      await chrome.windows.update(existing.windowId, { focused: true });
+    }
+    return;
+  }
+  await chrome.tabs.create({ url: url + hash });
+}
+
+export function openManage(): void {
+  void chrome.tabs.create({ url: `chrome://extensions/?id=${chrome.runtime.id}` });
+}
+
+export function openShortcutConfig(): void {
+  void chrome.tabs.create({ url: 'chrome://extensions/configureCommands' });
+}

--- a/packages/ui/src/lib/messaging.ts
+++ b/packages/ui/src/lib/messaging.ts
@@ -158,6 +158,24 @@ export async function refreshActivePage(): Promise<void> {
   await chrome.tabs.reload(tab.id, { bypassCache: true });
 }
 
+/**
+ * Show the settings in Chrome's side panel.
+ *
+ * Must be called synchronously from a user gesture — the API rejects
+ * otherwise, and awaiting anything first loses the gesture. Returns false when
+ * the panel is unavailable so the caller can fall back to a tab.
+ */
+export function openSidePanel(): boolean {
+  if (!chrome.sidePanel?.open) return false;
+  try {
+    // windowId is resolved by Chrome from the calling context.
+    void chrome.sidePanel.open({ windowId: chrome.windows.WINDOW_ID_CURRENT });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /** Focus the existing options tab if there is one, otherwise open it. */
 export async function openOptions(hash = ''): Promise<void> {
   const url = chrome.runtime.getURL('options.html');

--- a/packages/ui/src/lib/profile-view.ts
+++ b/packages/ui/src/lib/profile-view.ts
@@ -1,0 +1,132 @@
+/**
+ * Presentation rules for profiles.
+ *
+ * The CoffeeScript UI defined all of this twice — once in the AngularJS
+ * `omegaDecoration` module for the options page and again as plain objects in
+ * the popup's `profiles.js`. The two copies had already drifted. This is the
+ * single definition.
+ */
+
+import { Profiles, type OptionsBag, type Profile } from '@switchydelta/pac';
+
+/** Palette offered by the profile colour picker. */
+export const profileColors: readonly string[] = [
+  '#99ccee',
+  '#ffcc00',
+  '#cc99cc',
+  '#77dd77',
+  '#ff9966',
+  '#dd7788',
+  '#99cc99',
+  '#cccccc',
+  '#66bbdd',
+];
+
+/** Icon name per profile type. */
+export const profileIcons: Readonly<Record<string, string>> = {
+  DirectProfile: 'transfer',
+  SystemProfile: 'off',
+  FixedProfile: 'globe',
+  PacProfile: 'file',
+  VirtualProfile: 'question-sign',
+  SwitchProfile: 'retweet',
+  RuleListProfile: 'list',
+  SwitchyRuleListProfile: 'list',
+  AutoProxyRuleListProfile: 'list',
+};
+
+/** Sort weight per profile type; lower sorts first. */
+const typeOrder: Readonly<Record<string, number>> = {
+  FixedProfile: 1,
+  PacProfile: 2,
+  VirtualProfile: 3,
+  SwitchProfile: 4,
+  RuleListProfile: 5,
+  SwitchyRuleListProfile: 5,
+  AutoProxyRuleListProfile: 5,
+};
+
+/** A rule list profile implicitly attached to a switch profile. */
+export function getAttachedName(name: string): string {
+  return '__ruleListOf_' + name;
+}
+
+export function getParentName(name: string): string | undefined {
+  return name.startsWith('__ruleListOf_') ? name.substring('__ruleListOf_'.length) : undefined;
+}
+
+/** Hidden profiles are not offered in pickers. */
+export function isProfileNameHidden(name: string): boolean {
+  return name.startsWith('_');
+}
+
+/** Reserved profiles are internal machinery, never user-visible. */
+export function isProfileNameReserved(name: string): boolean {
+  return name.startsWith('__');
+}
+
+/**
+ * Follow a virtual profile to the profile it currently resolves to.
+ *
+ * Virtual profiles are indirection: they display the icon and colour of their
+ * target so the UI shows where traffic actually goes.
+ */
+export function getVirtualTarget(profile: Profile, options: OptionsBag): Profile {
+  let current = profile;
+  const seen = new Set<string>();
+  while (current.profileType === 'VirtualProfile') {
+    if (seen.has(current.name)) break; // defensive: options can contain cycles
+    seen.add(current.name);
+    const next = Profiles.byName(
+      (current as Profile & { defaultProfileName: string }).defaultProfileName,
+      options,
+    );
+    if (!next) break;
+    current = next;
+  }
+  return current;
+}
+
+export function iconFor(profile: Profile, options: OptionsBag): string {
+  const target = getVirtualTarget(profile, options);
+  return profileIcons[target.profileType] ?? 'question-sign';
+}
+
+export function colorFor(profile: Profile, options: OptionsBag): string {
+  const target = getVirtualTarget(profile, options);
+  return target.color ?? profile.color ?? '#cccccc';
+}
+
+/** Order profiles by type then name, the way both old UIs did. */
+export function compareProfiles(a: Profile, b: Profile): number {
+  const orderA = typeOrder[a.profileType] ?? 99;
+  const orderB = typeOrder[b.profileType] ?? 99;
+  if (orderA !== orderB) return orderA - orderB;
+  return a.name.localeCompare(b.name);
+}
+
+/**
+ * The profiles a picker should offer.
+ *
+ * `resultFor` narrows the list to profiles that the named profile may target
+ * without creating a reference cycle.
+ */
+export function listProfiles(
+  options: OptionsBag,
+  { includeBuiltin = false, resultFor }: { includeBuiltin?: boolean; resultFor?: string } = {},
+): Profile[] {
+  if (resultFor) {
+    return Profiles.validResultProfilesFor(resultFor, options)
+      .filter((p) => !isProfileNameHidden(p.name))
+      .sort(compareProfiles);
+  }
+
+  const result: Profile[] = [];
+  Profiles.each(options, (_key, profile) => {
+    if (isProfileNameReserved(profile.name)) return;
+    if (!includeBuiltin && profile.builtin) return;
+    if (!includeBuiltin && isProfileNameHidden(profile.name)) return;
+    result.push(profile);
+  });
+  return result.sort(compareProfiles);
+}

--- a/packages/ui/src/options/main.ts
+++ b/packages/ui/src/options/main.ts
@@ -1,0 +1,160 @@
+/**
+ * Options page shell: routing, the working copy of options, and saving.
+ *
+ * The AngularJS version deep-diffed the whole options object with jsondiffpatch
+ * and sent the resulting delta to the background, which immediately reduced it
+ * back to a map of changed top-level keys. Options is a flat bag at the top
+ * level, so this compares top-level keys directly and sends that map — same
+ * result, no diff library in the bundle.
+ */
+
+import { must, on, render } from '../lib/dom.js';
+import { localizeDocument, profileDisplayName, t } from '../lib/i18n.js';
+import { api, callBackground, localState } from '../lib/messaging.js';
+import { colorFor, listProfiles } from '../lib/profile-view.js';
+import { deepEqual } from '../lib/equal.js';
+import { renderAbout, renderGeneral, renderIo, renderProfile, renderUi } from './views.js';
+import type { OptionsBag } from '@switchydelta/pac';
+
+/** The saved state, used to decide what actually changed. */
+let pristine: OptionsBag = {};
+/** The live, edited copy bound to the form controls. */
+export let options: OptionsBag = {};
+
+export function markDirty(): void {
+  const dirty = changedKeys().length > 0;
+  must<HTMLButtonElement>('#om-apply').disabled = !dirty;
+  must<HTMLButtonElement>('#om-revert').disabled = !dirty;
+  must('#om-status').textContent = dirty ? t('options_unsavedChanges') : '';
+}
+
+function changedKeys(): string[] {
+  const keys = new Set([...Object.keys(pristine), ...Object.keys(options)]);
+  return [...keys].filter((key) => !deepEqual(pristine[key], options[key]));
+}
+
+async function applyChanges(): Promise<void> {
+  const changes: Record<string, unknown> = {};
+  for (const key of changedKeys()) {
+    changes[key] = options[key];
+  }
+  if (Object.keys(changes).length === 0) return;
+
+  must('#om-status').textContent = t('options_saving');
+  try {
+    // `undefined` marks a removed key, matching the storage layer's convention.
+    await callBackground('applyChanges', changes);
+    pristine = structuredClone(options);
+    markDirty();
+    must('#om-status').textContent = t('options_saved');
+  } catch (err) {
+    must('#om-status').textContent = err instanceof Error ? err.message : String(err);
+  }
+}
+
+// --- Routing ----------------------------------------------------------------
+
+type View = (container: HTMLElement, param: string) => void;
+
+const routes: Array<[RegExp, View]> = [
+  [/^#\/ui$/, renderUi],
+  [/^#\/general$/, renderGeneral],
+  [/^#\/io$/, renderIo],
+  [/^#\/about$/, renderAbout],
+  [/^#\/profile\/(.*)$/, renderProfile],
+];
+
+function route(): void {
+  const hash = location.hash || '#/about';
+  const container = must('#om-view');
+
+  for (const [pattern, view] of routes) {
+    const match = pattern.exec(hash);
+    if (match) {
+      container.replaceChildren();
+      view(container, decodeURIComponent(match[1] ?? ''));
+      localizeDocument(container);
+      highlightNav(hash);
+      localState.set('lastUrl', hash);
+      return;
+    }
+  }
+
+  location.hash = '#/about';
+}
+
+function highlightNav(hash: string): void {
+  for (const link of document.querySelectorAll<HTMLAnchorElement>('.om-sidebar .om-item')) {
+    link.setAttribute('aria-current', link.getAttribute('href') === hash ? 'page' : 'false');
+  }
+}
+
+function renderProfileNav(): void {
+  const nav = must('#om-nav-profiles');
+  render(
+    nav,
+    listProfiles(options).map((profile) => {
+      const link = document.createElement('a');
+      link.className = 'om-item';
+      link.href = '#/profile/' + encodeURIComponent(profile.name);
+
+      const swatch = document.createElement('span');
+      swatch.className = 'om-swatch';
+      swatch.style.background = colorFor(profile, options);
+
+      const label = document.createElement('span');
+      label.textContent = profileDisplayName(profile.name);
+
+      link.append(swatch, label);
+      const li = document.createElement('li');
+      li.append(link);
+      return li;
+    }),
+  );
+}
+
+// --- Boot -------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  localizeDocument();
+
+  try {
+    pristine = await api.getAll();
+  } catch (err) {
+    must('#om-view').textContent = err instanceof Error ? err.message : String(err);
+    return;
+  }
+  options = structuredClone(pristine);
+
+  renderProfileNav();
+
+  must('#om-apply').addEventListener('click', () => void applyChanges());
+  must('#om-revert').addEventListener('click', () => location.reload());
+
+  // Any control carrying data-option writes straight into the working copy.
+  on(document, 'change', '[data-option]', (_event, target) => {
+    const key = target.dataset['option'];
+    if (!key) return;
+    const input = target as HTMLInputElement;
+    options[key] =
+      input.type === 'checkbox'
+        ? input.checked
+        : input.type === 'number'
+          ? Number(input.value)
+          : input.value;
+    markDirty();
+  });
+
+  window.addEventListener('hashchange', route);
+  window.addEventListener('beforeunload', (event) => {
+    if (changedKeys().length > 0) event.preventDefault();
+  });
+
+  if (!location.hash) {
+    location.hash = localState.get('lastUrl') ?? '#/about';
+  }
+  route();
+  markDirty();
+}
+
+void main();

--- a/packages/ui/src/options/main.ts
+++ b/packages/ui/src/options/main.ts
@@ -131,6 +131,12 @@ async function main(): Promise<void> {
   must('#om-apply').addEventListener('click', () => void applyChanges());
   must('#om-revert').addEventListener('click', () => location.reload());
 
+  // Escape hatch out of the side panel for the wider screens (rule tables in
+  // particular are unusable at panel width).
+  must('#om-open-tab').addEventListener('click', () => {
+    void chrome.tabs.create({ url: chrome.runtime.getURL('options.html') + location.hash });
+  });
+
   // Any control carrying data-option writes straight into the working copy.
   on(document, 'change', '[data-option]', (_event, target) => {
     const key = target.dataset['option'];

--- a/packages/ui/src/options/main.ts
+++ b/packages/ui/src/options/main.ts
@@ -13,7 +13,14 @@ import { localizeDocument, profileDisplayName, t } from '../lib/i18n.js';
 import { api, callBackground, localState } from '../lib/messaging.js';
 import { colorFor, listProfiles } from '../lib/profile-view.js';
 import { deepEqual } from '../lib/equal.js';
-import { renderAbout, renderGeneral, renderIo, renderProfile, renderUi } from './views.js';
+import {
+  renderAbout,
+  renderGeneral,
+  renderIo,
+  renderNewProfile,
+  renderProfile,
+  renderUi,
+} from './views.js';
 import type { OptionsBag } from '@switchydelta/pac';
 
 /** The saved state, used to decide what actually changed. */
@@ -21,11 +28,17 @@ let pristine: OptionsBag = {};
 /** The live, edited copy bound to the form controls. */
 export let options: OptionsBag = {};
 
+export function isDirty(): boolean {
+  return changedKeys().length > 0;
+}
+
 export function markDirty(): void {
-  const dirty = changedKeys().length > 0;
+  const dirty = isDirty();
   must<HTMLButtonElement>('#om-apply').disabled = !dirty;
   must<HTMLButtonElement>('#om-revert').disabled = !dirty;
-  must('#om-status').textContent = dirty ? t('options_unsavedChanges') : '';
+  // As in the original, the enabled Apply/Discard buttons are the unsaved-
+  // changes indicator; there is no catalogue string for a status line.
+  must('#om-status').textContent = '';
 }
 
 function changedKeys(): string[] {
@@ -40,13 +53,12 @@ async function applyChanges(): Promise<void> {
   }
   if (Object.keys(changes).length === 0) return;
 
-  must('#om-status').textContent = t('options_saving');
   try {
     // `undefined` marks a removed key, matching the storage layer's convention.
     await callBackground('applyChanges', changes);
     pristine = structuredClone(options);
     markDirty();
-    must('#om-status').textContent = t('options_saved');
+    must('#om-status').textContent = t('options_saveSuccess');
   } catch (err) {
     must('#om-status').textContent = err instanceof Error ? err.message : String(err);
   }
@@ -61,6 +73,7 @@ const routes: Array<[RegExp, View]> = [
   [/^#\/general$/, renderGeneral],
   [/^#\/io$/, renderIo],
   [/^#\/about$/, renderAbout],
+  [/^#\/new$/, renderNewProfile],
   [/^#\/profile\/(.*)$/, renderProfile],
 ];
 
@@ -111,6 +124,14 @@ function renderProfileNav(): void {
       return li;
     }),
   );
+
+  const newLink = document.createElement('a');
+  newLink.className = 'om-item om-item-new';
+  newLink.href = '#/new';
+  newLink.textContent = t('options_newProfile');
+  const li = document.createElement('li');
+  li.append(newLink);
+  nav.append(li);
 }
 
 // --- Boot -------------------------------------------------------------------

--- a/packages/ui/src/options/options.css
+++ b/packages/ui/src/options/options.css
@@ -42,13 +42,87 @@ body.om-options {
   font: 14px/1.5 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
 }
 
+/* Narrow layout, which is what the Chrome side panel always is (~320-400px).
+   The sidebar collapses from a column into a horizontally scrollable strip of
+   chips so it costs one row instead of a screenful. */
 @media (max-width: 720px) {
   body.om-options {
     grid-template-columns: 1fr;
   }
+
+  /* Grid items default to min-width:auto, which lets wide content push the
+     track open instead of scrolling inside it. clip rather than hidden so the
+     sticky sidebar and toolbar keep working. */
+  body.om-options {
+    overflow-x: clip;
+  }
+
+  .om-sidebar,
+  .om-main {
+    min-width: 0;
+  }
+
   .om-sidebar {
-    position: static !important;
-    height: auto !important;
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    height: auto;
+    overflow: clip;
+    padding: 8px 0 6px;
+    border-right: 0;
+    border-bottom: 1px solid var(--om-border);
+  }
+
+  /* Buttons wrap rather than forcing the toolbar wider than the panel. */
+  .om-toolbar {
+    flex-wrap: wrap;
+  }
+
+  /* The window/panel title already identifies the extension. */
+  .om-brand,
+  .om-group-label {
+    display: none;
+  }
+
+  .om-sidebar nav {
+    display: flex;
+    gap: 6px;
+    padding: 0 10px;
+    overflow-x: auto;
+    scrollbar-width: thin;
+  }
+
+  .om-sidebar .om-list {
+    display: flex;
+    gap: 6px;
+  }
+
+  .om-sidebar .om-item {
+    white-space: nowrap;
+    padding: 5px 10px;
+    border: 1px solid var(--om-border);
+    border-radius: 999px;
+  }
+
+  .om-toolbar {
+    top: 47px;
+    padding: 10px 14px;
+  }
+
+  .om-view {
+    padding: 14px;
+  }
+}
+
+/* Only useful when the page is cramped; in a full tab it is redundant. */
+#om-open-tab {
+  display: none;
+}
+
+@media (max-width: 720px) {
+  #om-open-tab {
+    display: inline-block;
+    margin-left: auto;
   }
 }
 

--- a/packages/ui/src/options/options.css
+++ b/packages/ui/src/options/options.css
@@ -42,88 +42,9 @@ body.om-options {
   font: 14px/1.5 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
 }
 
-/* Narrow layout, which is what the Chrome side panel always is (~320-400px).
-   The sidebar collapses from a column into a horizontally scrollable strip of
-   chips so it costs one row instead of a screenful. */
-@media (max-width: 720px) {
-  body.om-options {
-    grid-template-columns: 1fr;
-  }
-
-  /* Grid items default to min-width:auto, which lets wide content push the
-     track open instead of scrolling inside it. clip rather than hidden so the
-     sticky sidebar and toolbar keep working. */
-  body.om-options {
-    overflow-x: clip;
-  }
-
-  .om-sidebar,
-  .om-main {
-    min-width: 0;
-  }
-
-  .om-sidebar {
-    position: sticky;
-    top: 0;
-    z-index: 2;
-    height: auto;
-    overflow: clip;
-    padding: 8px 0 6px;
-    border-right: 0;
-    border-bottom: 1px solid var(--om-border);
-  }
-
-  /* Buttons wrap rather than forcing the toolbar wider than the panel. */
-  .om-toolbar {
-    flex-wrap: wrap;
-  }
-
-  /* The window/panel title already identifies the extension. */
-  .om-brand,
-  .om-group-label {
-    display: none;
-  }
-
-  .om-sidebar nav {
-    display: flex;
-    gap: 6px;
-    padding: 0 10px;
-    overflow-x: auto;
-    scrollbar-width: thin;
-  }
-
-  .om-sidebar .om-list {
-    display: flex;
-    gap: 6px;
-  }
-
-  .om-sidebar .om-item {
-    white-space: nowrap;
-    padding: 5px 10px;
-    border: 1px solid var(--om-border);
-    border-radius: 999px;
-  }
-
-  .om-toolbar {
-    top: 47px;
-    padding: 10px 14px;
-  }
-
-  .om-view {
-    padding: 14px;
-  }
-}
-
 /* Only useful when the page is cramped; in a full tab it is redundant. */
 #om-open-tab {
   display: none;
-}
-
-@media (max-width: 720px) {
-  #om-open-tab {
-    display: inline-block;
-    margin-left: auto;
-  }
 }
 
 .om-sidebar {
@@ -240,6 +161,204 @@ body.om-options {
 .om-view h2 {
   margin-top: 0;
   font-size: 18px;
+}
+
+.om-view h3 {
+  margin: 24px 0 10px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--om-border);
+  font-size: 15px;
+}
+
+.om-view h4 {
+  margin: 14px 0 6px;
+  font-size: 13px;
+}
+
+.om-help {
+  margin: 4px 0 14px;
+  color: var(--om-muted);
+  font-size: 12px;
+}
+
+.om-badge-conflict {
+  display: inline-block;
+  padding: 0 5px;
+  border-radius: 3px;
+  background: #da4f49;
+  color: #fff;
+  font-weight: 700;
+}
+
+.om-cycle {
+  list-style: none;
+  margin: 0 0 14px;
+  padding: 0;
+  max-width: 420px;
+  border: 1px solid var(--om-border);
+  border-radius: 6px;
+}
+
+.om-cycle:empty {
+  min-height: 34px;
+  background: var(--om-panel);
+}
+
+.om-cycle li {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 5px 10px;
+  border-top: 1px solid var(--om-border);
+}
+
+.om-cycle li:first-child {
+  border-top: 0;
+}
+
+.om-cycle-buttons {
+  display: flex;
+  gap: 4px;
+}
+
+.om-mini {
+  padding: 1px 8px;
+  border: 1px solid var(--om-border);
+  border-radius: 4px;
+  background: var(--om-bg);
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.om-mini:hover {
+  background: var(--om-hover);
+}
+
+.om-btn-danger:not(:disabled) {
+  border-color: var(--om-danger);
+  color: var(--om-danger);
+}
+
+.om-profile-head {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.om-profile-head h2 {
+  margin: 0;
+}
+
+.om-actions-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0 0 14px;
+}
+
+.om-inline-form {
+  margin: 0 0 14px;
+  padding: 10px;
+  border: 1px solid var(--om-border);
+  border-radius: 6px;
+  background: var(--om-panel);
+}
+
+/* Protocol/server/port share a row; the server column takes the slack. */
+.om-proxy-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) 5.5em;
+  gap: 8px;
+}
+
+.om-item-new {
+  color: var(--om-accent);
+}
+
+/* Narrow layout, which is what the Chrome side panel always is (~320-400px).
+   The sidebar collapses from a column into a horizontally scrollable strip of
+   chips so it costs one row instead of a screenful.
+
+   This block MUST stay at the end of the file: it overrides base rules of the
+   same specificity, and with media queries only source order decides. */
+@media (max-width: 720px) {
+  body.om-options {
+    grid-template-columns: 1fr;
+
+    /* Explicit rows: with min-height stretching the grid, two auto rows would
+       share the leftover space and the sidebar would balloon; 1fr hands all
+       of it to the content row instead. */
+    grid-template-rows: auto 1fr;
+
+    /* Grid items default to min-width:auto, which lets wide content push the
+       track open instead of scrolling inside it. clip rather than hidden so
+       the sticky sidebar and toolbar keep working. */
+    overflow-x: clip;
+  }
+
+  .om-sidebar,
+  .om-main {
+    min-width: 0;
+  }
+
+  .om-sidebar {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    height: auto;
+    overflow: clip;
+    padding: 8px 0 6px;
+    border-right: 0;
+    border-bottom: 1px solid var(--om-border);
+  }
+
+  /* The window/panel title already identifies the extension. */
+  .om-brand,
+  .om-group-label {
+    display: none;
+  }
+
+  /* Two chip rows: settings pages on top, profiles below. Each row scrolls
+     sideways on its own, so profiles are always visible instead of being
+     buried at the end of one long strip. */
+  .om-sidebar nav {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 0 10px;
+  }
+
+  .om-sidebar .om-list {
+    display: flex;
+    gap: 6px;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+
+  .om-sidebar .om-item {
+    white-space: nowrap;
+    padding: 5px 10px;
+    border: 1px solid var(--om-border);
+    border-radius: 999px;
+  }
+
+  /* Buttons wrap rather than forcing the toolbar wider than the panel. */
+  .om-toolbar {
+    flex-wrap: wrap;
+    top: 47px;
+    padding: 10px 14px;
+  }
+
+  .om-view {
+    padding: 14px;
+  }
+
+  #om-open-tab {
+    display: inline-block;
+    margin-left: auto;
+  }
 }
 
 .om-field {

--- a/packages/ui/src/options/options.css
+++ b/packages/ui/src/options/options.css
@@ -1,0 +1,211 @@
+/* Options page. Replaces Bootstrap 3 + Less with a small system-font sheet. */
+
+:root {
+  --om-bg: #ffffff;
+  --om-panel: #f8f9fa;
+  --om-fg: #1a1a1a;
+  --om-muted: #6b7280;
+  --om-hover: #eef0f3;
+  --om-active: #e7f1fb;
+  --om-border: #e4e6eb;
+  --om-accent: #1a73e8;
+  --om-accent-fg: #ffffff;
+  --om-danger: #c5221f;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --om-bg: #202124;
+    --om-panel: #292a2d;
+    --om-fg: #e8eaed;
+    --om-muted: #9aa0a6;
+    --om-hover: #35363a;
+    --om-active: #1f3a5f;
+    --om-border: #3c4043;
+    --om-accent: #8ab4f8;
+    --om-accent-fg: #202124;
+    --om-danger: #f28b82;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body.om-options {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  min-height: 100vh;
+  margin: 0;
+  background: var(--om-bg);
+  color: var(--om-fg);
+  font: 14px/1.5 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}
+
+@media (max-width: 720px) {
+  body.om-options {
+    grid-template-columns: 1fr;
+  }
+  .om-sidebar {
+    position: static !important;
+    height: auto !important;
+  }
+}
+
+.om-sidebar {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  overflow-y: auto;
+  padding: 16px 0;
+  background: var(--om-panel);
+  border-right: 1px solid var(--om-border);
+}
+
+.om-brand {
+  margin: 0 16px 16px;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.om-group-label {
+  margin: 16px 16px 4px;
+  color: var(--om-muted);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.om-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.om-item {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  padding: 7px 16px;
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.om-item:hover {
+  background: var(--om-hover);
+}
+
+.om-item[aria-current="page"] {
+  background: var(--om-active);
+  font-weight: 600;
+}
+
+.om-swatch {
+  flex: 0 0 auto;
+  width: 14px;
+  height: 14px;
+  border-radius: 4px;
+  border: 1px solid rgb(0 0 0 / 0.15);
+}
+
+.om-main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.om-toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 12px 24px;
+  background: var(--om-bg);
+  border-bottom: 1px solid var(--om-border);
+}
+
+.om-btn {
+  padding: 6px 14px;
+  border: 1px solid var(--om-border);
+  border-radius: 6px;
+  background: var(--om-bg);
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.om-btn:hover:not(:disabled) {
+  background: var(--om-hover);
+}
+
+.om-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.om-btn-primary:not(:disabled) {
+  background: var(--om-accent);
+  border-color: var(--om-accent);
+  color: var(--om-accent-fg);
+}
+
+.om-status {
+  color: var(--om-muted);
+  font-size: 12px;
+}
+
+.om-view {
+  padding: 24px;
+  max-width: 860px;
+}
+
+.om-view h2 {
+  margin-top: 0;
+  font-size: 18px;
+}
+
+.om-field {
+  display: block;
+  margin: 0 0 14px;
+}
+
+.om-field > span {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--om-muted);
+  font-size: 12px;
+}
+
+.om-field input[type="text"],
+.om-field input[type="url"],
+.om-field input[type="number"],
+.om-field select,
+.om-field textarea {
+  width: 100%;
+  padding: 6px 8px;
+  border: 1px solid var(--om-border);
+  border-radius: 6px;
+  background: var(--om-bg);
+  color: inherit;
+  font: inherit;
+}
+
+.om-field textarea {
+  min-height: 160px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.om-check {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  margin: 0 0 10px;
+}
+
+.om-error {
+  color: var(--om-danger);
+}

--- a/packages/ui/src/options/views.ts
+++ b/packages/ui/src/options/views.ts
@@ -1,0 +1,256 @@
+/**
+ * Screen renderers for the options page.
+ *
+ * Each takes the container to fill. Controls carrying `data-option` are bound
+ * to the working copy by the shell; anything more involved wires its own
+ * listeners.
+ */
+
+import { downloadFile, h, must } from '../lib/dom.js';
+import { t } from '../lib/i18n.js';
+import { api, callBackground } from '../lib/messaging.js';
+import { markDirty, options } from './main.js';
+import { Profiles, type FixedProfile, type Profile, type ProxyServer } from '@switchydelta/pac';
+
+/** A labelled checkbox bound to a top-level option key. */
+function check(key: string, labelKey: string, hint?: string) {
+  const input = h('input', {
+    type: 'checkbox',
+    checked: options[key] !== false,
+    dataset: { option: key },
+  });
+  // Defaults differ per key; only a strict false counts as off.
+  input.checked = options[key] === true || (options[key] !== false && defaultsOn(key));
+
+  return h(
+    'label',
+    { class: 'om-check' },
+    input,
+    h('span', {}, h('span', { text: t(labelKey) }), hint && h('small', { text: ' ' + t(hint) })),
+  );
+}
+
+function defaultsOn(key: string): boolean {
+  return key === '-confirmDeletion' || key === '-showExternalProfile';
+}
+
+function field(labelKey: string, control: HTMLElement) {
+  return h('label', { class: 'om-field' }, h('span', { text: t(labelKey) }), control);
+}
+
+export function renderUi(container: HTMLElement): void {
+  container.append(
+    h('h2', { text: t('options_navInterface') }),
+    check('-confirmDeletion', 'options_confirmDeletion'),
+    check('-refreshOnProfileChange', 'options_refreshOnProfileChange'),
+    check('-addConditionsToBottom', 'options_addConditionsToBottom'),
+    check('-showExternalProfile', 'options_showExternalProfile'),
+    check('-enableQuickSwitch', 'options_enableQuickSwitch'),
+  );
+}
+
+/** Download interval choices, in minutes; -1 means never. */
+const DOWNLOAD_INTERVALS = [15, 60, 180, 360, 720, 1440, -1];
+
+export function renderGeneral(container: HTMLElement): void {
+  const select = h(
+    'select',
+    { dataset: { option: '-downloadInterval' } },
+    ...DOWNLOAD_INTERVALS.map((minutes) =>
+      h('option', {
+        value: String(minutes),
+        text: minutes < 0 ? t('options_updateInterval_never') : String(minutes),
+        selected: options['-downloadInterval'] === minutes,
+      }),
+    ),
+  );
+
+  container.append(
+    h('h2', { text: t('options_navGeneral') }),
+    field('options_downloadInterval', select),
+    check('-monitorWebRequests', 'options_monitorWebRequests'),
+  );
+}
+
+export function renderIo(container: HTMLElement): void {
+  const urlInput = h('input', { type: 'url', placeholder: 'https://' });
+  const status = h('p', { class: 'om-status' });
+
+  const restore = async (text: string) => {
+    try {
+      await api.reset(JSON.parse(text));
+      location.reload();
+    } catch (err) {
+      status.className = 'om-error';
+      status.textContent = err instanceof Error ? err.message : String(err);
+    }
+  };
+
+  const fileInput = h('input', {
+    type: 'file',
+    accept: '.bak,application/json',
+    onchange: async (event: Event) => {
+      const file = (event.target as HTMLInputElement).files?.[0];
+      if (file) await restore(await file.text());
+    },
+  });
+
+  container.append(
+    h('h2', { text: t('options_navImportExport') }),
+
+    h('h3', { text: t('options_exportOptions') }),
+    h('button', {
+      type: 'button',
+      class: 'om-btn',
+      text: t('options_exportOptions'),
+      onclick: () =>
+        downloadFile('OmegaOptions.bak', JSON.stringify(options, null, 2), 'application/json'),
+    }),
+
+    h('h3', { text: t('options_importOptions') }),
+    field('options_restoreLocal', fileInput),
+    field('options_restoreOnline', urlInput),
+    h('button', {
+      type: 'button',
+      class: 'om-btn',
+      text: t('options_restoreOnline'),
+      onclick: async () => {
+        try {
+          const response = await fetch(urlInput.value);
+          if (!response.ok) throw new Error(`HTTP ${response.status}`);
+          await restore(await response.text());
+        } catch (err) {
+          status.className = 'om-error';
+          status.textContent = err instanceof Error ? err.message : String(err);
+        }
+      },
+    }),
+    status,
+  );
+}
+
+export function renderAbout(container: HTMLElement): void {
+  const version = chrome.runtime.getManifest().version;
+  container.append(
+    h('h2', { text: t('options_navAbout') }),
+    h('p', { text: `${t('appNameShort')} ${version}` }),
+    h('p', {}, h('a', { href: 'https://github.com/madeye/SwitchyDelta', text: 'GitHub' })),
+  );
+}
+
+// --- Profile editing --------------------------------------------------------
+
+const PROXY_SCHEMES = ['http', 'https', 'socks4', 'socks5'];
+const DEFAULT_PORTS: Record<string, number> = { http: 80, https: 443, socks4: 1080, socks5: 1080 };
+
+export function renderProfile(container: HTMLElement, name: string): void {
+  const profile = Profiles.byName(name, options);
+  if (!profile) {
+    container.append(h('p', { class: 'om-error', text: t('options_profileNotFound') }));
+    return;
+  }
+
+  container.append(h('h2', { text: profile.name }));
+
+  if (profile.profileType === 'FixedProfile') {
+    renderFixedProfile(container, profile as FixedProfile);
+  } else {
+    // Editors for the remaining profile types are not ported yet; the profile
+    // itself still works, it just cannot be edited from this screen.
+    container.append(
+      h('p', {
+        text: `${t('options_profileType')}: ${profile.profileType}`,
+      }),
+      h('p', {
+        class: 'om-error',
+        text: `Editing ${profile.profileType} is not available in this build yet.`,
+      }),
+    );
+  }
+
+  container.append(
+    h('button', {
+      type: 'button',
+      class: 'om-btn',
+      text: t('options_exportPacFile'),
+      onclick: () => exportPac(profile),
+    }),
+  );
+}
+
+function renderFixedProfile(container: HTMLElement, profile: FixedProfile): void {
+  const proxy: ProxyServer = profile.fallbackProxy ?? { scheme: 'http', host: '', port: 80 };
+  profile.fallbackProxy = proxy;
+
+  const touch = () => {
+    Profiles.updateRevision(profile);
+    markDirty();
+  };
+
+  const scheme = h(
+    'select',
+    {
+      onchange: (event: Event) => {
+        proxy.scheme = (event.target as HTMLSelectElement).value;
+        if (!port.value) proxy.port = DEFAULT_PORTS[proxy.scheme] ?? 80;
+        touch();
+      },
+    },
+    ...PROXY_SCHEMES.map((s) =>
+      h('option', { value: s, text: s.toUpperCase(), selected: proxy.scheme === s }),
+    ),
+  );
+
+  const host = h('input', {
+    type: 'text',
+    value: proxy.host,
+    oninput: (event: Event) => {
+      proxy.host = (event.target as HTMLInputElement).value;
+      touch();
+    },
+  });
+
+  const port = h('input', {
+    type: 'number',
+    value: String(proxy.port),
+    min: '1',
+    max: '65535',
+    oninput: (event: Event) => {
+      proxy.port = Number((event.target as HTMLInputElement).value);
+      touch();
+    },
+  });
+
+  const bypass = h('textarea', {
+    value: (profile.bypassList ?? []).map((c) => c.pattern).join('\n'),
+    oninput: (event: Event) => {
+      profile.bypassList = (event.target as HTMLTextAreaElement).value
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .map((pattern) => ({ conditionType: 'BypassCondition' as const, pattern }));
+      touch();
+    },
+  });
+
+  container.append(
+    field('options_proxyProtocol', scheme),
+    field('options_proxyServer', host),
+    field('options_proxyPort', port),
+    field('options_bypassList', bypass),
+  );
+}
+
+async function exportPac(profile: Profile): Promise<void> {
+  try {
+    const pac = await callPac(profile.name);
+    downloadFile(`OmegaProfile_${profile.name}.pac`, pac, 'application/x-ns-proxy-autoconfig');
+  } catch (err) {
+    must('#om-status').textContent = err instanceof Error ? err.message : String(err);
+  }
+}
+
+/** PAC generation runs in the background, which owns the resolved options. */
+function callPac(name: string): Promise<string> {
+  return callBackground<string>('pacForProfile', name);
+}

--- a/packages/ui/src/options/views.ts
+++ b/packages/ui/src/options/views.ts
@@ -6,11 +6,22 @@
  * listeners.
  */
 
-import { downloadFile, h, must } from '../lib/dom.js';
-import { t } from '../lib/i18n.js';
-import { api, callBackground } from '../lib/messaging.js';
-import { markDirty, options } from './main.js';
+import { append, downloadFile, h, must, render } from '../lib/dom.js';
+import { profileDisplayName, t } from '../lib/i18n.js';
+import { api, callBackground, getState } from '../lib/messaging.js';
+import { colorFor, listProfiles, profileColors } from '../lib/profile-view.js';
+import { isDirty, markDirty, options } from './main.js';
 import { Profiles, type FixedProfile, type Profile, type ProxyServer } from '@switchydelta/pac';
+
+/** Option keys whose absence means "on" (mirrors the background's defaults). */
+const DEFAULT_ON = new Set([
+  '-confirmDeletion',
+  '-refreshOnProfileChange',
+  '-showInspectMenu',
+  '-showExternalProfile',
+  '-monitorWebRequests',
+  '-revertProxyChanges',
+]);
 
 /** A labelled checkbox bound to a top-level option key. */
 function check(key: string, labelKey: string, hint?: string) {
@@ -20,7 +31,7 @@ function check(key: string, labelKey: string, hint?: string) {
     dataset: { option: key },
   });
   // Defaults differ per key; only a strict false counts as off.
-  input.checked = options[key] === true || (options[key] !== false && defaultsOn(key));
+  input.checked = options[key] === true || (options[key] !== false && DEFAULT_ON.has(key));
 
   return h(
     'label',
@@ -30,23 +41,199 @@ function check(key: string, labelKey: string, hint?: string) {
   );
 }
 
-function defaultsOn(key: string): boolean {
-  return key === '-confirmDeletion' || key === '-showExternalProfile';
-}
-
 function field(labelKey: string, control: HTMLElement) {
   return h('label', { class: 'om-field' }, h('span', { text: t(labelKey) }), control);
 }
 
+/** A section heading inside a tab, like the original's `.settings-group h3`. */
+function group(labelKey: string) {
+  return h('h3', { text: t(labelKey) });
+}
+
+/**
+ * A help paragraph. Rendered as HTML because several catalogue strings carry
+ * inline markup (`<br>`, `<b>`, …); they are our own translations, so this is
+ * as trusted as the original's `omega-html` binding was.
+ */
+function help(labelKey: string, substitutions?: string[]) {
+  return h('p', { class: 'om-help', html: t(labelKey, substitutions) });
+}
+
+/** Names offered by profile pickers: the builtins plus every user profile. */
+function selectableProfileNames(): string[] {
+  return ['direct', 'system', ...listProfiles(options).map((profile) => profile.name)];
+}
+
 export function renderUi(container: HTMLElement): void {
   container.append(
-    h('h2', { text: t('options_navInterface') }),
+    h('h2', { text: t('options_tab_ui') }),
+
+    group('options_group_miscOptions'),
     check('-confirmDeletion', 'options_confirmDeletion'),
     check('-refreshOnProfileChange', 'options_refreshOnProfileChange'),
+    check('-showInspectMenu', 'options_showInspectMenu'),
     check('-addConditionsToBottom', 'options_addConditionsToBottom'),
-    check('-showExternalProfile', 'options_showExternalProfile'),
-    check('-enableQuickSwitch', 'options_enableQuickSwitch'),
+
+    group('options_group_keyboardShortcut'),
+    h(
+      'p',
+      {},
+      h('button', {
+        type: 'button',
+        class: 'om-btn',
+        text: t('options_menuShortcutConfigure'),
+        // chrome:// pages cannot be linked, only opened through the tabs API.
+        onclick: () => void chrome.tabs.create({ url: 'chrome://extensions/shortcuts' }),
+      }),
+      ' ',
+      t('options_menuShortcutHelp'),
+    ),
+    help('options_menuShortcutMore'),
+
+    group('options_group_switchOptions'),
+    field('options_startupProfile', startupProfileSelect()),
+    advancedConditionTypesCheck(),
+    quickSwitchSection(),
   );
+}
+
+function startupProfileSelect(): HTMLSelectElement {
+  const current = (options['-startupProfileName'] as string | undefined) ?? '';
+  return h(
+    'select',
+    { dataset: { option: '-startupProfileName' } },
+    h('option', { value: '', text: t('options_startupProfile_none'), selected: current === '' }),
+    ...selectableProfileNames().map((name) =>
+      h('option', { value: name, text: profileDisplayName(name), selected: current === name }),
+    ),
+  );
+}
+
+/** Stored as 1/0 rather than a boolean; kept that way for backup compatibility. */
+function advancedConditionTypesCheck(): DocumentFragment {
+  const fragment = document.createDocumentFragment();
+  const input = h('input', {
+    type: 'checkbox',
+    checked: Number(options['-showConditionTypes'] ?? 0) > 0,
+    onchange: () => {
+      options['-showConditionTypes'] = input.checked ? 1 : 0;
+      markDirty();
+    },
+  });
+  fragment.append(
+    h(
+      'label',
+      { class: 'om-check' },
+      input,
+      h('span', {}, h('span', { text: t('options_showConditionTypesAdvanced') })),
+    ),
+    help('options_showConditionTypesAdvancedHelp'),
+  );
+  return fragment;
+}
+
+/**
+ * Quick Switch: the enable toggle plus the cycle editor — which profiles the
+ * toolbar icon cycles through, in order. The original used drag-and-drop
+ * lists; buttons do the same job at side-panel width.
+ */
+function quickSwitchSection(): DocumentFragment {
+  const fragment = document.createDocumentFragment();
+  const editor = h('div', { class: 'om-quick-switch' });
+
+  const enable = h('input', {
+    type: 'checkbox',
+    checked: options['-enableQuickSwitch'] === true,
+    onchange: () => {
+      options['-enableQuickSwitch'] = enable.checked;
+      markDirty();
+      rerender();
+    },
+  });
+
+  const rerender = () => {
+    editor.hidden = options['-enableQuickSwitch'] !== true;
+    if (editor.hidden) {
+      render(editor, []);
+      return;
+    }
+
+    const cycled = ((options['-quickSwitchProfiles'] as string[] | undefined) ?? []).slice();
+    const notCycled = selectableProfileNames().filter((name) => !cycled.includes(name));
+    const setCycled = (next: string[]) => {
+      options['-quickSwitchProfiles'] = next;
+      markDirty();
+      rerender();
+    };
+
+    render(editor, [
+      h('h4', { text: t('options_cycledProfiles') }),
+      h('p', { class: 'om-help', text: t('options_cycledProfilesHelp') }),
+      cycled.length < 2 && h('p', { class: 'om-error', text: t('options_cycledProfilesTooFew') }),
+      h(
+        'ul',
+        { class: 'om-cycle' },
+        ...cycled.map((name, index) =>
+          h(
+            'li',
+            {},
+            h('span', { text: profileDisplayName(name) }),
+            h(
+              'span',
+              { class: 'om-cycle-buttons' },
+              index > 0 &&
+                h('button', {
+                  type: 'button',
+                  class: 'om-mini',
+                  text: '↑',
+                  onclick: () => {
+                    const next = cycled.slice();
+                    [next[index - 1], next[index]] = [next[index]!, next[index - 1]!];
+                    setCycled(next);
+                  },
+                }),
+              h('button', {
+                type: 'button',
+                class: 'om-mini',
+                text: '✕',
+                onclick: () => setCycled(cycled.filter((other) => other !== name)),
+              }),
+            ),
+          ),
+        ),
+      ),
+      h('h4', { text: t('options_notCycledProfiles') }),
+      h(
+        'ul',
+        { class: 'om-cycle' },
+        ...notCycled.map((name) =>
+          h(
+            'li',
+            {},
+            h('span', { text: profileDisplayName(name) }),
+            h('button', {
+              type: 'button',
+              class: 'om-mini',
+              text: '+',
+              onclick: () => setCycled([...cycled, name]),
+            }),
+          ),
+        ),
+      ),
+    ]);
+  };
+
+  rerender();
+  fragment.append(
+    h(
+      'label',
+      { class: 'om-check' },
+      enable,
+      h('span', {}, h('span', { text: t('options_quickSwitch') })),
+    ),
+    editor,
+  );
+  return fragment;
 }
 
 /** Download interval choices, in minutes; -1 means never. */
@@ -59,16 +246,38 @@ export function renderGeneral(container: HTMLElement): void {
     ...DOWNLOAD_INTERVALS.map((minutes) =>
       h('option', {
         value: String(minutes),
-        text: minutes < 0 ? t('options_updateInterval_never') : String(minutes),
+        text: t(
+          minutes < 0 ? 'options_downloadInterval_never' : 'options_downloadInterval_' + minutes,
+        ),
         selected: options['-downloadInterval'] === minutes,
       }),
     ),
   );
+  const systemName = profileDisplayName('system');
 
   container.append(
-    h('h2', { text: t('options_navGeneral') }),
-    field('options_downloadInterval', select),
+    h('h2', { text: t('options_tab_general') }),
+
+    group('options_group_networkRequests'),
     check('-monitorWebRequests', 'options_monitorWebRequests'),
+    help('options_monitorWebRequestsHelp'),
+
+    group('options_downloadOptions'),
+    help('options_downloadOptionsHelp'),
+    field('options_downloadInterval', select),
+
+    group('options_group_conflicts'),
+    h('p', { text: t('options_conflicts_introduction') }),
+    h(
+      'p',
+      { class: 'om-help' },
+      h('span', { class: 'om-badge-conflict', text: '=' }),
+      ' ',
+      t('options_conflicts_lowerPriority'),
+    ),
+    help('options_conflicts_higherPriority', [systemName]),
+    check('-showExternalProfile', 'options_showExternalProfile'),
+    help('options_showExternalProfileHelp', [systemName, t('popup_externalProfile')]),
   );
 }
 
@@ -95,25 +304,34 @@ export function renderIo(container: HTMLElement): void {
     },
   });
 
-  container.append(
-    h('h2', { text: t('options_navImportExport') }),
+  append(container, [
+    h('h2', { text: t('options_tab_importExport') }),
 
-    h('h3', { text: t('options_exportOptions') }),
+    group('options_group_importExportProfile'),
+    help('options_exportProfileHelp'),
+    // The legacy format only matters for basic condition types, so the
+    // original hides this once advanced types are on. Same here.
+    Number(options['-showConditionTypes'] ?? 0) <= 0 &&
+      check('-exportLegacyRuleList', 'options_exportLegacyRuleList'),
+    Number(options['-showConditionTypes'] ?? 0) <= 0 && help('options_exportLegacyRuleListHelp'),
+
+    group('options_group_importExportSettings'),
     h('button', {
       type: 'button',
       class: 'om-btn',
-      text: t('options_exportOptions'),
+      text: t('options_makeBackup'),
       onclick: () =>
         downloadFile('OmegaOptions.bak', JSON.stringify(options, null, 2), 'application/json'),
     }),
+    help('options_makeBackupHelp'),
 
-    h('h3', { text: t('options_importOptions') }),
     field('options_restoreLocal', fileInput),
+    help('options_restoreLocalHelp'),
     field('options_restoreOnline', urlInput),
     h('button', {
       type: 'button',
       class: 'om-btn',
-      text: t('options_restoreOnline'),
+      text: t('options_restoreOnlineSubmit'),
       onclick: async () => {
         try {
           const response = await fetch(urlInput.value);
@@ -126,13 +344,76 @@ export function renderIo(container: HTMLElement): void {
       },
     }),
     status,
-  );
+
+    group('options_group_syncing'),
+    syncSection(),
+  ]);
+}
+
+/**
+ * Options syncing. The state machine lives in the background; this renders
+ * the same four states the original page had and calls the same RPCs. Sync
+ * actions can replace the whole options bag, so the page reloads after each.
+ */
+function syncSection(): HTMLElement {
+  const wrap = h('div');
+
+  const act = (action: () => Promise<unknown>) => {
+    void action().then(
+      () => location.reload(),
+      (err: unknown) => {
+        wrap.append(
+          h('p', { class: 'om-error', text: err instanceof Error ? err.message : String(err) }),
+        );
+      },
+    );
+  };
+  const button = (labelKey: string, action: () => Promise<unknown>) =>
+    h('button', {
+      type: 'button',
+      class: 'om-btn',
+      text: t(labelKey),
+      onclick: () => act(action),
+    });
+
+  void getState('syncOptions').then(({ syncOptions }) => {
+    const mode = (syncOptions as string) || 'pristine';
+    if (mode === 'unsupported') {
+      render(wrap, [help('options_syncUnsupportedHelp')]);
+    } else if (mode === 'sync') {
+      render(wrap, [
+        h('p', { text: t('options_syncSyncAlert') }),
+        help('options_syncSyncHelp'),
+        h('p', {}, button('options_syncDisable', () => api.setOptionsSync(false))),
+      ]);
+    } else if (mode === 'conflict') {
+      render(wrap, [
+        h('p', { text: t('options_syncConflictAlert') }),
+        help('options_syncConflictHelp'),
+        h(
+          'p',
+          {},
+          button('options_syncEnableForce', () => api.setOptionsSync(true, { force: true })),
+          ' ',
+          button('options_syncReset', () => api.resetOptionsSync()),
+        ),
+      ]);
+    } else {
+      // pristine / disabled
+      render(wrap, [
+        help('options_syncPristineHelp'),
+        h('p', {}, button('options_syncEnable', () => api.setOptionsSync(true))),
+      ]);
+    }
+  });
+
+  return wrap;
 }
 
 export function renderAbout(container: HTMLElement): void {
   const version = chrome.runtime.getManifest().version;
   container.append(
-    h('h2', { text: t('options_navAbout') }),
+    h('h2', { text: t('about_title') }),
     h('p', { text: `${t('appNameShort')} ${version}` }),
     h('p', {}, h('a', { href: 'https://github.com/madeye/SwitchyDelta', text: 'GitHub' })),
   );
@@ -149,8 +430,148 @@ export function renderProfile(container: HTMLElement, name: string): void {
     container.append(h('p', { class: 'om-error', text: t('options_profileNotFound') }));
     return;
   }
+  const typeName =
+    chrome.i18n.getMessage('options_profileType' + profile.profileType) || profile.profileType;
 
-  container.append(h('h2', { text: profile.name }));
+  const feedback = h('p', { class: 'om-error' });
+
+  // Rename / delete talk to the background directly, so pending edits would be
+  // silently dropped by the reload that follows. Same rule as the original:
+  // apply first.
+  const requireClean = (): boolean => {
+    if (!isDirty()) return true;
+    feedback.textContent = t('options_applyOptionsRequired');
+    return false;
+  };
+
+  // --- Rename: an inline row instead of the original's modal. ---------------
+  const renameInput = h('input', { type: 'text', value: profile.name });
+  const renameRow = h(
+    'div',
+    { class: 'om-inline-form', hidden: true },
+    field('options_renameProfileName', renameInput),
+    h('button', {
+      type: 'button',
+      class: 'om-btn om-btn-primary',
+      text: t('dialog_ok'),
+      onclick: () => {
+        const next = renameInput.value.trim();
+        const problem = profileNameProblem(next, profile.name);
+        if (problem) {
+          feedback.textContent = problem;
+          return;
+        }
+        if (next === profile.name) {
+          renameRow.hidden = true;
+          return;
+        }
+        void api.renameProfile(profile.name, next).then(
+          () => {
+            location.hash = '#/profile/' + encodeURIComponent(next);
+            location.reload();
+          },
+          (err: unknown) => {
+            feedback.textContent = err instanceof Error ? err.message : String(err);
+          },
+        );
+      },
+    }),
+    ' ',
+    h('button', {
+      type: 'button',
+      class: 'om-btn',
+      text: t('dialog_cancel'),
+      onclick: () => (renameRow.hidden = true),
+    }),
+  );
+
+  // --- Delete: inline confirm, honouring the confirm-deletion option. -------
+  const doDelete = () => {
+    if (profileReferencedBy(profile.name)) {
+      feedback.textContent = t('options_modalHeader_cannotDeleteProfile');
+      return;
+    }
+    // replaceRef points the applied profile elsewhere if this one is active;
+    // with no references left it is otherwise a no-op. The removal itself
+    // goes through patch's `[old, 0, 0]` delta — an `undefined` value would
+    // be dropped by the message JSON serialization and delete nothing.
+    void api
+      .replaceRef(profile.name, 'direct')
+      .then(() => api.patch({ ['+' + profile.name]: [profile, 0, 0] }))
+      .then(
+        () => {
+          location.hash = '#/ui';
+          location.reload();
+        },
+        (err: unknown) => {
+          feedback.textContent = err instanceof Error ? err.message : String(err);
+        },
+      );
+  };
+  const deleteRow = h(
+    'div',
+    { class: 'om-inline-form', hidden: true },
+    h('span', { text: t('options_deleteProfileConfirm') + ' ' + profile.name }),
+    ' ',
+    h('button', {
+      type: 'button',
+      class: 'om-btn om-btn-danger',
+      text: t('dialog_ok'),
+      onclick: doDelete,
+    }),
+    ' ',
+    h('button', {
+      type: 'button',
+      class: 'om-btn',
+      text: t('dialog_cancel'),
+      onclick: () => (deleteRow.hidden = true),
+    }),
+  );
+
+  container.append(
+    h(
+      'div',
+      { class: 'om-profile-head' },
+      h('span', { class: 'om-swatch', style: { background: colorFor(profile, options) } }),
+      h('h2', { text: profile.name }),
+    ),
+    h('p', { class: 'om-help', text: typeName }),
+    h(
+      'div',
+      { class: 'om-actions-row' },
+      h('button', {
+        type: 'button',
+        class: 'om-btn',
+        text: t('options_renameProfile'),
+        onclick: () => {
+          if (!requireClean()) return;
+          deleteRow.hidden = true;
+          renameRow.hidden = false;
+          renameInput.focus();
+        },
+      }),
+      h('button', {
+        type: 'button',
+        class: 'om-btn',
+        text: t('options_deleteProfile'),
+        onclick: () => {
+          if (!requireClean()) return;
+          renameRow.hidden = true;
+          if (options['-confirmDeletion'] === false) doDelete();
+          else deleteRow.hidden = false;
+        },
+      }),
+      h('button', {
+        type: 'button',
+        class: 'om-btn',
+        text: t('options_profileExportPac'),
+        onclick: () => exportPac(profile),
+      }),
+    ),
+    renameRow,
+    deleteRow,
+    feedback,
+  );
 
   if (profile.profileType === 'FixedProfile') {
     renderFixedProfile(container, profile as FixedProfile);
@@ -159,21 +580,91 @@ export function renderProfile(container: HTMLElement, name: string): void {
     // itself still works, it just cannot be edited from this screen.
     container.append(
       h('p', {
-        text: `${t('options_profileType')}: ${profile.profileType}`,
-      }),
-      h('p', {
         class: 'om-error',
-        text: `Editing ${profile.profileType} is not available in this build yet.`,
+        text: `Editing ${typeName} is not available in this build yet.`,
       }),
     );
   }
+}
+
+/** Why `name` cannot be used as a (new) profile name, or null if it can. */
+function profileNameProblem(name: string, allowCurrent?: string): string | null {
+  if (!name) return t('options_profileNameEmpty');
+  if (name.startsWith('__')) return t('options_profileNameReserved');
+  if (name !== allowCurrent && Profiles.byName(name, options)) {
+    return t('options_profileNameConflict');
+  }
+  return null;
+}
+
+/** Whether other profiles or options still point at `name`. */
+function profileReferencedBy(name: string): boolean {
+  let referenced = options['-startupProfileName'] === name;
+  Profiles.each(options, (_key, other) => {
+    const record = other as Profile & {
+      defaultProfileName?: string;
+      rules?: Array<{ profileName?: string }>;
+    };
+    if (record.defaultProfileName === name) referenced = true;
+    for (const rule of record.rules ?? []) {
+      if (rule.profileName === name) referenced = true;
+    }
+  });
+  return referenced;
+}
+
+export function renderNewProfile(container: HTMLElement): void {
+  const nameInput = h('input', { type: 'text', placeholder: t('options_newProfileName') });
+  const error = h('p', { class: 'om-error' });
+
+  const create = () => {
+    if (isDirty()) {
+      error.textContent = t('options_applyOptionsRequired');
+      return;
+    }
+    const name = nameInput.value.trim();
+    const problem = profileNameProblem(name);
+    if (problem) {
+      error.textContent = problem;
+      return;
+    }
+    const used = listProfiles(options).length;
+    const profile: FixedProfile = {
+      profileType: 'FixedProfile',
+      name,
+      color: profileColors[used % profileColors.length]!,
+      fallbackProxy: { scheme: 'http', host: 'example.com', port: 80 },
+      bypassList: [
+        { pattern: '127.0.0.1', conditionType: 'BypassCondition' },
+        { pattern: '::1', conditionType: 'BypassCondition' },
+        { pattern: 'localhost', conditionType: 'BypassCondition' },
+      ],
+    };
+    void api.addProfile(profile).then(
+      () => {
+        location.hash = '#/profile/' + encodeURIComponent(name);
+        location.reload();
+      },
+      (err: unknown) => {
+        error.textContent = err instanceof Error ? err.message : String(err);
+      },
+    );
+  };
+  nameInput.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') create();
+  });
 
   container.append(
+    h('h2', { text: t('options_modalHeader_newProfile') }),
+    // Only the proxy profile editor is ported, so that is the type created.
+    h('p', { class: 'om-help', text: t('options_profileTypeFixedProfile') }),
+    field('options_newProfileName', nameInput),
+    error,
     h('button', {
       type: 'button',
-      class: 'om-btn',
-      text: t('options_exportPacFile'),
-      onclick: () => exportPac(profile),
+      class: 'om-btn om-btn-primary',
+      text: t('options_createProfile'),
+      onclick: create,
     }),
   );
 }
@@ -234,10 +725,14 @@ function renderFixedProfile(container: HTMLElement, profile: FixedProfile): void
   });
 
   container.append(
-    field('options_proxyProtocol', scheme),
-    field('options_proxyServer', host),
-    field('options_proxyPort', port),
-    field('options_bypassList', bypass),
+    h(
+      'div',
+      { class: 'om-proxy-row' },
+      field('options_proxy_protocol', scheme),
+      field('options_proxy_server', host),
+      field('options_proxy_port', port),
+    ),
+    field('options_group_bypassList', bypass),
   );
 }
 

--- a/packages/ui/src/popup/main.ts
+++ b/packages/ui/src/popup/main.ts
@@ -226,9 +226,11 @@ function showNotControllable(reason: string): void {
   const notice = must('#om-not-controllable');
   notice.hidden = false;
   must('#om-not-controllable-title').textContent = t('popup_proxyNotControllable_' + reason);
-  must('#om-not-controllable-detail').textContent = t(
-    'popup_proxyNotControllableDetails_' + reason,
-  );
+  // Only some reasons have a specific detail string; fall back to the generic
+  // one like the original template did.
+  must('#om-not-controllable-detail').textContent =
+    chrome.i18n.getMessage('popup_proxyNotControllableDetails_' + reason) ||
+    t('popup_proxyNotControllableDetails');
 }
 
 function showError(err: unknown): void {

--- a/packages/ui/src/popup/main.ts
+++ b/packages/ui/src/popup/main.ts
@@ -10,7 +10,7 @@
 
 import { all, h, must, on, render } from '../lib/dom.js';
 import { localizeDocument, profileDisplayName, t } from '../lib/i18n.js';
-import { api, getState, openOptions, refreshActivePage } from '../lib/messaging.js';
+import { api, getState, openOptions, openSidePanel, refreshActivePage } from '../lib/messaging.js';
 
 /** A profile as summarised by the background for display. */
 interface AvailableProfile {
@@ -159,8 +159,13 @@ function wireActions(): void {
     });
   }
 
+  // Settings open in the side panel, falling back to a tab where the panel is
+  // unavailable. openSidePanel must run before any await, or the user gesture
+  // that authorises it is gone.
   must('#om-options').addEventListener('click', () => {
-    void openOptions();
+    if (!openSidePanel()) {
+      void openOptions();
+    }
     window.close();
   });
 }

--- a/packages/ui/src/popup/main.ts
+++ b/packages/ui/src/popup/main.ts
@@ -1,0 +1,235 @@
+/**
+ * Toolbar popup.
+ *
+ * Replaces both previous popups: the AngularJS `popup.html` app and the
+ * hand-rolled `popup/js/*.js` DOM version that had been split out of it.
+ *
+ * The popup holds no state of its own — it reads a snapshot from the service
+ * worker, renders it, and closes as soon as the user picks something.
+ */
+
+import { all, h, must, on, render } from '../lib/dom.js';
+import { localizeDocument, profileDisplayName, t } from '../lib/i18n.js';
+import { api, getState, openOptions, refreshActivePage } from '../lib/messaging.js';
+
+/** A profile as summarised by the background for display. */
+interface AvailableProfile {
+  name: string;
+  profileType: string;
+  color?: string;
+  desc?: string;
+  builtin?: boolean;
+  validResultProfiles?: string[];
+}
+
+interface PopupState {
+  availableProfiles?: Record<string, AvailableProfile>;
+  currentProfileName?: string;
+  isSystemProfile?: boolean;
+  currentProfileCanAddRule?: boolean;
+  proxyNotControllable?: string | null;
+  refreshOnProfileChange?: boolean;
+}
+
+/** One letter per profile type, shown inside the colour swatch. */
+const TYPE_INITIAL: Record<string, string> = {
+  DirectProfile: 'D',
+  SystemProfile: 'S',
+  FixedProfile: 'F',
+  PacProfile: 'P',
+  VirtualProfile: 'V',
+  SwitchProfile: 'A',
+  RuleListProfile: 'L',
+  SwitchyRuleListProfile: 'L',
+  AutoProxyRuleListProfile: 'L',
+};
+
+const TYPE_ORDER: Record<string, number> = {
+  DirectProfile: 0,
+  SystemProfile: 0,
+  FixedProfile: 1,
+  PacProfile: 2,
+  VirtualProfile: 3,
+  SwitchProfile: 4,
+  RuleListProfile: 5,
+  SwitchyRuleListProfile: 5,
+  AutoProxyRuleListProfile: 5,
+};
+
+let state: PopupState = {};
+
+async function main(): Promise<void> {
+  localizeDocument();
+
+  try {
+    state = (await getState([
+      'availableProfiles',
+      'currentProfileName',
+      'isSystemProfile',
+      'currentProfileCanAddRule',
+      'proxyNotControllable',
+      'refreshOnProfileChange',
+    ])) as PopupState;
+  } catch (err) {
+    showError(err);
+    return;
+  }
+
+  if (state.proxyNotControllable) {
+    showNotControllable(state.proxyNotControllable);
+  }
+
+  renderProfiles();
+  wireActions();
+  installKeyboard();
+
+  // Focus the current profile so keyboard use starts from a sensible place.
+  const current = document.querySelector<HTMLElement>('.om-item[aria-current="true"]');
+  (current ?? document.querySelector<HTMLElement>('.om-item'))?.focus();
+}
+
+function sortedProfiles(): AvailableProfile[] {
+  const profiles = Object.values(state.availableProfiles ?? {});
+  return profiles
+    .filter((p) => !p.name.startsWith('_'))
+    .sort((a, b) => {
+      const orderA = TYPE_ORDER[a.profileType] ?? 99;
+      const orderB = TYPE_ORDER[b.profileType] ?? 99;
+      if (orderA !== orderB) return orderA - orderB;
+      return a.name.localeCompare(b.name);
+    });
+}
+
+function renderProfiles(): void {
+  const list = must('#om-profiles');
+  const profiles = sortedProfiles();
+
+  render(
+    list,
+    profiles.map((profile, index) => {
+      const isCurrent =
+        profile.name === state.currentProfileName ||
+        (state.isSystemProfile && profile.profileType === 'SystemProfile');
+
+      // Digits 1-9 select the first nine profiles.
+      const shortcut = index < 9 ? String(index + 1) : '';
+
+      return h(
+        'li',
+        {},
+        h(
+          'button',
+          {
+            type: 'button',
+            class: 'om-item',
+            dataset: { profile: profile.name },
+            'aria-current': isCurrent ? 'true' : 'false',
+            title: profile.desc ?? '',
+          },
+          h(
+            'span',
+            {
+              class: 'om-swatch',
+              style: { background: profile.color ?? '#cccccc' },
+              'aria-hidden': 'true',
+            },
+            TYPE_INITIAL[profile.profileType] ?? '?',
+          ),
+          h('span', { class: 'om-name', text: profileDisplayName(profile.name) }),
+          shortcut && h('span', { class: 'om-key', text: shortcut }),
+        ),
+      );
+    }),
+  );
+
+  on(list, 'click', '.om-item', (_event, target) => {
+    const name = target.dataset['profile'];
+    if (name) void applyProfile(name);
+  });
+}
+
+function wireActions(): void {
+  const addRule = must<HTMLButtonElement>('#om-add-rule');
+  if (state.currentProfileCanAddRule) {
+    addRule.hidden = false;
+    addRule.addEventListener('click', () => {
+      // The full condition editor lives on the options page.
+      void openOptions('#/profile/' + encodeURIComponent(state.currentProfileName ?? ''));
+      window.close();
+    });
+  }
+
+  must('#om-options').addEventListener('click', () => {
+    void openOptions();
+    window.close();
+  });
+}
+
+async function applyProfile(name: string): Promise<void> {
+  try {
+    await api.applyProfile(name);
+    if (state.refreshOnProfileChange !== false) {
+      await refreshActivePage();
+    }
+  } catch (err) {
+    showError(err);
+    return;
+  }
+  window.close();
+}
+
+/**
+ * Keyboard navigation, matching the shortcuts the previous popup taught users:
+ * digits jump to a profile, j/k and arrows move, Enter activates.
+ */
+function installKeyboard(): void {
+  document.addEventListener('keydown', (event) => {
+    if (event.ctrlKey || event.metaKey || event.altKey) return;
+
+    const items = all<HTMLButtonElement>('.om-item:not([hidden])');
+    if (items.length === 0) return;
+
+    const activeIndex = items.indexOf(document.activeElement as HTMLButtonElement);
+
+    if (event.key >= '1' && event.key <= '9') {
+      const target = items[Number(event.key) - 1];
+      if (target) {
+        event.preventDefault();
+        target.click();
+      }
+      return;
+    }
+
+    let delta = 0;
+    if (event.key === 'ArrowDown' || event.key === 'j') delta = 1;
+    else if (event.key === 'ArrowUp' || event.key === 'k') delta = -1;
+    else if (event.key === 'o') {
+      event.preventDefault();
+      must<HTMLButtonElement>('#om-options').click();
+      return;
+    } else {
+      return;
+    }
+
+    event.preventDefault();
+    const next = items[(activeIndex + delta + items.length) % items.length];
+    next?.focus();
+  });
+}
+
+function showNotControllable(reason: string): void {
+  const notice = must('#om-not-controllable');
+  notice.hidden = false;
+  must('#om-not-controllable-title').textContent = t('popup_proxyNotControllable_' + reason);
+  must('#om-not-controllable-detail').textContent = t(
+    'popup_proxyNotControllableDetails_' + reason,
+  );
+}
+
+function showError(err: unknown): void {
+  const el = must('#om-error');
+  el.hidden = false;
+  el.textContent = err instanceof Error ? err.message : String(err);
+}
+
+void main();

--- a/packages/ui/src/popup/popup.css
+++ b/packages/ui/src/popup/popup.css
@@ -1,0 +1,145 @@
+/* Popup styling. Replaces Bootstrap 3 + the hand-written om-*.css with one
+   small sheet using system fonts and CSS custom properties. */
+
+:root {
+  --om-bg: #ffffff;
+  --om-fg: #1a1a1a;
+  --om-muted: #6b7280;
+  --om-hover: #f1f3f5;
+  --om-active: #e7f1fb;
+  --om-border: #e4e6eb;
+  --om-accent: #1a73e8;
+  --om-danger: #c5221f;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --om-bg: #202124;
+    --om-fg: #e8eaed;
+    --om-muted: #9aa0a6;
+    --om-hover: #2d2e31;
+    --om-active: #1f3a5f;
+    --om-border: #3c4043;
+    --om-accent: #8ab4f8;
+    --om-danger: #f28b82;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body.om-popup {
+  margin: 0;
+  min-width: 260px;
+  max-width: 360px;
+  padding: 6px 0;
+  background: var(--om-bg);
+  color: var(--om-fg);
+  font: 13px/1.4 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}
+
+.om-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.om-item {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  width: 100%;
+  padding: 7px 12px;
+  border: 0;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.om-item:hover,
+.om-item:focus-visible {
+  background: var(--om-hover);
+  outline: none;
+}
+
+.om-item[aria-current="true"] {
+  background: var(--om-active);
+  font-weight: 600;
+}
+
+/* The colour swatch stands in for the old Glyphicon-per-profile-type icon;
+   the type is conveyed by the letter inside it. */
+.om-swatch {
+  flex: 0 0 auto;
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  border: 1px solid rgb(0 0 0 / 0.15);
+  display: grid;
+  place-items: center;
+  font-size: 9px;
+  font-weight: 700;
+  color: rgb(0 0 0 / 0.6);
+}
+
+.om-name {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.om-detail {
+  color: var(--om-muted);
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.om-key {
+  flex: 0 0 auto;
+  color: var(--om-muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.om-icon {
+  flex: 0 0 auto;
+  width: 16px;
+  text-align: center;
+  color: var(--om-muted);
+}
+
+.om-sep {
+  margin: 6px 0;
+  border: 0;
+  border-top: 1px solid var(--om-border);
+}
+
+.om-notice {
+  margin: 0 0 6px;
+  padding: 8px 12px;
+  background: color-mix(in srgb, var(--om-danger) 12%, transparent);
+  border-bottom: 1px solid var(--om-border);
+}
+
+.om-notice-title {
+  margin: 0 0 2px;
+  font-weight: 600;
+}
+
+.om-notice-detail {
+  margin: 0;
+  color: var(--om-muted);
+  font-size: 12px;
+}
+
+.om-error {
+  margin: 6px 12px 0;
+  color: var(--om-danger);
+  font-size: 12px;
+}

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["chrome", "vite/client"],
+    "paths": {
+      "@switchydelta/pac": ["../pac/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", "vite.config.ts"]
+}

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,16 +1,27 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": ".",
     "noEmit": true,
     "composite": false,
     "declaration": false,
     "declarationMap": false,
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "types": ["chrome", "vite/client"],
+    "lib": [
+      "ES2022",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "types": [
+      "chrome",
+      "vite/client"
+    ],
     "paths": {
-      "@switchydelta/pac": ["../pac/src/index.ts"]
+      "@switchydelta/pac": [
+        "../pac/src/index.ts"
+      ]
     }
   },
-  "include": ["src/**/*.ts", "vite.config.ts"]
+  "include": [
+    "src/**/*.ts",
+    "vite.config.ts"
+  ]
 }

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -1,0 +1,38 @@
+import { resolve } from 'node:path';
+import { defineConfig } from 'vite';
+
+/**
+ * Multi-page build for the extension's two HTML surfaces.
+ *
+ * MV3 allows `script-src 'self'` only, so nothing may be inlined. Two settings
+ * matter for that: `modulePreload.polyfill` off (the polyfill is injected as an
+ * inline script) and `cssCodeSplit` off (avoids the inline style injector).
+ * Everything Vite emits is then an external file the manifest can load.
+ */
+export default defineConfig({
+  // The extension loads pages from its own package root, so asset URLs must be
+  // relative rather than server-absolute.
+  base: './',
+
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    // Matches minimum_chrome_version in the manifest, so no needless downlevelling.
+    target: 'chrome109',
+    modulePreload: { polyfill: false },
+    cssCodeSplit: false,
+    sourcemap: true,
+
+    rollupOptions: {
+      input: {
+        options: resolve(__dirname, 'options.html'),
+        popup: resolve(__dirname, 'popup.html'),
+      },
+      output: {
+        entryFileNames: 'js/[name].js',
+        chunkFileNames: 'js/[name]-[hash].js',
+        assetFileNames: 'assets/[name][extname]',
+      },
+    },
+  },
+});

--- a/scripts/build-extension.mjs
+++ b/scripts/build-extension.mjs
@@ -58,14 +58,12 @@ await copyIfPresent(resolve(root, 'packages/extension/manifest.json'), resolve(o
 // package root next to the manifest.
 await copyIfPresent(resolve(root, 'packages/ui/dist'), out, 'ui (vite output)');
 
-// Icons and translations still come from the pre-rewrite tree. The `.po` ->
-// messages.json step (previously grunt-po2crx) has not been ported yet, so the
-// already-generated catalogues are reused.
+// Icons still come from the pre-rewrite tree.
 await copyIfPresent(resolve(root, 'omega-web/img'), resolve(out, 'img'), 'icons');
-await copyIfPresent(
-  resolve(root, 'omega-target-chromium-extension/build/_locales'),
-  resolve(out, '_locales'),
-  '_locales',
-);
+
+// Translations are compiled from the gettext catalogues on every build.
+const { buildLocales } = await import('./build-locales.mjs');
+const locales = await buildLocales(resolve(root, 'omega-locales'), resolve(out, '_locales'));
+console.log(`  built   _locales (${locales.length} locales)`);
 
 console.log(`\ndone -> ${out}`);

--- a/scripts/build-extension.mjs
+++ b/scripts/build-extension.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * Assemble the loadable extension into `dist/`.
+ *
+ * Replaces the Grunt pipeline (coffee -> browserify -> copy -> compress). The
+ * three source bundles that used to be concatenated into the worker's global
+ * scope by `importScripts`, in a load-bearing order, are now one ES module.
+ */
+
+import { build } from 'esbuild';
+import { cp, mkdir, rm, stat } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const out = resolve(root, 'dist');
+
+async function exists(path) {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Copy a path if it is there, reporting what was skipped. */
+async function copyIfPresent(from, to, label) {
+  if (!(await exists(from))) {
+    console.warn(`  skipped ${label}: ${from} not found`);
+    return false;
+  }
+  await cp(from, to, { recursive: true });
+  console.log(`  copied  ${label}`);
+  return true;
+}
+
+await rm(out, { recursive: true, force: true });
+await mkdir(out, { recursive: true });
+
+console.log('building service worker');
+await build({
+  entryPoints: [resolve(root, 'packages/extension/src/sw.ts')],
+  outfile: resolve(out, 'js/sw.js'),
+  bundle: true,
+  format: 'esm',
+  // Matches minimum_chrome_version in the manifest.
+  target: 'chrome109',
+  minify: process.env['NODE_ENV'] === 'production',
+  sourcemap: true,
+  logLevel: 'warning',
+});
+
+console.log('copying assets');
+await copyIfPresent(resolve(root, 'packages/extension/manifest.json'), resolve(out, 'manifest.json'), 'manifest');
+
+// The UI is built separately by Vite; its output is laid out to sit at the
+// package root next to the manifest.
+await copyIfPresent(resolve(root, 'packages/ui/dist'), out, 'ui (vite output)');
+
+// Icons and translations still come from the pre-rewrite tree. The `.po` ->
+// messages.json step (previously grunt-po2crx) has not been ported yet, so the
+// already-generated catalogues are reused.
+await copyIfPresent(resolve(root, 'omega-web/img'), resolve(out, 'img'), 'icons');
+await copyIfPresent(
+  resolve(root, 'omega-target-chromium-extension/build/_locales'),
+  resolve(out, '_locales'),
+  '_locales',
+);
+
+console.log(`\ndone -> ${out}`);

--- a/scripts/build-locales.mjs
+++ b/scripts/build-locales.mjs
@@ -1,0 +1,121 @@
+/**
+ * Compile the gettext catalogues in omega-locales/ to Chrome's
+ * _locales/<locale>/messages.json format.
+ *
+ * A port of the legacy grunt-po2crx task, so the output is byte-compatible
+ * with what the old pipeline generated: the same `$(\d+:)?(\w+)\$` placeholder
+ * rewriting, the same `_unused_<i>` fillers for gaps in explicit ordering, and
+ * the single-space-means-empty convention.
+ */
+
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+/**
+ * Locale directories that need renaming for Chrome, which only accepts its
+ * own fixed set of locale codes. Directories mapping to null are skipped
+ * because Chrome has no matching code and errors out on unknown ones.
+ */
+const LOCALE_NAMES = {
+  en_US: 'en',
+  he_IL: 'he',
+  nb_NO: 'nb',
+  pt: 'pt_PT',
+  ach: null, // Acholi
+  lzh: null, // Literary Chinese
+  is: null, // Icelandic
+  si: null, // Sinhala
+  es_AR: null, // es exists separately; es_AR is not a Chrome locale
+  zh_Hant: null, // zh_TW exists separately
+};
+
+/** Parse a PO file into {msgid: msgstr}, ignoring the header entry. */
+function parsePo(source) {
+  const messages = {};
+  let msgid = null;
+  let current = null; // the string being accumulated, 'id' | 'str'
+  let id = '';
+  let str = '';
+
+  const unquote = (line) =>
+    line
+      .slice(line.indexOf('"') + 1, line.lastIndexOf('"'))
+      .replace(/\\([\\"ntr])/g, (_, c) => ({ '\\': '\\', '"': '"', n: '\n', t: '\t', r: '\r' })[c]);
+
+  const flush = () => {
+    if (msgid !== null && msgid !== '') messages[msgid] = str;
+    msgid = null;
+    id = '';
+    str = '';
+  };
+
+  for (const raw of source.split('\n')) {
+    const line = raw.trim();
+    if (line.startsWith('msgid ')) {
+      flush();
+      current = 'id';
+      id = unquote(line);
+      msgid = id;
+    } else if (line.startsWith('msgstr')) {
+      current = 'str';
+      str = unquote(line);
+    } else if (line.startsWith('"')) {
+      if (current === 'id') {
+        id += unquote(line);
+        msgid = id;
+      } else if (current === 'str') {
+        str += unquote(line);
+      }
+    } else if (line === '' || line.startsWith('#')) {
+      // comment or separator; entry is flushed when the next msgid starts
+    }
+  }
+  flush();
+  return messages;
+}
+
+/** The grunt-po2crx message transform: extract $REF$ placeholders. */
+function toChromeMessage(message) {
+  const refs = [];
+  let matchCount = 0;
+  const rewritten = message.replace(/\$(\d+:)?(\w+)\$/g, (_, order, ref) => {
+    matchCount++;
+    refs[order ? parseInt(order) : matchCount] = ref;
+    return '$' + ref + '$';
+  });
+
+  let placeholders;
+  if (matchCount) {
+    placeholders = {};
+    for (let i = 0; i < refs.length; i++) {
+      placeholders[refs[i] ?? '_unused_' + i] = { content: '$' + i };
+    }
+  }
+  return { message: rewritten === ' ' ? '' : rewritten, placeholders };
+}
+
+/** Compile every catalogue into `<outDir>/<locale>/messages.json`. */
+export async function buildLocales(localesDir, outDir) {
+  const built = [];
+  for (const dir of (await readdir(localesDir, { withFileTypes: true })).filter((d) =>
+    d.isDirectory(),
+  )) {
+    const locale = LOCALE_NAMES[dir.name] === undefined ? dir.name : LOCALE_NAMES[dir.name];
+    if (locale === null) continue;
+
+    const po = await readFile(join(localesDir, dir.name, 'LC_MESSAGES', 'omega-web.po'), 'utf8');
+    const result = {};
+    for (const [key, value] of Object.entries(parsePo(po))) {
+      // Untranslated entries are omitted so Chrome falls back to the
+      // default locale instead of showing an empty string.
+      if (!value) continue;
+      result[key] = toChromeMessage(value);
+    }
+
+    const dest = join(outDir, locale);
+    await mkdir(dest, { recursive: true });
+    await writeFile(join(dest, 'messages.json'), JSON.stringify(result));
+    built.push(locale);
+  }
+  return built.sort();
+}

--- a/scripts/dev-chrome.mjs
+++ b/scripts/dev-chrome.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * Launch a Chrome session with the built extension loaded, and leave it
+ * running for manual testing.
+ *
+ * Chrome 137+ ignores --load-extension, so the extension is installed through
+ * the Extensions CDP domain instead. The profile persists between runs so
+ * settings survive a restart; delete the directory to start fresh.
+ */
+
+import { spawn } from 'node:child_process';
+import { mkdir } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const CHROME =
+  process.env['CHROME_PATH'] ?? '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const EXT = process.argv[2] ?? resolve(root, 'dist');
+const PORT = Number(process.env['DEV_CDP_PORT'] ?? 9400);
+const PROFILE = process.env['DEV_PROFILE'] ?? resolve(root, '.dev-chrome-profile');
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Attaching to a Chrome that is already up would silently reuse its profile
+// and skip the install, so refuse rather than half-work.
+try {
+  await fetch(`http://127.0.0.1:${PORT}/json/version`);
+  console.error(`A Chrome is already listening on ${PORT}.`);
+  console.error(`Close it first, or set DEV_CDP_PORT to a free port.`);
+  process.exit(1);
+} catch {
+  /* nothing there, good */
+}
+
+await mkdir(PROFILE, { recursive: true });
+
+const chrome = spawn(
+  CHROME,
+  [
+    `--user-data-dir=${PROFILE}`,
+    '--enable-unsafe-extension-debugging',
+    `--remote-debugging-port=${PORT}`,
+    '--no-first-run',
+    '--no-default-browser-check',
+    'about:blank',
+  ],
+  { stdio: 'ignore', detached: true },
+);
+// Let this process exit while Chrome keeps running.
+chrome.unref();
+
+let version = null;
+for (let i = 0; i < 60 && !version; i++) {
+  await sleep(500);
+  try {
+    version = await (await fetch(`http://127.0.0.1:${PORT}/json/version`)).json();
+  } catch {
+    /* still starting */
+  }
+}
+if (!version) {
+  console.error('Chrome did not expose a debugging endpoint.');
+  process.exit(1);
+}
+
+/** One-shot CDP call over the browser-level socket. */
+async function browserCall(method, params) {
+  const ws = new WebSocket(version.webSocketDebuggerUrl);
+  await new Promise((res, rej) => {
+    ws.addEventListener('open', res, { once: true });
+    ws.addEventListener('error', rej, { once: true });
+  });
+  const result = await new Promise((resolve) => {
+    ws.addEventListener('message', (ev) => {
+      const msg = JSON.parse(ev.data);
+      if (msg.id === 1) resolve(msg);
+    });
+    ws.send(JSON.stringify({ id: 1, method, params }));
+  });
+  ws.close();
+  return result;
+}
+
+const loaded = await browserCall('Extensions.loadUnpacked', { path: EXT });
+if (loaded.error) {
+  console.error('Failed to install the extension: ' + JSON.stringify(loaded.error));
+  process.exit(1);
+}
+const id = loaded.result.id;
+
+await sleep(1500);
+const targets = await (await fetch(`http://127.0.0.1:${PORT}/json/list`)).json();
+const swRunning = targets.some((t) => t.type === 'service_worker' && t.url.includes(id));
+
+// Land on the settings page so the session is immediately useful.
+await fetch(`http://127.0.0.1:${PORT}/json/new?chrome-extension://${id}/options.html`, {
+  method: 'PUT',
+});
+
+console.log(`
+Chrome is running and will stay up after this command returns.
+
+  extension id   ${id}
+  service worker ${swRunning ? 'running' : 'not started yet (it starts on demand)'}
+  loaded from    ${EXT}
+  profile        ${PROFILE}
+  devtools port  ${PORT}
+
+  settings       chrome-extension://${id}/options.html   (opened for you)
+  popup page     chrome-extension://${id}/popup.html
+  manage         chrome://extensions/?id=${id}
+
+To try the toolbar popup and the side panel, pin the extension first:
+click the puzzle-piece icon in the toolbar, then the pin next to SwitchyDelta.
+The popup's settings button opens the side panel.
+
+Rebuild with 'npm run build', then press the reload arrow on
+chrome://extensions to pick up the change.
+`);

--- a/test/e2e/profiles.mjs
+++ b/test/e2e/profiles.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+/**
+ * End-to-end functional test: install the extension into a throwaway Chrome
+ * profile, apply each profile type over the real RPC path, and check what
+ * actually lands in chrome.proxy.settings — including evaluating the generated
+ * PAC script.
+ */
+
+import { spawn } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const EXT = process.argv[2];
+const PORT = 9334;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+class Session {
+  #ws; #id = 0; #pending = new Map();
+  constructor(ws) {
+    this.#ws = ws;
+    ws.addEventListener('message', (ev) => {
+      const m = JSON.parse(ev.data);
+      if (m.id !== undefined) { this.#pending.get(m.id)?.(m); this.#pending.delete(m.id); }
+    });
+  }
+  static async open(url) {
+    const ws = new WebSocket(url);
+    await new Promise((res, rej) => {
+      ws.addEventListener('open', res, { once: true });
+      ws.addEventListener('error', rej, { once: true });
+    });
+    return new Session(ws);
+  }
+  send(method, params = {}) {
+    const id = ++this.#id;
+    return new Promise((resolve) => { this.#pending.set(id, resolve); this.#ws.send(JSON.stringify({ id, method, params })); });
+  }
+  /** Evaluate an async expression and return its value, throwing on error. */
+  async eval(expression) {
+    const r = await this.send('Runtime.evaluate', { expression, awaitPromise: true, returnByValue: true });
+    const exc = r.result?.exceptionDetails;
+    if (exc) throw new Error(exc.exception?.description ?? exc.text);
+    return r.result?.result?.value;
+  }
+  close() { this.#ws.close(); }
+}
+
+try {
+  await fetch(`http://127.0.0.1:${PORT}/json/version`);
+  console.error(`!! port ${PORT} already serving CDP — a stale Chrome is running.`);
+  console.error('   This run would attach to it and reuse its profile. Aborting.');
+  process.exit(2);
+} catch { /* nothing listening, good */ }
+
+const profile = await mkdtemp(join(tmpdir(), 'sd-func-'));
+const chrome = spawn(CHROME, [
+  `--user-data-dir=${profile}`,
+  '--enable-unsafe-extension-debugging',
+  `--remote-debugging-port=${PORT}`,
+  '--no-first-run', '--no-default-browser-check', 'about:blank',
+], { stdio: ['ignore', 'ignore', 'ignore'], detached: true });
+
+let version = null;
+for (let i = 0; i < 40 && !version; i++) {
+  await sleep(500);
+  try { version = await (await fetch(`http://127.0.0.1:${PORT}/json/version`)).json(); } catch {}
+}
+
+const browser = await Session.open(version.webSocketDebuggerUrl);
+const { result: { id: extId } } = await browser.send('Extensions.loadUnpacked', { path: EXT });
+await sleep(2500);
+
+const targets = await (await fetch(`http://127.0.0.1:${PORT}/json/list`)).json();
+const swTarget = targets.find((t) => t.type === 'service_worker' && t.url.includes(extId));
+const sw = await Session.open(swTarget.webSocketDebuggerUrl);
+
+// An extension page gives us a context with chrome.runtime, so profile changes
+// go through the same RPC path the real UI uses.
+const tab = await (await fetch(
+  `http://127.0.0.1:${PORT}/json/new?chrome-extension://${extId}/popup.html`, { method: 'PUT' })).json();
+const page = await Session.open(tab.webSocketDebuggerUrl);
+await page.send('Runtime.enable');
+await sleep(1000);
+
+const applyProfile = (name) =>
+  page.eval(`chrome.runtime.sendMessage({method:'applyProfile',args:[${JSON.stringify(name)}]})
+             .then(r => JSON.stringify(r))`);
+
+const proxyConfig = () =>
+  sw.eval(`new Promise(r => chrome.proxy.settings.get({}, c => r(JSON.stringify(c.value))))`)
+    .then(JSON.parse);
+
+let failures = 0;
+const check = (label, actual, expected) => {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (!ok) failures++;
+  console.log(`  ${ok ? 'PASS' : 'FAIL'}  ${label}`);
+  if (!ok) console.log(`          expected ${JSON.stringify(expected)}\n          actual   ${JSON.stringify(actual)}`);
+};
+
+console.log(`extension: ${extId}\n`);
+
+// --- FixedProfile ----------------------------------------------------------
+console.log('=== apply "proxy" (FixedProfile) ===');
+console.log('  rpc reply: ' + (await applyProfile('proxy')));
+await sleep(800);
+let cfg = await proxyConfig();
+check('mode is fixed_servers', cfg.mode, 'fixed_servers');
+// An http-scheme fallback cannot go in rules.fallbackProxy, so it is promoted.
+check('singleProxy host', cfg.rules?.singleProxy?.host, 'proxy.example.com');
+check('singleProxy port', cfg.rules?.singleProxy?.port, 8080);
+// Chrome's bypass list wants IPv6 literals bracketed, which is what
+// Conditions.str emits for a BypassCondition.
+check('bypass list', cfg.rules?.bypassList, ['127.0.0.1', '[::1]', 'localhost']);
+
+// --- SwitchProfile ---------------------------------------------------------
+console.log('\n=== apply "auto switch" (SwitchProfile -> generated PAC) ===');
+console.log('  rpc reply: ' + (await applyProfile('auto switch')));
+await sleep(800);
+cfg = await proxyConfig();
+check('mode is pac_script', cfg.mode, 'pac_script');
+
+const pac = cfg.pacScript?.data ?? '';
+console.log(`\n  generated PAC (${pac.length} bytes):`);
+console.log('  ' + pac.replace(/\n/g, '\n  '));
+
+console.log('\n=== resolve URLs through the generated PAC ===');
+const resolve = async (url, host) =>
+  page.eval(`(function(){ ${pac}\n return FindProxyForURL(${JSON.stringify(url)}, ${JSON.stringify(host)}); })()`);
+
+check('internal.example.com -> DIRECT (rule 1)',
+  await resolve('http://internal.example.com/', 'internal.example.com'), 'DIRECT');
+check('www.example.com -> proxy (rule 2)',
+  await resolve('http://www.example.com/', 'www.example.com'), 'PROXY proxy.example.com:8080');
+check('example.com -> proxy (apex, wildcard magic)',
+  await resolve('http://example.com/', 'example.com'), 'PROXY proxy.example.com:8080');
+check('other.org -> DIRECT (default)',
+  await resolve('http://other.org/', 'other.org'), 'DIRECT');
+check('127.0.0.1 -> DIRECT (bypass inside proxy profile)',
+  await resolve('http://127.0.0.1/', '127.0.0.1'), 'DIRECT');
+
+// --- DirectProfile ---------------------------------------------------------
+console.log('\n=== apply "direct" ===');
+console.log('  rpc reply: ' + (await applyProfile('direct')));
+await sleep(800);
+cfg = await proxyConfig();
+check('mode is direct', cfg.mode, 'direct');
+
+console.log(`\n=== RESULT: ${failures === 0 ? 'all checks passed' : failures + ' FAILURES'} ===`);
+
+sw.close(); page.close(); browser.close();
+try { process.kill(-chrome.pid, 'SIGKILL'); } catch { chrome.kill('SIGKILL'); }
+await sleep(1000);
+await rm(profile, { recursive: true, force: true });
+process.exit(failures ? 1 : 0);

--- a/test/e2e/profiles.mjs
+++ b/test/e2e/profiles.mjs
@@ -11,7 +11,13 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const CHROME =
+  process.env.CHROME_PATH ?? '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+// The "new" headless mode supports extensions; the sandbox flags are for CI
+// runners where the Chrome sandbox cannot be used.
+const HEADLESS_FLAGS = process.env.HEADLESS
+  ? ['--headless=new', '--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage']
+  : [];
 const EXT = process.argv[2];
 const PORT = 9334;
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
@@ -56,6 +62,7 @@ try {
 
 const profile = await mkdtemp(join(tmpdir(), 'sd-func-'));
 const chrome = spawn(CHROME, [
+  ...HEADLESS_FLAGS,
   `--user-data-dir=${profile}`,
   '--enable-unsafe-extension-debugging',
   `--remote-debugging-port=${PORT}`,

--- a/test/e2e/rule-list.mjs
+++ b/test/e2e/rule-list.mjs
@@ -9,6 +9,8 @@
 
 import { spawn } from 'node:child_process';
 import { mkdtemp, rm } from 'node:fs/promises';
+import { createServer as createHttpServer, request as httpRequest } from 'node:http';
+import net from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -28,6 +30,46 @@ const PROXY = {
 };
 const GFWLIST = 'https://raw.githubusercontent.com/gfwlist/gfwlist/refs/heads/master/gfwlist.txt';
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// The download deliberately goes through a local proxy, the way a user behind
+// one would fetch the list. On a dev machine that is whatever already listens
+// on the configured port; anywhere else (CI) a minimal CONNECT proxy is
+// started here so the test carries its own dependency.
+function portOpen(host, port) {
+  return new Promise((resolve) => {
+    const socket = net.connect({ host, port, timeout: 1000 });
+    socket.once('connect', () => { socket.destroy(); resolve(true); });
+    socket.once('error', () => resolve(false));
+    socket.once('timeout', () => { socket.destroy(); resolve(false); });
+  });
+}
+
+let builtinProxy = null;
+if (!(await portOpen(PROXY.host, PROXY.port))) {
+  builtinProxy = createHttpServer((req, res) => {
+    // Absolute-form plain HTTP proxying.
+    const url = new URL(req.url);
+    const upstream = httpRequest({
+      host: url.hostname, port: url.port || 80, method: req.method,
+      path: url.pathname + url.search, headers: req.headers,
+    }, (up) => { res.writeHead(up.statusCode, up.headers); up.pipe(res); });
+    upstream.on('error', () => res.destroy());
+    req.pipe(upstream);
+  });
+  builtinProxy.on('connect', (req, socket, head) => {
+    const [host, port] = req.url.split(':');
+    const up = net.connect(Number(port) || 443, host, () => {
+      socket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+      up.write(head);
+      up.pipe(socket);
+      socket.pipe(up);
+    });
+    up.on('error', () => socket.destroy());
+    socket.on('error', () => up.destroy());
+  });
+  await new Promise((r) => builtinProxy.listen(PROXY.port, PROXY.host, r));
+  console.log(`(nothing on ${PROXY.host}:${PROXY.port} — started built-in CONNECT proxy)`);
+}
 
 class Session {
   #ws; #id = 0; #pending = new Map();
@@ -198,6 +240,7 @@ for (const [url, host, expected] of [
 console.log(`\n=== RESULT: ${failures === 0 ? 'all checks passed' : failures + ' FAILURES'} ===`);
 
 sw.close(); page.close(); browser.close();
+builtinProxy?.close();
 try { process.kill(-chrome.pid, 'SIGKILL'); } catch { chrome.kill('SIGKILL'); }
 await sleep(1000);
 await rm(profile, { recursive: true, force: true });

--- a/test/e2e/rule-list.mjs
+++ b/test/e2e/rule-list.mjs
@@ -12,7 +12,13 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const CHROME =
+  process.env.CHROME_PATH ?? '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+// The "new" headless mode supports extensions; the sandbox flags are for CI
+// runners where the Chrome sandbox cannot be used.
+const HEADLESS_FLAGS = process.env.HEADLESS
+  ? ['--headless=new', '--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage']
+  : [];
 const EXT = process.argv[2];
 const PORT = 9335;
 const PROXY = {
@@ -62,6 +68,7 @@ try {
 
 const profile = await mkdtemp(join(tmpdir(), 'sd-gfw-'));
 const chrome = spawn(CHROME, [
+  ...HEADLESS_FLAGS,
   `--user-data-dir=${profile}`, '--enable-unsafe-extension-debugging',
   `--remote-debugging-port=${PORT}`, '--no-first-run', '--no-default-browser-check', 'about:blank',
 ], { stdio: ['ignore', 'ignore', 'ignore'], detached: true });

--- a/test/e2e/rule-list.mjs
+++ b/test/e2e/rule-list.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+/**
+ * Real-world test: a local proxy plus the gfwlist rule list.
+ *
+ * Exercises the download path (fetch + content-type hints), the base64
+ * preprocess (atob/TextDecoder in place of Buffer), the AutoProxy parser, and
+ * PAC generation at real scale (~4.5k rules).
+ */
+
+import { spawn } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const EXT = process.argv[2];
+const PORT = 9335;
+const PROXY = {
+  scheme: 'http',
+  host: process.env.E2E_PROXY_HOST ?? '127.0.0.1',
+  port: Number(process.env.E2E_PROXY_PORT ?? 7890),
+};
+const GFWLIST = 'https://raw.githubusercontent.com/gfwlist/gfwlist/refs/heads/master/gfwlist.txt';
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+class Session {
+  #ws; #id = 0; #pending = new Map();
+  constructor(ws) {
+    this.#ws = ws;
+    ws.addEventListener('message', (ev) => {
+      const m = JSON.parse(ev.data);
+      if (m.id !== undefined) { this.#pending.get(m.id)?.(m); this.#pending.delete(m.id); }
+    });
+  }
+  static async open(url) {
+    const ws = new WebSocket(url);
+    await new Promise((res, rej) => {
+      ws.addEventListener('open', res, { once: true });
+      ws.addEventListener('error', rej, { once: true });
+    });
+    return new Session(ws);
+  }
+  send(method, params = {}) {
+    const id = ++this.#id;
+    return new Promise((r) => { this.#pending.set(id, r); this.#ws.send(JSON.stringify({ id, method, params })); });
+  }
+  async eval(expression) {
+    const r = await this.send('Runtime.evaluate', { expression, awaitPromise: true, returnByValue: true });
+    const exc = r.result?.exceptionDetails;
+    if (exc) throw new Error(exc.exception?.description ?? exc.text);
+    return r.result?.result?.value;
+  }
+  close() { this.#ws.close(); }
+}
+
+try {
+  await fetch(`http://127.0.0.1:${PORT}/json/version`);
+  console.error(`!! port ${PORT} already serving CDP — a stale Chrome is running.`);
+  console.error('   This run would attach to it and reuse its profile. Aborting.');
+  process.exit(2);
+} catch { /* nothing listening, good */ }
+
+const profile = await mkdtemp(join(tmpdir(), 'sd-gfw-'));
+const chrome = spawn(CHROME, [
+  `--user-data-dir=${profile}`, '--enable-unsafe-extension-debugging',
+  `--remote-debugging-port=${PORT}`, '--no-first-run', '--no-default-browser-check', 'about:blank',
+], { stdio: ['ignore', 'ignore', 'ignore'], detached: true });
+
+let version = null;
+for (let i = 0; i < 40 && !version; i++) {
+  await sleep(500);
+  try { version = await (await fetch(`http://127.0.0.1:${PORT}/json/version`)).json(); } catch {}
+}
+const browser = await Session.open(version.webSocketDebuggerUrl);
+const { result: { id: extId } } = await browser.send('Extensions.loadUnpacked', { path: EXT });
+await sleep(2500);
+
+const targets = await (await fetch(`http://127.0.0.1:${PORT}/json/list`)).json();
+const sw = await Session.open(targets.find((t) => t.type === 'service_worker' && t.url.includes(extId)).webSocketDebuggerUrl);
+const tab = await (await fetch(`http://127.0.0.1:${PORT}/json/new?chrome-extension://${extId}/popup.html`, { method: 'PUT' })).json();
+const page = await Session.open(tab.webSocketDebuggerUrl);
+await page.send('Runtime.enable');
+await sleep(800);
+
+const rpc = (method, ...args) =>
+  page.eval(`chrome.runtime.sendMessage({method:${JSON.stringify(method)},args:${JSON.stringify(args)}})
+             .then(r => JSON.stringify(r ?? null))`).then((s) => JSON.parse(s));
+
+let failures = 0;
+const norm = (v) => {
+  if (Array.isArray(v)) return v.map(norm);
+  if (v && typeof v === 'object')
+    return Object.fromEntries(Object.keys(v).sort().map((k) => [k, norm(v[k])]));
+  return v;
+};
+const check = (label, actual, expected) => {
+  const ok = JSON.stringify(norm(actual)) === JSON.stringify(norm(expected));
+  if (!ok) failures++;
+  console.log(`  ${ok ? 'PASS' : 'FAIL'}  ${label}${ok ? '' : `\n          expected ${JSON.stringify(expected)}\n          actual   ${JSON.stringify(actual)}`}`);
+};
+
+console.log(`extension: ${extId}\n`);
+
+console.log('=== add profiles ===');
+const brief = (r) => (r?.error ? 'ERROR ' + JSON.stringify(r.error) : 'ok');
+console.log('  local  : ' + brief(await rpc('addProfile', {
+  name: 'local', profileType: 'FixedProfile', color: '#99ccee', revision: 'test1',
+  fallbackProxy: PROXY,
+  bypassList: [
+    { conditionType: 'BypassCondition', pattern: '127.0.0.1' },
+    { conditionType: 'BypassCondition', pattern: '[::1]' },
+    { conditionType: 'BypassCondition', pattern: 'localhost' },
+  ],
+})));
+console.log('  gfwlist: ' + brief(await rpc('addProfile', {
+  name: 'gfwlist', profileType: 'RuleListProfile', format: 'AutoProxy', color: '#dd7788',
+  revision: 'test2', sourceUrl: GFWLIST, ruleList: '',
+  matchProfileName: 'local', defaultProfileName: 'direct',
+})));
+
+// Download through the local proxy, the way a user behind it would.
+console.log('\n=== apply "local" so the download uses the proxy ===');
+await rpc('applyProfile', 'local');
+await sleep(600);
+let cfg = JSON.parse(await sw.eval(`new Promise(r => chrome.proxy.settings.get({}, c => r(JSON.stringify(c.value))))`));
+check('mode is fixed_servers', cfg.mode, 'fixed_servers');
+check('singleProxy', cfg.rules?.singleProxy, PROXY);
+
+console.log('\n=== download + parse gfwlist ===');
+const t0 = Date.now();
+const upd = await rpc('updateProfile', 'gfwlist');
+const downloadMs = Date.now() - t0;
+console.log('  updateProfile -> ' + brief(upd));
+console.log(`  took ${downloadMs} ms`);
+
+const stored = JSON.parse(await sw.eval(
+  `chrome.storage.local.get('+gfwlist').then(s => JSON.stringify({
+     bytes: (s['+gfwlist'].ruleList||'').length,
+     head: (s['+gfwlist'].ruleList||'').slice(0, 40),
+     format: s['+gfwlist'].format,
+     lastUpdate: !!s['+gfwlist'].lastUpdate,
+   }))`));
+console.log(`  stored ruleList: ${stored.bytes} bytes, format=${stored.format}, lastUpdate=${stored.lastUpdate}`);
+check('rule list was base64-decoded', stored.head.startsWith('[AutoProxy'), true);
+check('format detected as AutoProxy', stored.format, 'AutoProxy');
+
+console.log('\n=== apply "gfwlist" (generate PAC from ~4.5k rules) ===');
+const t1 = Date.now();
+await rpc('applyProfile', 'gfwlist');
+const applyMs = Date.now() - t1;
+await sleep(1200);
+cfg = JSON.parse(await sw.eval(`new Promise(r => chrome.proxy.settings.get({}, c => r(JSON.stringify(c.value))))`));
+check('mode is pac_script', cfg.mode, 'pac_script');
+const pac = cfg.pacScript?.data ?? '';
+console.log(`  PAC generated: ${pac.length} bytes in ~${applyMs} ms (apply round trip)`);
+console.log(`  PAC head: ${pac.slice(0, 120)}...`);
+
+console.log('\n=== PAC generation cost (in the worker, no RPC) ===');
+const timing = JSON.parse(await page.eval(`(async () => {
+  const r = await chrome.runtime.sendMessage({method:'pacForProfile', args:['gfwlist']});
+  const t = [];
+  for (let i = 0; i < 5; i++) {
+    const s = performance.now();
+    await chrome.runtime.sendMessage({method:'pacForProfile', args:['gfwlist']});
+    t.push(performance.now() - s);
+  }
+  return JSON.stringify({ bytes: (r?.result||'').length, times: t.map(x => Math.round(x)) });
+})()`));
+console.log('  round trips (ms): ' + timing.times.join(', ') + `  [PAC ${timing.bytes} bytes]`);
+
+console.log('\n=== resolve real URLs through the generated PAC ===');
+const expectProxy = `PROXY ${PROXY.host}:${PROXY.port}`;
+const resolve = (url, host) =>
+  page.eval(`(function(){ ${JSON.stringify(pac)} ; })(), (function(){ ${pac}
+    return FindProxyForURL(${JSON.stringify(url)}, ${JSON.stringify(host)}); })()`);
+
+for (const [url, host, expected] of [
+  ['https://twitter.com/', 'twitter.com', expectProxy],
+  ['https://www.google.com/', 'www.google.com', expectProxy],
+  ['https://www.youtube.com/', 'www.youtube.com', expectProxy],
+  ['https://www.wikipedia.org/', 'www.wikipedia.org', expectProxy],
+  ['https://www.baidu.com/', 'www.baidu.com', 'DIRECT'],
+  ['https://www.qq.com/', 'www.qq.com', 'DIRECT'],
+  ['http://localhost/', 'localhost', 'DIRECT'],
+]) {
+  let got;
+  try { got = await resolve(url, host); } catch (e) { got = 'THREW: ' + e.message; }
+  check(`${host} -> ${expected}`, got, expected);
+}
+
+console.log(`\n=== RESULT: ${failures === 0 ? 'all checks passed' : failures + ' FAILURES'} ===`);
+
+sw.close(); page.close(); browser.close();
+try { process.kill(-chrome.pid, 'SIGKILL'); } catch { chrome.kill('SIGKILL'); }
+await sleep(1000);
+await rm(profile, { recursive: true, force: true });
+process.exit(failures ? 1 : 0);

--- a/test/e2e/side-panel.mjs
+++ b/test/e2e/side-panel.mjs
@@ -9,7 +9,13 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const CHROME =
+  process.env.CHROME_PATH ?? '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+// The "new" headless mode supports extensions; the sandbox flags are for CI
+// runners where the Chrome sandbox cannot be used.
+const HEADLESS_FLAGS = process.env.HEADLESS
+  ? ['--headless=new', '--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage']
+  : [];
 const EXT = process.argv[2];
 const PORT = 9336;
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
@@ -50,6 +56,7 @@ try {
 
 const profile = await mkdtemp(join(tmpdir(), 'sd-sp-'));
 const chrome = spawn(CHROME, [
+  ...HEADLESS_FLAGS,
   `--user-data-dir=${profile}`, '--enable-unsafe-extension-debugging',
   `--remote-debugging-port=${PORT}`, '--no-first-run', '--no-default-browser-check', 'about:blank',
 ], { stdio: ['ignore', 'ignore', 'ignore'], detached: true });

--- a/test/e2e/side-panel.mjs
+++ b/test/e2e/side-panel.mjs
@@ -106,15 +106,15 @@ const layout = JSON.parse(await op.evalGesture(`JSON.stringify({
   clientW: document.documentElement.clientWidth,
   overflowsX: document.body.scrollWidth > document.documentElement.clientWidth + 1,
   sidebarDisplay: getComputedStyle(document.querySelector('.om-sidebar nav')).display,
-  navScrollable: (() => { const n = document.querySelector('.om-sidebar nav');
-    return n.scrollWidth > n.clientWidth; })(),
+  navScrollable: (() => { const lists = [...document.querySelectorAll('.om-sidebar .om-list')];
+    return lists.length > 0 && lists.every((l) => getComputedStyle(l).overflowX === 'auto'); })(),
   openInTabVisible: getComputedStyle(document.querySelector('#om-open-tab')).display !== 'none',
   navItems: document.querySelectorAll('.om-sidebar .om-item').length,
 })`));
 check('no horizontal overflow of the page', layout.overflowsX, false);
 check('body fits the panel width', layout.bodyScrollW, layout.clientW);
 check('nav collapsed to a scrollable strip', layout.sidebarDisplay, 'flex');
-check('nav scrolls internally instead of widening the page', layout.navScrollable, true);
+check('nav rows scroll internally instead of widening the page', layout.navScrollable, true);
 check('open-in-tab escape hatch is visible', layout.openInTabVisible, true);
 if (failures) console.log('\n=== elements exceeding 360px ===');
 if (failures) console.log(await op.evalGesture(`(() => {

--- a/test/e2e/side-panel.mjs
+++ b/test/e2e/side-panel.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/**
+ * Side panel: the settings page is registered as a side panel, opens through
+ * chrome.sidePanel.open, and lays out without horizontal overflow at panel
+ * width (~360px).
+ */
+import { spawn } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const EXT = process.argv[2];
+const PORT = 9336;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+class Session {
+  #ws; #id = 0; #pending = new Map();
+  constructor(ws) {
+    this.#ws = ws;
+    ws.addEventListener('message', (e) => {
+      const m = JSON.parse(e.data);
+      if (m.id !== undefined) { this.#pending.get(m.id)?.(m); this.#pending.delete(m.id); }
+    });
+  }
+  static async open(url) {
+    const ws = new WebSocket(url);
+    await new Promise((res, rej) => { ws.addEventListener('open', res, { once: true }); ws.addEventListener('error', rej, { once: true }); });
+    return new Session(ws);
+  }
+  send(method, params = {}) {
+    const id = ++this.#id;
+    return new Promise((r) => { this.#pending.set(id, r); this.#ws.send(JSON.stringify({ id, method, params })); });
+  }
+  /** userGesture: true makes Chrome treat this as user-activated. */
+  async evalGesture(expression) {
+    const r = await this.send('Runtime.evaluate', {
+      expression, awaitPromise: true, returnByValue: true, userGesture: true,
+    });
+    if (r.result?.exceptionDetails) return 'THREW: ' + (r.result.exceptionDetails.exception?.description ?? '').split('\n')[0];
+    return r.result?.result?.value;
+  }
+  close() { this.#ws.close(); }
+}
+
+try {
+  await fetch(`http://127.0.0.1:${PORT}/json/version`);
+  console.error(`!! port ${PORT} busy — stale Chrome. Aborting.`); process.exit(2);
+} catch {}
+
+const profile = await mkdtemp(join(tmpdir(), 'sd-sp-'));
+const chrome = spawn(CHROME, [
+  `--user-data-dir=${profile}`, '--enable-unsafe-extension-debugging',
+  `--remote-debugging-port=${PORT}`, '--no-first-run', '--no-default-browser-check', 'about:blank',
+], { stdio: ['ignore', 'ignore', 'ignore'], detached: true });
+
+let version = null;
+for (let i = 0; i < 40 && !version; i++) {
+  await sleep(500);
+  try { version = await (await fetch(`http://127.0.0.1:${PORT}/json/version`)).json(); } catch {}
+}
+const browser = await Session.open(version.webSocketDebuggerUrl);
+const { result: { id: extId } } = await browser.send('Extensions.loadUnpacked', { path: EXT });
+await sleep(2500);
+
+const tab = await (await fetch(`http://127.0.0.1:${PORT}/json/new?chrome-extension://${extId}/popup.html`, { method: 'PUT' })).json();
+const page = await Session.open(tab.webSocketDebuggerUrl);
+await page.send('Runtime.enable');
+await sleep(800);
+
+let failures = 0;
+const check = (label, actual, expected) => {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (!ok) failures++;
+  console.log(`  ${ok ? 'PASS' : 'FAIL'}  ${label}` +
+    (ok ? '' : `\n          expected ${JSON.stringify(expected)}\n          actual   ${JSON.stringify(actual)}`));
+};
+
+console.log('=== side panel registration ===');
+check('manifest declares side_panel',
+  JSON.parse(await page.evalGesture(`JSON.stringify(chrome.runtime.getManifest().side_panel)`)),
+  { default_path: 'options.html' });
+check('sidePanel.open is available',
+  await page.evalGesture(`typeof chrome.sidePanel?.open`), 'function');
+check('panel is enabled and points at options.html',
+  JSON.parse(await page.evalGesture(`chrome.sidePanel.getOptions({}).then(o => JSON.stringify(o))`)),
+  { enabled: true, path: 'options.html' });
+
+console.log('\n=== opening the panel ===');
+check('open({windowId: WINDOW_ID_CURRENT})', await page.evalGesture(
+  `chrome.sidePanel.open({windowId: chrome.windows.WINDOW_ID_CURRENT}).then(() => 'OK').catch(e => 'REJECTED: ' + e.message)`), 'OK');
+check('open({windowId: <real id>})', await page.evalGesture(
+  `chrome.windows.getCurrent().then(w => chrome.sidePanel.open({windowId: w.id})).then(() => 'OK').catch(e => 'REJECTED: ' + e.message)`), 'OK');
+
+
+// Layout check at side-panel width.
+const opts = await (await fetch(`http://127.0.0.1:${PORT}/json/new?chrome-extension://${extId}/options.html`, { method: 'PUT' })).json();
+const op = await Session.open(opts.webSocketDebuggerUrl);
+await op.send('Runtime.enable');
+await op.send('Emulation.setDeviceMetricsOverride', { width: 360, height: 700, deviceScaleFactor: 1, mobile: false });
+await sleep(1500);
+
+console.log('\n=== options.html at 360px (side panel width) ===');
+const layout = JSON.parse(await op.evalGesture(`JSON.stringify({
+  bodyScrollW: document.body.scrollWidth,
+  clientW: document.documentElement.clientWidth,
+  overflowsX: document.body.scrollWidth > document.documentElement.clientWidth + 1,
+  sidebarDisplay: getComputedStyle(document.querySelector('.om-sidebar nav')).display,
+  navScrollable: (() => { const n = document.querySelector('.om-sidebar nav');
+    return n.scrollWidth > n.clientWidth; })(),
+  openInTabVisible: getComputedStyle(document.querySelector('#om-open-tab')).display !== 'none',
+  navItems: document.querySelectorAll('.om-sidebar .om-item').length,
+})`));
+check('no horizontal overflow of the page', layout.overflowsX, false);
+check('body fits the panel width', layout.bodyScrollW, layout.clientW);
+check('nav collapsed to a scrollable strip', layout.sidebarDisplay, 'flex');
+check('nav scrolls internally instead of widening the page', layout.navScrollable, true);
+check('open-in-tab escape hatch is visible', layout.openInTabVisible, true);
+if (failures) console.log('\n=== elements exceeding 360px ===');
+if (failures) console.log(await op.evalGesture(`(() => {
+  const w = document.documentElement.clientWidth;
+  const out = [];
+  for (const el of document.querySelectorAll('*')) {
+    const r = el.getBoundingClientRect();
+    if (r.right > w + 0.5 || r.width > w + 0.5) {
+      out.push(\`  \${el.tagName.toLowerCase()}\${el.id ? '#'+el.id : ''}\${el.className && typeof el.className === 'string' ? '.'+el.className.trim().split(/\\s+/).join('.') : ''}  width=\${Math.round(r.width)} right=\${Math.round(r.right)}\`);
+    }
+  }
+  return out.slice(0, 12).join('\\n') || '  (none)';
+})()`));
+op.close();
+
+console.log(`\n=== RESULT: ${failures === 0 ? 'all checks passed' : failures + ' FAILURES'} ===`);
+
+page.close(); browser.close();
+try { process.kill(-chrome.pid, 'SIGKILL'); } catch { chrome.kill('SIGKILL'); }
+await sleep(800);
+await rm(profile, { recursive: true, force: true });
+process.exit(failures ? 1 : 0);

--- a/test/e2e/smoke.mjs
+++ b/test/e2e/smoke.mjs
@@ -9,7 +9,13 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const CHROME =
+  process.env.CHROME_PATH ?? '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+// The "new" headless mode supports extensions; the sandbox flags are for CI
+// runners where the Chrome sandbox cannot be used.
+const HEADLESS_FLAGS = process.env.HEADLESS
+  ? ['--headless=new', '--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage']
+  : [];
 const EXT = process.argv[2];
 const PORT = 9333;
 
@@ -76,7 +82,8 @@ console.log(`extension: ${EXT}\n`);
 const chrome = spawn(
   CHROME,
   [
-    `--user-data-dir=${profile}`,
+    ...HEADLESS_FLAGS,
+  `--user-data-dir=${profile}`,
     // Chrome 137+ ignores --load-extension entirely; the extension is
     // installed below via the Extensions CDP domain, which needs this flag.
     '--enable-unsafe-extension-debugging',

--- a/test/e2e/smoke.mjs
+++ b/test/e2e/smoke.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+/**
+ * Load the built extension into a throwaway Chrome profile and report whether
+ * the service worker boots cleanly. Drives Chrome over CDP.
+ */
+
+import { spawn } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const EXT = process.argv[2];
+const PORT = 9333;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function cdpList() {
+  const res = await fetch(`http://127.0.0.1:${PORT}/json/list`);
+  return res.json();
+}
+
+/** Minimal CDP client over the debugger WebSocket. */
+class Session {
+  #ws;
+  #id = 0;
+  #pending = new Map();
+  events = [];
+
+  constructor(ws) {
+    this.#ws = ws;
+    ws.addEventListener('message', (ev) => {
+      const msg = JSON.parse(ev.data);
+      if (msg.id !== undefined) {
+        this.#pending.get(msg.id)?.(msg);
+        this.#pending.delete(msg.id);
+      } else {
+        this.events.push(msg);
+      }
+    });
+  }
+
+  static async open(url) {
+    const ws = new WebSocket(url);
+    await new Promise((resolve, reject) => {
+      ws.addEventListener('open', resolve, { once: true });
+      ws.addEventListener('error', reject, { once: true });
+    });
+    return new Session(ws);
+  }
+
+  send(method, params = {}) {
+    const id = ++this.#id;
+    return new Promise((resolve) => {
+      this.#pending.set(id, resolve);
+      this.#ws.send(JSON.stringify({ id, method, params }));
+    });
+  }
+
+  close() {
+    this.#ws.close();
+  }
+}
+
+try {
+  await fetch(`http://127.0.0.1:${PORT}/json/version`);
+  console.error(`!! port ${PORT} already serving CDP — a stale Chrome is running.`);
+  console.error('   This run would attach to it and reuse its profile. Aborting.');
+  process.exit(2);
+} catch { /* nothing listening, good */ }
+
+const profile = await mkdtemp(join(tmpdir(), 'sd-smoke-'));
+console.log(`profile: ${profile}`);
+console.log(`extension: ${EXT}\n`);
+
+const chrome = spawn(
+  CHROME,
+  [
+    `--user-data-dir=${profile}`,
+    // Chrome 137+ ignores --load-extension entirely; the extension is
+    // installed below via the Extensions CDP domain, which needs this flag.
+    '--enable-unsafe-extension-debugging',
+    `--remote-debugging-port=${PORT}`,
+    '--no-first-run',
+    '--no-default-browser-check',
+    '--disable-background-timer-throttling',
+    'about:blank',
+  ],
+  { stdio: ['ignore', 'pipe', 'pipe'], detached: true },
+);
+
+let chromeErr = '';
+chrome.stderr.on('data', (d) => (chromeErr += d));
+
+let version = null;
+for (let i = 0; i < 40; i++) {
+  await sleep(500);
+  try {
+    version = await (await fetch(`http://127.0.0.1:${PORT}/json/version`)).json();
+    if (version) break;
+  } catch {
+    /* not up yet */
+  }
+}
+if (!version) {
+  console.log('!! Chrome did not expose a debugging endpoint');
+  process.exit(1);
+}
+
+// Install the unpacked extension through the browser-level session.
+const browser = await Session.open(version.webSocketDebuggerUrl);
+const loaded = await browser.send('Extensions.loadUnpacked', { path: EXT });
+if (loaded.error) {
+  console.log('!! Extensions.loadUnpacked failed: ' + JSON.stringify(loaded.error));
+  process.exit(1);
+}
+const loadedId = loaded.result?.id;
+console.log(`loaded extension id: ${loadedId}`);
+await sleep(2000);
+
+let targets = await cdpList();
+
+console.log('=== CDP targets ===');
+for (const t of targets) console.log(`  ${t.type.padEnd(16)} ${t.url}`);
+
+const sw = targets.find((t) => t.type === 'service_worker' && t.url.includes(loadedId));
+const extId = loadedId;
+
+console.log(`\nextension id: ${extId || '(not detected)'}`);
+
+let failed = false;
+
+if (!sw) {
+  console.log('\n!! service worker target not found — extension did not load or SW did not start');
+  failed = true;
+} else {
+  const s = await Session.open(sw.webSocketDebuggerUrl);
+  await s.send('Runtime.enable');
+  await s.send('Log.enable');
+  await sleep(2500);
+
+  const errors = s.events.filter(
+    (e) =>
+      e.method === 'Runtime.exceptionThrown' ||
+      (e.method === 'Log.entryAdded' && e.params?.entry?.level === 'error') ||
+      (e.method === 'Runtime.consoleAPICalled' && e.params?.type === 'error'),
+  );
+
+  console.log(`\n=== service worker errors: ${errors.length} ===`);
+  for (const e of errors) {
+    const d = e.params?.exceptionDetails;
+    console.log('  ' + (d?.exception?.description ?? d?.text ?? e.params?.entry?.text ??
+      JSON.stringify(e.params?.args?.map((a) => a.value ?? a.description))));
+  }
+  if (errors.length) failed = true;
+
+  const probe = await s.send('Runtime.evaluate', {
+    expression: `(async () => {
+      const cfg = await new Promise(r => chrome.proxy.settings.get({}, r));
+      const st = await chrome.storage.local.get(null);
+      return JSON.stringify({
+        proxyMode: cfg?.value?.mode ?? null,
+        levelOfControl: cfg?.levelOfControl ?? null,
+        profileKeys: Object.keys(st).filter(k => k[0] === '+'),
+        schemaVersion: st.schemaVersion ?? null,
+      });
+    })()`,
+    awaitPromise: true,
+    returnByValue: true,
+  });
+
+  console.log('\n=== worker state probe ===');
+  const val = probe.result?.result?.value;
+  const exc = probe.result?.exceptionDetails;
+  if (exc) {
+    console.log('  probe threw: ' + (exc.exception?.description ?? exc.text));
+    failed = true;
+  } else {
+    console.log('  ' + val);
+  }
+  s.close();
+}
+
+// Load the popup as a page and check it renders without script errors.
+if (extId) {
+  const res = await fetch(`http://127.0.0.1:${PORT}/json/new?chrome-extension://${extId}/popup.html`, { method: 'PUT' });
+  const tab = await res.json().catch(() => null);
+  if (tab?.webSocketDebuggerUrl) {
+    const p = await Session.open(tab.webSocketDebuggerUrl);
+    await p.send('Runtime.enable');
+    await p.send('Log.enable');
+    await sleep(2500);
+    const perrs = p.events.filter(
+      (e) =>
+        e.method === 'Runtime.exceptionThrown' ||
+        (e.method === 'Log.entryAdded' && e.params?.entry?.level === 'error'),
+    );
+    console.log(`\n=== popup errors: ${perrs.length} ===`);
+    for (const e of perrs) {
+      const d = e.params?.exceptionDetails;
+      console.log('  ' + (d?.exception?.description ?? d?.text ?? e.params?.entry?.text));
+    }
+    if (perrs.length) failed = true;
+
+    const dom = await p.send('Runtime.evaluate', {
+      expression: `JSON.stringify({
+        profiles: [...document.querySelectorAll('#om-profiles .om-item')].map(e => e.textContent.trim()),
+        error: document.querySelector('#om-error')?.hidden === false
+          ? document.querySelector('#om-error').textContent : null,
+      })`,
+      returnByValue: true,
+    });
+    console.log('\n=== popup rendered ===');
+    console.log('  ' + dom.result?.result?.value);
+    p.close();
+  }
+}
+
+console.log(`\n=== RESULT: ${failed ? 'FAILURES DETECTED' : 'clean'} ===`);
+if (chromeErr.trim()) {
+  const lines = chromeErr.trim().split('\n').filter((l) => /error|fail|invalid|manifest/i.test(l));
+  if (lines.length) {
+    console.log('\n=== chrome stderr (filtered) ===');
+    for (const l of lines.slice(0, 20)) console.log('  ' + l);
+  }
+}
+
+try { process.kill(-chrome.pid, 'SIGKILL'); } catch { chrome.kill('SIGKILL'); }
+await sleep(1000);
+await rm(profile, { recursive: true, force: true });
+process.exit(failed ? 1 : 0);

--- a/test/e2e/smoke.mjs
+++ b/test/e2e/smoke.mjs
@@ -205,6 +205,9 @@ if (extId) {
     const dom = await p.send('Runtime.evaluate', {
       expression: `JSON.stringify({
         profiles: [...document.querySelectorAll('#om-profiles .om-item')].map(e => e.textContent.trim()),
+        // aria-current must be a real attribute or the highlight rule cannot match.
+        current: [...document.querySelectorAll('#om-profiles .om-item[aria-current="true"]')]
+          .map(e => e.textContent.trim()),
         error: document.querySelector('#om-error')?.hidden === false
           ? document.querySelector('#om-error').textContent : null,
       })`,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": false,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "composite": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "./packages/pac" }]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,8 @@
 {
   "files": [],
-  "references": [{ "path": "./packages/pac" }]
+  "references": [
+    { "path": "./packages/pac" },
+    { "path": "./packages/target" },
+    { "path": "./packages/extension" }
+  ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['packages/*/test/**/*.test.ts'],
+    // The original suite pinned this timezone so that weekday and hour
+    // conditions are deterministic.
+    env: { TZ: 'Europe/London' },
+  },
+});


### PR DESCRIPTION
## Summary

Rewrites the extension in TypeScript, replacing the CoffeeScript/AngularJS stack:

- **@switchydelta/pac** — omega-pac rewritten in TypeScript (match-only PAC, lazy compile, DomainTrie host matching)
- **@switchydelta/target** — storage, sync, defaults and the Options controller ported, with latent correctness bugs fixed along the way
- **@switchydelta/extension** — minimal MV3 service worker, Chrome options/proxy/auth bindings, build script
- **@switchydelta/ui** — Vite + TypeScript popup and settings pages with no runtime framework; the settings page is registered as the Chrome side panel with a narrow-first layout, matching the original settings sections and i18n catalogue keys, plus profile management (create / rename / delete / export PAC)
- **CI** — GitHub workflow running the build, 174 unit tests, and four browser end-to-end suites against headless Chrome installed via CDP `Extensions.loadUnpacked`

## Test plan

- `npm run build` (includes typecheck)
- `npm test` — 174 unit tests
- `npm run e2e` — smoke, side-panel, profiles, rule-list suites against a real Chrome (verified headed and headless)
- Manual check of popup + side panel in a dev Chrome session