### PR TITLE
Track proxy control loss; action icon follows the current profile

### DIFF
--- a/packages/extension/src/action-icon.ts
+++ b/packages/extension/src/action-icon.ts
@@ -1,0 +1,48 @@
+/**
+ * The toolbar action icon, tinted with the current profile's colour.
+ *
+ * Redraws the delta mark from icon.svg on an OffscreenCanvas: the profile
+ * colour fills the rounded square and the white delta outline sits on top,
+ * so the icon both brands the extension and shows which profile is active —
+ * the same job the original's dynamically drawn omega icon did.
+ */
+
+const SIZES = [16, 24, 32];
+
+export async function setActionIcon(color: string): Promise<void> {
+  const imageData: Record<number, ImageData> = {};
+  for (const size of SIZES) {
+    const canvas = new OffscreenCanvas(size, size);
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const scale = size / 128;
+
+    ctx.beginPath();
+    ctx.roundRect(0, 0, size, size, 26 * scale);
+    ctx.fillStyle = color;
+    ctx.fill();
+
+    ctx.beginPath();
+    ctx.moveTo(64 * scale, 31 * scale);
+    ctx.lineTo(99 * scale, 95 * scale);
+    ctx.lineTo(29 * scale, 95 * scale);
+    ctx.closePath();
+    ctx.strokeStyle = '#ffffff';
+    ctx.lineWidth = Math.max(1.5, 13 * scale);
+    ctx.lineJoin = 'round';
+    ctx.stroke();
+
+    imageData[size] = ctx.getImageData(0, 0, size, size);
+  }
+  await chrome.action.setIcon({ imageData });
+}
+
+/** The red "=" badge the original showed when proxy control is lost. */
+export function setControlLostBadge(): void {
+  void chrome.action.setBadgeText({ text: '=' });
+  void chrome.action.setBadgeBackgroundColor({ color: '#da4f49' });
+}
+
+export function clearBadge(): void {
+  void chrome.action.setBadgeText({ text: '' });
+}

--- a/packages/extension/src/chrome-options.ts
+++ b/packages/extension/src/chrome-options.ts
@@ -13,6 +13,7 @@ import type { OmegaOptions } from '@switchydelta/target';
 import { Profiles } from '@switchydelta/pac';
 import type { Profile } from '@switchydelta/pac';
 
+import { clearBadge, setActionIcon, setControlLostBadge } from './action-icon.js';
 import { fetchUrl } from './fetch-url.js';
 
 export class ChromeOptions extends Options {
@@ -133,6 +134,47 @@ export class ChromeOptions extends Options {
 
   override currentProfileChanged(reason?: string): void {
     Log.log('Options#currentProfileChanged', reason ?? '');
+
+    const profile = this._currentProfileName ? this.currentProfile() : null;
+    // Virtual profiles take the colour of their target, like the popup does.
+    let display = profile;
+    if (display?.profileType === 'VirtualProfile') {
+      const target = Profiles.byName(
+        (display as Profile & { defaultProfileName: string }).defaultProfileName,
+        this._options,
+      );
+      if (target) display = target;
+    }
+    void setActionIcon(display?.color ?? '#1a73e8');
+
+    if (profile) {
+      const name = chrome.i18n.getMessage('profile_' + profile.name) || profile.name;
+      void chrome.action.setTitle({ title: name });
+    }
+  }
+
+  // --- Proxy control loss ---------------------------------------------------
+
+  private _proxyNotControllable: string | null = null;
+
+  proxyNotControllable(): string | null {
+    return this._proxyNotControllable;
+  }
+
+  /**
+   * Record why the proxy setting cannot be controlled ('app' or 'policy'),
+   * or null when control is (back) in our hands. Drives the popup notice via
+   * state and the red "=" badge, matching the original.
+   */
+  setProxyNotControllable(reason: string | null): void {
+    this._proxyNotControllable = reason;
+    if (reason) {
+      void this._state.set({ proxyNotControllable: reason });
+      setControlLostBadge();
+    } else {
+      void this._state.remove(['proxyNotControllable']);
+      clearBadge();
+    }
   }
 }
 

--- a/packages/extension/src/proxy-settings.ts
+++ b/packages/extension/src/proxy-settings.ts
@@ -187,6 +187,95 @@ export class ProxySettings {
       profileNotFound: (name) => this._profileNotFound(name),
     });
   }
+
+  /**
+   * Observe proxy setting changes, including the initial state. The callback
+   * receives the ChromeSetting details ({value, levelOfControl}).
+   */
+  watchProxyChange(callback: (details: chrome.types.ChromeSettingGetResultDetails) => void): void {
+    chrome.proxy.settings.onChange.addListener(callback);
+    chrome.proxy.settings.get({}, callback);
+  }
+
+  /**
+   * Identify the profile equivalent to an externally set proxy config: a
+   * builtin, an existing profile with the same effect, or an unnamed snapshot
+   * profile the popup can offer to import. Ported from the original
+   * `proxy_impl_settings.coffee` (minus the PAC magic-comment probe — this
+   * build's PAC scripts no longer carry one).
+   */
+  parseExternalProfile(
+    details: chrome.types.ChromeSettingGetResultDetails,
+    options: OptionsBag,
+  ): Profile | null {
+    const value = details.value as chrome.proxy.ProxyConfig | undefined;
+    switch (value?.mode) {
+      case 'system':
+        return Profiles.byName('system', options) ?? null;
+      case 'direct':
+        return Profiles.byName('direct', options) ?? null;
+      case 'auto_detect':
+        return {
+          profileType: 'PacProfile',
+          name: '',
+          pacUrl: 'http://wpad/wpad.dat',
+        } as Profile;
+      case 'pac_script': {
+        const url = value.pacScript?.url;
+        const data = value.pacScript?.data;
+        let found: Profile | null = null;
+        Profiles.each(options, (_key, p) => {
+          const pac = p as Profile & { pacUrl?: string; pacScript?: string };
+          if (p.profileType !== 'PacProfile') return;
+          if ((url && pac.pacUrl === url) || (!url && data && pac.pacScript === data)) found = p;
+        });
+        if (found) return found;
+        return (
+          url
+            ? { profileType: 'PacProfile', name: '', pacUrl: url }
+            : { profileType: 'PacProfile', name: '', pacScript: data ?? '' }
+        ) as Profile;
+      }
+      case 'fixed_servers': {
+        const rules = value.rules ?? {};
+        // Compare against each fixed profile's own generated config; matching
+        // the effect beats matching the representation.
+        const normalize = (config: chrome.proxy.ProxyRules) => {
+          const copy: Record<string, unknown> = { ...config };
+          if (copy['singleProxy']) {
+            copy['fallbackProxy'] = copy['singleProxy'];
+            delete copy['singleProxy'];
+          }
+          (copy['bypassList'] as string[] | undefined)?.sort();
+          return JSON.stringify(copy);
+        };
+        const wanted = normalize(rules);
+        let found: Profile | null = null;
+        Profiles.each(options, (_key, p) => {
+          if (p.profileType !== 'FixedProfile') return;
+          const config = this._fixedProfileConfig(p as FixedProfile);
+          if (config.mode === 'fixed_servers' && normalize(config.rules ?? {}) === wanted) {
+            found = p;
+          }
+        });
+        if (found) return found;
+        return {
+          profileType: 'FixedProfile',
+          name: '',
+          fallbackProxy: rules.singleProxy ?? rules.fallbackProxy,
+          proxyForHttp: rules.proxyForHttp,
+          proxyForHttps: rules.proxyForHttps,
+          proxyForFtp: rules.proxyForFtp,
+          bypassList: (rules.bypassList ?? []).map((pattern) => ({
+            conditionType: 'BypassCondition',
+            pattern,
+          })),
+        } as Profile;
+      }
+      default:
+        return null;
+    }
+  }
 }
 
 export default ProxySettings;

--- a/packages/extension/src/sw.ts
+++ b/packages/extension/src/sw.ts
@@ -42,6 +42,7 @@ function encodeError(value: unknown): unknown {
 
 let options: ChromeOptions | undefined;
 const state = new BrowserStorage('omega.local.');
+const proxySettings = new ProxySettings();
 
 async function boot(): Promise<Options> {
   const storage = new ChromeStorage('local');
@@ -57,7 +58,7 @@ async function boot(): Promise<Options> {
     sync.enabled = syncOptions === 'sync';
   }
 
-  options = new ChromeOptions(null, storage, state, Log, sync, new ProxySettings());
+  options = new ChromeOptions(null, storage, state, Log, sync, proxySettings);
   await options.ready;
   return options;
 }
@@ -66,6 +67,56 @@ const ready = boot().catch((err: unknown) => {
   Log.error('Service worker boot failed', err);
   throw err;
 });
+
+// Paint the action icon for the restored profile on every worker start.
+void ready.then(() => options?.currentProfileChanged('boot'));
+
+/**
+ * Track who controls the proxy setting.
+ *
+ * Another extension or an enterprise policy can take the setting away, in
+ * which case our writes succeed silently but change nothing — the popup
+ * notice and the red "=" badge are the only way the user learns why nothing
+ * happens. Registered at the top level so the event can wake the worker.
+ */
+let externalProfileTimer: ReturnType<typeof setTimeout> | undefined;
+function handleProxyChange(details: chrome.types.ChromeSettingGetResultDetails): void {
+  void (async () => {
+    await ready;
+    const target = options;
+    if (!target || !details) return;
+
+    const notControllableBefore = target.proxyNotControllable();
+    let internal = false;
+    let noRevert = false;
+    switch (details.levelOfControl) {
+      case 'controlled_by_other_extensions':
+      case 'not_controllable':
+        target.setProxyNotControllable(
+          details.levelOfControl === 'not_controllable' ? 'policy' : 'app',
+        );
+        noRevert = true;
+        break;
+      default:
+        target.setProxyNotControllable(null);
+    }
+
+    if (details.levelOfControl === 'controlled_by_this_extension') {
+      internal = true;
+      // Our own writes are only interesting when control was just regained.
+      if (!notControllableBefore) return;
+    }
+    Log.log('external proxy change', details.levelOfControl);
+
+    const parsed = proxySettings.parseExternalProfile(details, await target.getAll());
+    clearTimeout(externalProfileTimer);
+    externalProfileTimer = setTimeout(() => {
+      if (parsed) target.setExternalProfile(parsed, { noRevert, internal });
+    }, 500);
+  })();
+}
+chrome.proxy.settings.onChange.addListener(handleProxyChange);
+void ready.then(() => chrome.proxy.settings.get({}, handleProxyChange));
 
 /**
  * RPC dispatcher.


### PR DESCRIPTION
Two connected gaps found while investigating "switching to an http proxy profile does nothing":

**Proxy control was never monitored.** `chrome.proxy.settings.set` succeeds silently even when another extension (most recently installed wins) or an enterprise policy holds the setting — and the port had no `onChange` watcher, no `levelOfControl` check, no `proxyNotControllable` state, so the popup's warning notice never fired and there was no badge. Ported from the original background: watcher registered at the worker top level, `controlled_by_other_extensions` → reason `app`, `not_controllable` → `policy`, red `=` badge, popup notice, external config parsed back to an equivalent profile (`parseExternalProfile`) feeding the external-profile/revert logic, all cleared when control returns.

**The action icon never changed.** The toolbar icon now redraws the delta mark over the current profile's colour via OffscreenCanvas and sets the profile name as the action title, on every profile switch and worker start.

Verified headless with a second "hijacker" extension fixture: apply profile → title/colour set, no badge; hijacker loads → state `app`, badge `=`, popup shows the translated notice; hijacker releases → state and badge clear, control returns. 174 unit tests + all four e2e suites pass.