### PR TITLE
Rule list download: auto-apply, spinner, in-place result

### DIFF
--- a/packages/ui/src/options/main.ts
+++ b/packages/ui/src/options/main.ts
@@ -46,7 +46,14 @@ function changedKeys(): string[] {
   return [...keys].filter((key) => !deepEqual(pristine[key], options[key]));
 }
 
-async function applyChanges(): Promise<void> {
+/** Adopt a background-refreshed value for one key without marking it dirty. */
+export function adoptOptionsKey(key: string, value: unknown): void {
+  pristine[key] = structuredClone(value);
+  options[key] = structuredClone(value);
+  markDirty();
+}
+
+export async function applyChanges(): Promise<void> {
   const changes: Record<string, unknown> = {};
   for (const key of changedKeys()) {
     changes[key] = options[key];

--- a/packages/ui/src/options/options.css
+++ b/packages/ui/src/options/options.css
@@ -303,6 +303,24 @@ body.om-options {
   border-color: var(--om-danger) !important;
 }
 
+.om-spinner {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  margin-left: 8px;
+  vertical-align: -1px;
+  border: 2px solid var(--om-muted);
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: om-spin 0.8s linear infinite;
+}
+
+@keyframes om-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .om-radio-row {
   display: flex;
   gap: 14px;

--- a/packages/ui/src/options/views.ts
+++ b/packages/ui/src/options/views.ts
@@ -10,7 +10,7 @@ import { append, downloadFile, h, must, render } from '../lib/dom.js';
 import { profileDisplayName, t } from '../lib/i18n.js';
 import { api, callBackground, getState } from '../lib/messaging.js';
 import { colorFor, getAttachedName, listProfiles, profileColors } from '../lib/profile-view.js';
-import { isDirty, markDirty, options } from './main.js';
+import { adoptOptionsKey, applyChanges, isDirty, markDirty, options } from './main.js';
 import {
   Conditions,
   parseIp,
@@ -1044,19 +1044,6 @@ function renderSwitchProfile(container: HTMLElement, profile: SwitchProfile): vo
       ];
     }
 
-    const urlInput = h('input', {
-      type: 'url',
-      value: list.sourceUrl ?? '',
-      placeholder: 'https://',
-      onchange: () => {
-        list.sourceUrl = urlInput.value.trim();
-        // A different source invalidates the downloaded copy.
-        delete (list as { lastUpdate?: unknown }).lastUpdate;
-        touchAttached();
-        rerender();
-      },
-    });
-
     const text = h('textarea', {
       value: list.ruleList ?? '',
       disabled: !!list.sourceUrl,
@@ -1066,7 +1053,75 @@ function renderSwitchProfile(container: HTMLElement, profile: SwitchProfile): vo
       },
     });
 
-    const lastUpdate = (list as { lastUpdate?: string | number }).lastUpdate;
+    // Last-update line, refreshed in place so URL edits and downloads do not
+    // need a full re-render (which would swallow the click that caused them).
+    const status = h('div');
+    const renderStatus = () => {
+      const current = attached();
+      const lastUpdate = (current as { lastUpdate?: string | number } | undefined)?.lastUpdate;
+      render(status, [
+        !!current?.sourceUrl &&
+          (lastUpdate
+            ? h('p', {
+                class: 'om-help',
+                text: t('options_ruleListLastUpdate', [new Date(lastUpdate).toLocaleString()]),
+              })
+            : h('p', { class: 'om-error', text: t('options_ruleListObsolete') })),
+      ]);
+    };
+    renderStatus();
+
+    const downloadButton = h('button', {
+      type: 'button',
+      class: 'om-btn',
+      text: t('options_downloadProfileNow'),
+      disabled: !list.sourceUrl,
+      onclick: () => void download(),
+    });
+
+    // Pending edits are applied automatically: a freshly pasted URL should
+    // download on the first click, not demand a manual Apply first.
+    const download = async () => {
+      feedback.textContent = '';
+      downloadButton.disabled = true;
+      const spinner = h('span', { class: 'om-spinner', 'aria-hidden': 'true' });
+      downloadButton.append(spinner);
+      try {
+        if (isDirty()) await applyChanges();
+        const result = await api.updateProfile(attachedName);
+        const failed = Object.values(result ?? {}).find(
+          (value) => (value as { _error?: string } | null)?._error,
+        );
+        if (failed) {
+          throw new Error((failed as { message?: string }).message ?? 'Download failed');
+        }
+        // Pull the downloaded list back in without dirtying the page.
+        adoptOptionsKey(attachedKey, (await api.getAll())[attachedKey]);
+        const fresh = attached();
+        text.value = fresh?.ruleList ?? '';
+        renderStatus();
+      } catch (err) {
+        feedback.textContent = err instanceof Error ? err.message : String(err);
+      } finally {
+        spinner.remove();
+        downloadButton.disabled = !attached()?.sourceUrl;
+      }
+    };
+
+    const urlInput = h('input', {
+      type: 'url',
+      value: list.sourceUrl ?? '',
+      placeholder: 'https://',
+      onchange: () => {
+        list.sourceUrl = urlInput.value.trim();
+        // A different source invalidates the downloaded copy.
+        delete (list as { lastUpdate?: unknown }).lastUpdate;
+        touchAttached();
+        downloadButton.disabled = !list.sourceUrl;
+        text.disabled = !!list.sourceUrl;
+        renderStatus();
+      },
+    });
 
     return [
       h('h3', { text: t('options_group_ruleListConfig') }),
@@ -1094,33 +1149,10 @@ function renderSwitchProfile(container: HTMLElement, profile: SwitchProfile): vo
       ),
       field('options_group_ruleListUrl', urlInput),
       help('options_ruleListUrlHelp'),
-      h('button', {
-        type: 'button',
-        class: 'om-btn',
-        text: t('options_downloadProfileNow'),
-        disabled: !list.sourceUrl,
-        onclick: () => {
-          if (isDirty()) {
-            feedback.textContent = t('options_applyOptionsRequired');
-            return;
-          }
-          void api.updateProfile(attachedName).then(
-            () => location.reload(),
-            (err: unknown) => {
-              feedback.textContent = err instanceof Error ? err.message : String(err);
-            },
-          );
-        },
-      }),
+      downloadButton,
 
       h('h3', { text: t('options_group_ruleListText') }),
-      !!list.sourceUrl &&
-        (lastUpdate
-          ? h('p', {
-              class: 'om-help',
-              text: t('options_ruleListLastUpdate', [new Date(lastUpdate).toLocaleString()]),
-            })
-          : h('p', { class: 'om-error', text: t('options_ruleListObsolete') })),
+      status,
       text,
     ];
   }


### PR DESCRIPTION
Two UX fixes for the attached rule list download:

- **No manual Apply needed**: clicking Download Profile Now applies pending edits automatically first, so a freshly pasted URL downloads on the first click.
- **Async with progress**: the button disables and shows a spinner during the download; the downloaded list and last-update line are adopted back into the page in place (`adoptOptionsKey` syncs both the working copy and the pristine snapshot so the page stays clean) — no full page reload. Download errors (encoded per-profile) surface inline.

Verified headless against the real gfwlist: dirty page → Download → spinner shown, button disabled → completes in place (hash unchanged, no reload), status + text filled, page no longer dirty, PAC routes listed hosts via the match profile. 174 unit tests + all four e2e suites pass.