### PR TITLE
Restore proxy auth with optional host permission

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,8 +1,12 @@
 # SwitchyDelta authors:
 
+Max Lv <max.c.lv@gmail.com>
+
+# SwitchyDelta is based on SwitchyOmega. SwitchyOmega authors:
+
 FelisCatus <catusx@gmail.com>
 
-# SwitchyDelta translators:
+# SwitchyOmega / SwitchyDelta translators:
 
 Filip <filip@havlin.cz>
 Michal Čihař <michal@cihar.com>

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -178,18 +178,18 @@ Two smaller judgement calls, both deliberate:
 
 The worker is deliberately reduced to what only it can do:
 
+- **proxy authentication** — `chrome.webRequest.onAuthRequired` has no other
+  host, and its listener must be registered in the worker's first turn or the
+  event that woke the worker is lost. Host access is an
+  `optional_host_permissions` grant in this build: the popup offers it when a
+  profile carries credentials, and until it is granted the listeners are
+  registered but never fire.
 - **scheduled downloads** — `chrome.alarms` is the only timer that survives
   suspension
 - **applying the profile** to `chrome.proxy.settings`
 - **answering RPC** from the options page and popup
 
-Dropped from this build: proxy authentication (answering
-`webRequest.onAuthRequired` with stored credentials required the `webRequest`
-and `webRequestAuthProvider` permissions plus `<all_urls>` host access; the
-whole feature was cut to keep the permission surface minimal — profiles with
-`auth` entries still import, the credentials are just never used),
-external-proxy-change watching and
-`-revertProxyChanges`, quick-switch cycling, the badge and per-tab
+Dropped from this build: quick-switch cycling, the badge and per-tab
 icons/titles, the request monitor, the inspect context menus, and the
 SwitchySharp / external-extension bridges. `proxy_impl_script` and
 `proxy_impl_listener` are Firefox-only and were already dead on Chromium.

--- a/omega-locales/ach/LC_MESSAGES/omega-web.po
+++ b/omega-locales/ach/LC_MESSAGES/omega-web.po
@@ -1284,7 +1284,7 @@ msgstr "Other questions? Need help with using SwitchyDelta? Please see our "
 "<a href='https://github.com/madeye/SwitchyDelta/wiki/FAQ'>FAQ</a>."
 
 msgid "about_copyright"
-msgstr "Copyright 2012-2017 <a href='https://github.com/madeye/SwitchyDelta/blob/master/AUTHORS'>The SwitchyDelta Authors</a>. All rights reserved."
+msgstr "Copyright 2026 <a href='https://github.com/madeye'>Max Lv</a>.<br>Copyright 2012-2017 <a href='https://github.com/FelisCatus/SwitchyOmega/blob/master/AUTHORS'>The SwitchyOmega Authors</a>."
 
 msgid "about_credits"
 msgstr "SwitchyDelta is made possible by the <a href='https://github.com/madeye/SwitchyDelta'>SwitchyDelta</a> open source project and other <a href='https://github.com/madeye/SwitchyDelta/blob/master/AUTHORS'>open source software</a>."

--- a/omega-locales/cs/LC_MESSAGES/omega-web.po
+++ b/omega-locales/cs/LC_MESSAGES/omega-web.po
@@ -1278,7 +1278,7 @@ msgstr "Other questions? Need help with using SwitchyDelta? Please see our "
 "<a href='https://github.com/madeye/SwitchyDelta/wiki/FAQ'>FAQ</a>."
 
 msgid "about_copyright"
-msgstr "Copyright 2012-2017 <a href='https://github.com/madeye/SwitchyDelta/blob/master/AUTHORS'>The SwitchyDelta Authors</a>. All rights reserved."
+msgstr "Copyright 2026 <a href='https://github.com/madeye'>Max Lv</a>.<br>Copyright 2012-2017 <a href='https://github.com/FelisCatus/SwitchyOmega/blob/master/AUTHORS'>The SwitchyOmega Authors</a>."
 
 msgid "about_credits"
 msgstr "SwitchyDelta is made possible by the <a href='https://github.com/madeye/SwitchyDelta'>SwitchyDelta</a> open source project and other <a href='https://github.com/madeye/SwitchyDelta/blob/master/AUTHORS'>open source software</a>."

--- a/omega-locales/de/LC_MESSAGES/omega-web.po
+++ b/omega-locales/de/LC_MESSAGES/omega-web.po
@@ -1288,7 +1288,7 @@ msgstr "Other questions? Need help with using SwitchyDelta? Please see our "
 "<a href='https://github.com/madeye/SwitchyDelta/wiki/FAQ'>FAQ</a>."
 
 msgid "about_copyright"
-msgstr "Copyright 2012-2017 <a href='https://github.com/madeye/SwitchyDelta/blob/master/AUTHORS'>The SwitchyDelta Authors</a>. All rights reserved."
+msgstr "Copyright 2026 <a href='https://github.com/madeye'>Max Lv</a>.<br>Copyright 2012-2017 <a href='https://github.com/FelisCatus/SwitchyOmega/blob/master/AUTHORS'>The SwitchyOmega Authors</a>."
 
 msgid "about_credits"
 msgstr "SwitchyDelta is made possible by the <a href='https://github.com/madeye/SwitchyDelta'>SwitchyDelta</a> open source project and other <a href='https://github.com/madeye/SwitchyDelta/blob/master/AUTHORS'>open source software</a>."

--- a/omega-locales/en_US/LC_MESSAGES/omega-web.po
+++ b/omega-locales/en_US/LC_MESSAGES/omega-web.po
@@ -1266,10 +1266,16 @@ msgstr "Other questions? Need help with using SwitchyDelta? Please see our "
 "<a href='https://github.com/madeye/SwitchyDelta/wiki/FAQ'>FAQ</a>."
 
 msgid "about_copyright"
-msgstr "Copyright 2012-2017 <a href='https://github.com/madeye/SwitchyDelta/blob/master/AUTHORS'>The SwitchyDelta Authors</a>. All rights reserved."
+msgstr "Copyright 2026 <a href='https://github.com/madeye'>Max Lv</a>.<br>Copyright 2012-2017 <a href='https://github.com/FelisCatus/SwitchyOmega/blob/master/AUTHORS'>The SwitchyOmega Authors</a>."
 
 msgid "about_credits"
 msgstr "SwitchyDelta is made possible by the <a href='https://github.com/madeye/SwitchyDelta'>SwitchyDelta</a> open source project and other <a href='https://github.com/madeye/SwitchyDelta/blob/master/AUTHORS'>open source software</a>."
 
 msgid "about_license"
 msgstr "SwitchyDelta is <a href='https://www.gnu.org/philosophy/free-sw.en.html'>free software</a> licensed under <a href='https://www.gnu.org/licenses/gpl.html'>GNU General Public License</a> Version 3 or later."
+
+msgid "popup_proxyAuthPermission"
+msgstr "Signing in to authenticated proxies needs access to all websites."
+
+msgid "popup_proxyAuthPermissionGrant"
+msgstr "Grant access"

--- a/omega-locales/es/LC_MESSAGES/omega-web.po
+++ b/omega-locales/es/LC_MESSAGES/omega-web.po
@@ -1338,7 +1338,7 @@ msgstr ""
 "FAQ'>FAQ</a>."
 
 msgid "about_copyright"
-msgstr ""
+msgstr "Copyright 2026 <a href='https://github.com/madeye'>Max Lv</a>.<br>Copyright 2012-2017 <a href='https://github.com/FelisCatus/SwitchyOmega/blob/master/AUTHORS'>Los autores de SwitchyOmega</a>."
 "Copyright 2012-2017 <a href='https://github.com/madeye/SwitchyDelta/blob/"
 "master/AUTHORS'>Los autores de SwitchyDelta</a>. Todos los derechos "
 "reservados."

--- a/omega-locales/es_AR/LC_MESSAGES/omega-web.po
+++ b/omega-locales/es_AR/LC_MESSAGES/omega-web.po
@@ -1288,7 +1288,7 @@ msgstr "Other questions? Need help with using SwitchyDelta? Please see our "
 "<a href='https://github.com/madeye/SwitchyDelta/wiki/FAQ'>FAQ</a>."
 
 msgid "about_copyright"
-msgstr "Copyright 2012-2017 <a href='https://github.com/madeye/SwitchyDelta/blob/master/AUTHORS'>The SwitchyDelta Authors</a>. All rights reserved."
+msgstr "Copyright 2026 <a href='https://github.com/madeye'>Max Lv</a>.<br>Copyright 2012-2017 <a href='https://github.com/FelisCatus/SwitchyOmega/blob/master/AUTHORS'>The SwitchyOmega Authors</a>."
 
 msgid "about_credits"
 msgstr "SwitchyDelta is made possible by the <a href='https://github.com/madeye/SwitchyDelta'>SwitchyDelta</a> open source project and other <a href='https://github.com/madeye/SwitchyDelta/blob/master/AUTHORS'>open source software</a>."

--- a/omega-locales/fa/LC_MESSAGES/omega-web.po
+++ b/omega-locales/fa/LC_MESSAGES/omega-web.po
@@ -1298,7 +1298,7 @@ msgstr ""
 "madeye/SwitchyDelta/wiki/FAQ'>FAQ</a> مراجعه بفرمایید."
 
 msgid "about_copyright"
-msgstr ""
+msgstr "کپی رایت 2026 <a href='https://github.com/madeye'>Max Lv</a>.<br>کپی رایت 2012-2017 <a href='https://github.com/FelisCatus/SwitchyOmega/blob/master/AUTHORS'>نویسندگان SwitchyOmega</a>."
 "کپی رایت 2012-2017 <a "
 "href='https://github.com/madeye/SwitchyDelta/blob/master/AUTHORS'>"
 "نویسندگان The SwitchyDelta </a>. کلیه حقوق محفوظ است، ترجمه شده به فارسی "

--- a/omega-locales/fr/LC_MESSAGES/omega-web.po
+++ b/omega-locales/fr/LC_MESSAGES/omega-web.po
@@ -1292,7 +1292,7 @@ msgstr "Other questions? Need help with using SwitchyDelta? Please see our "
 "<a href='https://github.com/madeye/SwitchyDelta/wiki/FAQ'>FAQ</a>."
 
 msgid "about_copyright"
-msgstr "Copyright 2012-2017 <a href='https://github.com/madeye/SwitchyDelta/blob/master/AUTHORS'>The SwitchyDelta Authors</a>. All rights reserved."
+msgstr "Copyright 2026 <a href='https://github.com/madeye'>Max Lv</a>.<br>Copyright 2012-2017 <a href='https://github.com/FelisCatus/SwitchyOmega/blob/master/AUTHORS'>The SwitchyOmega Authors</a>."
 
 msgid "about_credits"
 msgstr "SwitchyDelta is made possible by the <a href='https://github.com/madeye/SwitchyDelta'>SwitchyDelta</a> open source project and other <a href='https://github.com/madeye/SwitchyDelta/blob/master/AUTHORS'>open source software</a>."

--- a/omega-locales/he_IL/LC_MESSAGES/omega-web.po
+++ b/omega-locales/he_IL/LC_MESSAGES/omega-web.po
@@ -1056,7 +1056,7 @@ msgid "about_help"
 msgstr ""
 
 msgid "about_copyright"
-msgstr ""
+msgstr "Copyright 2026 <a href='https://github.com/madeye'>Max Lv</a>.<br>Copyright 2012-2017 <a href='https://github.com/FelisCatus/SwitchyOmega/blob/master/AUTHORS'>The SwitchyOmega Authors</a>."
 
 msgid "about_credits"
 msgstr ""

--- a/omega-locales/id/LC_MESSAGES/omega-web.po
+++ b/omega-locales/id/LC_MESSAGES/omega-web.po
@@ -1088,7 +1088,7 @@ msgid "about_help"
 msgstr ""
 
 msgid "about_copyright"
-msgstr ""
+msgstr "Copyright 2026 <a href='https://github.com/madeye'>Max Lv</a>.<br>Copyright 2012-2017 <a href='https://github.com/FelisCatus/SwitchyOmega/blob/master/AUTHORS'>The SwitchyOmega Authors</a>."
 
 msgid "about_credits"
 msgstr ""

--- a/omega-locales/is/LC_MESSAGES/omega-web.po
+++ b/omega-locales/is/LC_MESSAGES/omega-web.po
@@ -1089,7 +1089,7 @@ msgstr "Other questions? Need help with using SwitchyDelta? Please see our "
 "<a href='https://github.com/madeye/SwitchyDelta/wiki/FAQ'>FAQ</a>."
 
 msgid "about_copyright"
-msgstr "Copyright 2012-2017 <a href='https://github.com/madeye/SwitchyDelta/blob/master/AUTHORS'>The SwitchyDelta Authors</a>. All rights reserved."
+msgstr "Copyright 2026 <a href='https://github.com/madeye'>Max Lv</a>.<br>Copyright 2012-2017 <a href='https://github.com/FelisCatus/SwitchyOmega/blob/master/AUTHORS'>The SwitchyOmega Authors</a>."
 
 msgid "about_credits"
 msgstr "SwitchyDelta is made possible by the <a href='https://github.com/madeye/SwitchyDelta'>SwitchyDelta</a> open source project and other <a href='https://github.com/madeye/SwitchyDelta/blob/master/AUTHORS'>open source software</a>."

--- a/omega-locales/it/LC_MESSAGES/omega-web.po
+++ b/omega-locales/it/LC_MESSAGES/omega-web.po
@@ -1057,7 +1057,7 @@ msgid "about_help"
 msgstr ""
 
 msgid "about_copyright"
-msgstr ""
+msgstr "Copyright 2026 <a href='https://github.com/madeye'>Max Lv</a>.<br>Copyright 2012-2017 <a href='https://github.com/FelisCatus/SwitchyOmega/blob/master/AUTHORS'>The SwitchyOmega Authors</a>."
 
 msgid "about_credits"
 msgstr ""

--- a/omega-locales/ja/LC_MESSAGES/omega-web.po
+++ b/omega-locales/ja/LC_MESSAGES/omega-web.po
@@ -1260,7 +1260,7 @@ msgstr "Other questions? Need help with using SwitchyDelta? Please see our "
 "<a href='https://github.com/madeye/SwitchyDelta/wiki/FAQ'>FAQ</a>."
 
 msgid "about_copyright"
-msgstr "Copyright 2012-2017 <a href='https://github.com/madeye/SwitchyDelta/blob/master/AUTHORS'>The SwitchyDelta Authors</a>. All rights reserved."
+msgstr "Copyright 2026 <a href='https://github.com/madeye'>Max Lv</a>.<br>Copyright 2012-2017 <a href='https://github.com/FelisCatus/SwitchyOmega/blob/master/AUTHORS'>The SwitchyOmega Authors</a>."
 
 msgid "about_credits"
 msgstr "SwitchyDelta is made possible by the <a href='https://github.com/madeye/SwitchyDelta'>SwitchyDelta</a> open source project and other <a href='https://github.com/madeye/SwitchyDelta/blob/master/AUTHORS'>open source software</a>."

--- a/omega-locales/lzh/LC_MESSAGES/omega-web.po
+++ b/omega-locales/lzh/LC_MESSAGES/omega-web.po
@@ -1083,7 +1083,7 @@ msgid "about_help"
 msgstr ""
 
 msgid "about_copyright"
-msgstr ""
+msgstr "Copyright 2026 <a href='https://github.com/madeye'>Max Lv</a>.<br>Copyright 2012-2017 <a href='https://github.com/FelisCatus/SwitchyOmega/blob/master/AUTHORS'>The SwitchyOmega Authors</a>."
 
 msgid "about_credits"
 msgstr ""

--- a/omega-locales/nb_NO/LC_MESSAGES/omega-web.po
+++ b/omega-locales/nb_NO/LC_MESSAGES/omega-web.po
@@ -1127,7 +1127,7 @@ msgstr "Other questions? Need help with using SwitchyDelta? Please see our "
 "<a href='https://github.com/madeye/SwitchyDelta/wiki/FAQ'>FAQ</a>."
 
 msgid "about_copyright"
-msgstr "Copyright 2012-2017 <a href='https://github.com/madeye/SwitchyDelta/blob/master/AUTHORS'>The SwitchyDelta Authors</a>. All rights reserved."
+msgstr "Copyright 2026 <a href='https://github.com/madeye'>Max Lv</a>.<br>Copyright 2012-2017 <a href='https://github.com/FelisCatus/SwitchyOmega/blob/master/AUTHORS'>The SwitchyOmega Authors</a>."
 
 msgid "about_credits"
 msgstr "SwitchyDelta is made possible by the <a href='https://github.com/madeye/SwitchyDelta'>SwitchyDelta</a> open source project and other <a href='https://github.com/madeye/SwitchyDelta/blob/master/AUTHORS'>open source software</a>."

--- a/omega-locales/nl/LC_MESSAGES/omega-web.po
+++ b/omega-locales/nl/LC_MESSAGES/omega-web.po
@@ -1078,7 +1078,7 @@ msgstr "Other questions? Need help with using SwitchyDelta? Please see our "
 "<a href='https://github.com/madeye/SwitchyDelta/wiki/FAQ'>FAQ</a>."
 
 msgid "about_copyright"
-msgstr "Copyright 2012-2017 <a href='https://github.com/madeye/SwitchyDelta/blob/master/AUTHORS'>The SwitchyDelta Authors</a>. All rights reserved."
+msgstr "Copyright 2026 <a href='https://github.com/madeye'>Max Lv</a>.<br>Copyright 2012-2017 <a href='https://github.com/FelisCatus/SwitchyOmega/blob/master/AUTHORS'>The SwitchyOmega Authors</a>."
 
 msgid "about_credits"
 msgstr "SwitchyDelta is made possible by the <a href='https://github.com/madeye/SwitchyDelta'>SwitchyDelta</a> open source project and other <a href='https://github.com/madeye/SwitchyDelta/blob/master/AUTHORS'>open source software</a>."

--- a/omega-locales/pl/LC_MESSAGES/omega-web.po
+++ b/omega-locales/pl/LC_MESSAGES/omega-web.po
@@ -1057,7 +1057,7 @@ msgid "about_help"
 msgstr ""
 
 msgid "about_copyright"
-msgstr ""
+msgstr "Copyright 2026 <a href='https://github.com/madeye'>Max Lv</a>.<br>Copyright 2012-2017 <a href='https://github.com/FelisCatus/SwitchyOmega/blob/master/AUTHORS'>The SwitchyOmega Authors</a>."
 
 msgid "about_credits"
 msgstr ""

--- a/omega-locales/pt/LC_MESSAGES/omega-web.po
+++ b/omega-locales/pt/LC_MESSAGES/omega-web.po
@@ -1075,7 +1075,7 @@ msgid "about_help"
 msgstr ""
 
 msgid "about_copyright"
-msgstr ""
+msgstr "Copyright 2026 <a href='https://github.com/madeye'>Max Lv</a>.<br>Copyright 2012-2017 <a href='https://github.com/FelisCatus/SwitchyOmega/blob/master/AUTHORS'>The SwitchyOmega Authors</a>."
 
 msgid "about_credits"
 msgstr ""

--- a/omega-locales/pt_BR/LC_MESSAGES/omega-web.po
+++ b/omega-locales/pt_BR/LC_MESSAGES/omega-web.po
@@ -1286,7 +1286,7 @@ msgstr "Other questions? Need help with using SwitchyDelta? Please see our "
 "<a href='https://github.com/madeye/SwitchyDelta/wiki/FAQ'>FAQ</a>."
 
 msgid "about_copyright"
-msgstr "Copyright 2012-2017 <a href='https://github.com/madeye/SwitchyDelta/blob/master/AUTHORS'>The SwitchyDelta Authors</a>. All rights reserved."
+msgstr "Copyright 2026 <a href='https://github.com/madeye'>Max Lv</a>.<br>Copyright 2012-2017 <a href='https://github.com/FelisCatus/SwitchyOmega/blob/master/AUTHORS'>The SwitchyOmega Authors</a>."
 
 msgid "about_credits"
 msgstr "SwitchyDelta is made possible by the <a href='https://github.com/madeye/SwitchyDelta'>SwitchyDelta</a> open source project and other <a href='https://github.com/madeye/SwitchyDelta/blob/master/AUTHORS'>open source software</a>."

--- a/omega-locales/ru/LC_MESSAGES/omega-web.po
+++ b/omega-locales/ru/LC_MESSAGES/omega-web.po
@@ -1321,7 +1321,7 @@ msgstr ""
 "<a href='https://github.com/madeye/SwitchyDelta/wiki/FAQ'>ЧаВО</a>."
 
 msgid "about_copyright"
-msgstr ""
+msgstr "Авторское право 2026 <a href='https://github.com/madeye'>Max Lv</a>.<br>Авторское право 2012-2017 <a href='https://github.com/FelisCatus/SwitchyOmega/blob/master/AUTHORS'>Авторы SwitchyOmega</a>."
 "Авторское право 2012-2017 <a href='https://github.com/madeye/"
 "SwitchyDelta/blob/master/AUTHORS'>Авторы SwitchyDelta</a>. Все права "
 "защищены."

--- a/omega-locales/si/LC_MESSAGES/omega-web.po
+++ b/omega-locales/si/LC_MESSAGES/omega-web.po
@@ -1056,7 +1056,7 @@ msgid "about_help"
 msgstr ""
 
 msgid "about_copyright"
-msgstr ""
+msgstr "Copyright 2026 <a href='https://github.com/madeye'>Max Lv</a>.<br>Copyright 2012-2017 <a href='https://github.com/FelisCatus/SwitchyOmega/blob/master/AUTHORS'>The SwitchyOmega Authors</a>."
 
 msgid "about_credits"
 msgstr ""

--- a/omega-locales/sk/LC_MESSAGES/omega-web.po
+++ b/omega-locales/sk/LC_MESSAGES/omega-web.po
@@ -1091,7 +1091,7 @@ msgstr "Other questions? Need help with using SwitchyDelta? Please see our "
 "<a href='https://github.com/madeye/SwitchyDelta/wiki/FAQ'>FAQ</a>."
 
 msgid "about_copyright"
-msgstr "Copyright 2012-2017 <a href='https://github.com/madeye/SwitchyDelta/blob/master/AUTHORS'>The SwitchyDelta Authors</a>. All rights reserved."
+msgstr "Copyright 2026 <a href='https://github.com/madeye'>Max Lv</a>.<br>Copyright 2012-2017 <a href='https://github.com/FelisCatus/SwitchyOmega/blob/master/AUTHORS'>The SwitchyOmega Authors</a>."
 
 msgid "about_credits"
 msgstr "SwitchyDelta is made possible by the <a href='https://github.com/madeye/SwitchyDelta'>SwitchyDelta</a> open source project and other <a href='https://github.com/madeye/SwitchyDelta/blob/master/AUTHORS'>open source software</a>."

--- a/omega-locales/sl/LC_MESSAGES/omega-web.po
+++ b/omega-locales/sl/LC_MESSAGES/omega-web.po
@@ -1090,7 +1090,7 @@ msgstr "Other questions? Need help with using SwitchyDelta? Please see our "
 "<a href='https://github.com/madeye/SwitchyDelta/wiki/FAQ'>FAQ</a>."
 
 msgid "about_copyright"
-msgstr "Copyright 2012-2017 <a href='https://github.com/madeye/SwitchyDelta/blob/master/AUTHORS'>The SwitchyDelta Authors</a>. All rights reserved."
+msgstr "Copyright 2026 <a href='https://github.com/madeye'>Max Lv</a>.<br>Copyright 2012-2017 <a href='https://github.com/FelisCatus/SwitchyOmega/blob/master/AUTHORS'>The SwitchyOmega Authors</a>."
 
 msgid "about_credits"
 msgstr "SwitchyDelta is made possible by the <a href='https://github.com/madeye/SwitchyDelta'>SwitchyDelta</a> open source project and other <a href='https://github.com/madeye/SwitchyDelta/blob/master/AUTHORS'>open source software</a>."

--- a/omega-locales/tr/LC_MESSAGES/omega-web.po
+++ b/omega-locales/tr/LC_MESSAGES/omega-web.po
@@ -1119,7 +1119,7 @@ msgstr ""
 "FAQ'>SSS</a>."
 
 msgid "about_copyright"
-msgstr ""
+msgstr "Telif Hakkı 2026 <a href='https://github.com/madeye'>Max Lv</a>.<br>Telif Hakkı 2012-2017 <a href='https://github.com/FelisCatus/SwitchyOmega/blob/master/AUTHORS'>SwitchyOmega Yazarları</a>."
 "Telif Hakkı 2012-2019 <a href='https://github.com/madeye/SwitchyDelta/"
 "blob/master/AUTHORS'>SwitchyDelta Yazarları</a>. Tüm hakları saklıdır."
 

--- a/omega-locales/uk/LC_MESSAGES/omega-web.po
+++ b/omega-locales/uk/LC_MESSAGES/omega-web.po
@@ -1439,7 +1439,7 @@ msgstr ""
 
 #, fuzzy
 msgid "about_copyright"
-msgstr ""
+msgstr "Авторське право 2026 <a href='https://github.com/madeye'>Max Lv</a>.<br>Авторське право 2012-2017 <a href='https://github.com/FelisCatus/SwitchyOmega/blob/master/AUTHORS'>Автори SwitchyOmega</a>."
 "Авторське право 2012-2017 <ahref='https://github.com/madeye/SwitchyDelta/"
 "blob/master/AUTHORS'>Автори SwitchyDelta</a>. Всі права захищені."
 

--- a/omega-locales/zh_CN/LC_MESSAGES/omega-web.po
+++ b/omega-locales/zh_CN/LC_MESSAGES/omega-web.po
@@ -1140,10 +1140,16 @@ msgstr ""
 "SwitchyDelta/wiki/FAQ'>常见问题</a>。"
 
 msgid "about_copyright"
-msgstr "版权所有 2012-2017 <a href='https://github.com/madeye/SwitchyDelta/blob/master/AUTHORS'>The SwitchyDelta Authors</a>. 保留所有权利。"
+msgstr "版权所有 2026 <a href='https://github.com/madeye'>Max Lv</a>。<br>版权所有 2012-2017 <a href='https://github.com/FelisCatus/SwitchyOmega/blob/master/AUTHORS'>SwitchyOmega 作者</a>。"
 
 msgid "about_credits"
 msgstr "SwitchyDelta 的诞生离不开 <a href='https://github.com/madeye/SwitchyDelta'>SwitchyDelta</a> 开源项目和其他<a href='https://github.com/madeye/SwitchyDelta/blob/master/AUTHORS'>开源软件</a>。"
 
 msgid "about_license"
 msgstr "SwitchyDelta 是<a href='https://www.gnu.org/philosophy/free-sw.zh-cn.html'>自由软件</a>，使用<a href='https://www.gnu.org/licenses/gpl.html'>GNU General Public License</a> 版本 3 及以上授权。"
+
+msgid "popup_proxyAuthPermission"
+msgstr "自动登录需要认证的代理服务器需要“访问所有网站”权限。"
+
+msgid "popup_proxyAuthPermissionGrant"
+msgstr "授予权限"

--- a/omega-locales/zh_Hant/LC_MESSAGES/omega-web.po
+++ b/omega-locales/zh_Hant/LC_MESSAGES/omega-web.po
@@ -1075,7 +1075,7 @@ msgid "about_help"
 msgstr ""
 
 msgid "about_copyright"
-msgstr ""
+msgstr "Copyright 2026 <a href='https://github.com/madeye'>Max Lv</a>.<br>Copyright 2012-2017 <a href='https://github.com/FelisCatus/SwitchyOmega/blob/master/AUTHORS'>The SwitchyOmega Authors</a>."
 
 msgid "about_credits"
 msgstr ""

--- a/omega-locales/zh_TW/LC_MESSAGES/omega-web.po
+++ b/omega-locales/zh_TW/LC_MESSAGES/omega-web.po
@@ -1127,10 +1127,16 @@ msgstr ""
 "%E5%B8%B8%E8%A7%81%E9%97%AE%E9%A2%98'>常見問題</a>。"
 
 msgid "about_copyright"
-msgstr "版權所有 2012-2017 <a href='https://github.com/madeye/SwitchyDelta/blob/master/AUTHORS'>The SwitchyDelta Authors</a>. 保留所有權利。"
+msgstr "版權所有 2026 <a href='https://github.com/madeye'>Max Lv</a>。<br>版權所有 2012-2017 <a href='https://github.com/FelisCatus/SwitchyOmega/blob/master/AUTHORS'>SwitchyOmega 作者</a>。"
 
 msgid "about_credits"
 msgstr "SwitchyDelta 的誕生離不開 <a href='https://github.com/madeye/SwitchyDelta'>SwitchyDelta</a> 開源項目和其他<a href='https://github.com/madeye/SwitchyDelta/blob/master/AUTHORS'>開源軟體</a>。"
 
 msgid "about_license"
 msgstr "SwitchyDelta 是<a href='https://www.gnu.org/philosophy/free-sw.zh-tw.html'>自由軟體</a>，使用<a href='https://www.gnu.org/licenses/gpl.html'>GNU General Public License</a> 版本 3 及以上授權。"
+
+msgid "popup_proxyAuthPermission"
+msgstr "自動登入需要驗證的代理伺服器需要「存取所有網站」權限。"
+
+msgid "popup_proxyAuthPermissionGrant"
+msgstr "授予權限"

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -41,7 +41,12 @@
     "unlimitedStorage",
     "alarms",
     "activeTab",
+    "webRequest",
+    "webRequestAuthProvider",
     "sidePanel"
+  ],
+  "optional_host_permissions": [
+    "<all_urls>"
   ],
   "commands": {
     "_execute_action": {

--- a/packages/extension/src/chrome-options.ts
+++ b/packages/extension/src/chrome-options.ts
@@ -15,11 +15,26 @@ import type { Profile } from '@switchydelta/pac';
 
 import { clearBadge, setActionIcon, setControlLostBadge } from './action-icon.js';
 import { fetchUrl } from './fetch-url.js';
+import { ProxyAuth } from './proxy-auth.js';
 
 export class ChromeOptions extends Options {
   /** Alarm callbacks, keyed by the name passed to {@link schedule}. */
   readonly #alarms = new Map<string, () => void>();
   #alarmListenerInstalled = false;
+
+  /**
+   * Whether any applied profile carries proxy credentials, and whether the
+   * optional `<all_urls>` host permission that auth interception depends on
+   * has been granted. The popup offers the grant when credentials exist
+   * without host access.
+   */
+  async proxyAuthStatus(): Promise<{ hasCredentials: boolean; hostAccess: boolean }> {
+    const [hasCredentials, hostAccess] = await Promise.all([
+      ProxyAuth.shared(Log).hasCredentials(),
+      chrome.permissions.contains({ origins: ['<all_urls>'] }),
+    ]);
+    return { hasCredentials, hostAccess };
+  }
 
   override fetchUrl(
     url: string,

--- a/packages/extension/src/proxy-auth.ts
+++ b/packages/extension/src/proxy-auth.ts
@@ -1,0 +1,391 @@
+/**
+ * Proxy authentication for the MV3 service worker.
+ *
+ * The worker is torn down and restarted at will, and a proxy auth challenge is
+ * one of the events that wakes it. Two things follow, and they shape this whole
+ * file:
+ *
+ *  - The `onAuthRequired` listener has to be registered synchronously during
+ *    worker startup, before anything is loaded from storage. A listener
+ *    attached at the end of an async boot is registered too late to see the
+ *    event that caused the wake-up.
+ *  - The credentials themselves therefore cannot live only in memory. They are
+ *    written to storage whenever a profile is applied and read back on demand.
+ *
+ * Hence the module-level singleton: startup registers the listener on it, and
+ * the later async boot fills in the credentials on the same object.
+ *
+ * Host access is an optional permission in this build: the listeners are
+ * registered unconditionally, but Chromium only dispatches webRequest events
+ * for origins the user has granted, so nothing here fires until the optional
+ * `<all_urls>` grant (offered by the popup) has been accepted.
+ */
+
+import { Profiles } from '@switchydelta/pac';
+import type {
+  FixedProfile,
+  Profile,
+  ProxyAuth as ProxyCredentials,
+  ProxyServer,
+} from '@switchydelta/pac';
+import type { Logger } from '@switchydelta/target';
+
+const STORAGE_KEY = 'omegaProxyAuth';
+
+/** One candidate credential for a challenge. Fallbacks carry no `config`. */
+interface AuthEntry {
+  config?: ProxyServer;
+  auth: ProxyCredentials;
+  name: string;
+}
+
+/** What gets persisted; must stay plain JSON. */
+interface AuthPayload {
+  proxies: Record<string, AuthEntry[] | undefined>;
+  fallbacks: AuthEntry[];
+}
+
+/** Credentials in the shape a `{user, pass}`-era options file may still hold. */
+interface LegacyAuth {
+  username?: string;
+  password?: string;
+  user?: string;
+  pass?: string;
+}
+
+type AreaName = 'session' | 'local';
+
+function storageArea(name: AreaName): chrome.storage.StorageArea | undefined {
+  if (typeof chrome === 'undefined' || !chrome.storage) return undefined;
+  return chrome.storage[name];
+}
+
+/** See {@link ProxyAuth.shared}. */
+let sharedInstance: ProxyAuth | null = null;
+
+export class ProxyAuth {
+  /**
+   * The single instance the worker registers its listener on.
+   *
+   * Everything must go through this: a second instance would register a second
+   * listener holding a different credential map, and which of the two answered
+   * a challenge would depend on registration order.
+   */
+  static shared(log?: Logger | null): ProxyAuth {
+    const instance = sharedInstance ?? new ProxyAuth(log);
+    if (log) instance.log = log;
+    return instance;
+  }
+
+  log: Logger | null;
+  listening = false;
+
+  /** Per-request state, keyed by requestId; see {@link _credentialsFor}. */
+  private _requests: Record<string, { authTries: number } | undefined> = {};
+  private _proxies: Record<string, AuthEntry[] | undefined> = {};
+  private _fallbacks: AuthEntry[] = [];
+  private _hydrated = false;
+  private _hydratePromise: Promise<void> | null = null;
+
+  constructor(log?: Logger | null) {
+    this.log = log ?? null;
+    sharedInstance = this;
+  }
+
+  /**
+   * Register the auth listeners. Idempotent, because startup and the first
+   * `applyProfile` both call it and neither knows about the other.
+   */
+  listen(): void {
+    if (this.listening) return;
+    if (!chrome.webRequest) {
+      this.log?.error('Proxy auth disabled! No webRequest permission.');
+      return;
+    }
+    if (!chrome.webRequest.onAuthRequired) {
+      this.log?.error('Proxy auth disabled! onAuthRequired not available.');
+      return;
+    }
+
+    const handler = (
+      details: chrome.webRequest.WebAuthenticationChallengeDetails,
+      asyncCallback?: (response: chrome.webRequest.BlockingResponse) => void,
+    ) => this.authHandler(details, asyncCallback);
+
+    // asyncBlocking is the MV3 form (it needs the webRequestAuthProvider
+    // permission) and is the only one that allows answering a challenge after
+    // an await. Older hosts only understand blocking, and reject the unknown
+    // extraInfoSpec by throwing.
+    try {
+      chrome.webRequest.onAuthRequired.addListener(handler, { urls: ['<all_urls>'] }, [
+        'asyncBlocking',
+      ]);
+    } catch (err) {
+      this.log?.error('asyncBlocking onAuthRequired failed; trying blocking.', err);
+      chrome.webRequest.onAuthRequired.addListener(handler, { urls: ['<all_urls>'] }, [
+        'blocking',
+      ]);
+    }
+
+    chrome.webRequest.onCompleted.addListener((details) => this._requestDone(details), {
+      urls: ['<all_urls>'],
+    });
+    chrome.webRequest.onErrorOccurred.addListener((details) => this._requestDone(details), {
+      urls: ['<all_urls>'],
+    });
+    this.listening = true;
+
+    // Warm the credentials from the last applyProfile so that the common case
+    // does not have to wait for storage inside the challenge handler.
+    void this._hydrate();
+  }
+
+  private _payload(): AuthPayload {
+    return { proxies: this._proxies, fallbacks: this._fallbacks };
+  }
+
+  private _applyPayload(data: AuthPayload | null | undefined): boolean {
+    if (!data) return false;
+    this._proxies = data.proxies || {};
+    this._fallbacks = data.fallbacks || [];
+    return true;
+  }
+
+  /**
+   * Write to both session and local storage.
+   *
+   * Session storage covers worker restarts within a browser session and is
+   * never written to disk. Local storage covers a full browser restart, where
+   * the first proxied request can easily beat `Options.init` to re-applying the
+   * profile — without it, that request would get no credentials at all.
+   */
+  private _persist(): void {
+    const payload = { [STORAGE_KEY]: this._payload() };
+    for (const areaName of ['session', 'local'] as const) {
+      const area = storageArea(areaName);
+      if (!area) continue;
+      try {
+        void Promise.resolve(area.set(payload)).catch(() => undefined);
+      } catch {
+        // A storage area that throws synchronously is unusable; the in-memory
+        // credentials still work for as long as this worker lives.
+      }
+    }
+  }
+
+  private async _getFromArea(areaName: AreaName): Promise<AuthPayload | null> {
+    const area = storageArea(areaName);
+    if (!area) return null;
+    try {
+      const items = await area.get(STORAGE_KEY);
+      if (chrome.runtime?.lastError) return null;
+      return (items?.[STORAGE_KEY] as AuthPayload | undefined) ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Load persisted credentials once, preferring session storage.
+   *
+   * Concurrent callers share one read: several challenges can arrive back to
+   * back on the same wake-up.
+   */
+  private _hydrate(): Promise<void> {
+    if (this._hydrated) return Promise.resolve();
+    if (this._hydratePromise) return this._hydratePromise;
+
+    this._hydratePromise = (async () => {
+      try {
+        let data = await this._getFromArea('session');
+        if (!data) {
+          data = await this._getFromArea('local');
+          // Mirror local into session so later wake-ups in this browser session
+          // take the cheap path and stop touching disk.
+          const session = data ? storageArea('session') : undefined;
+          if (session) {
+            try {
+              void Promise.resolve(session.set({ [STORAGE_KEY]: data })).catch(() => undefined);
+            } catch {
+              // Ignore; the local copy is still authoritative.
+            }
+          }
+        }
+        this._applyPayload(data);
+      } catch {
+        // Never let a storage failure hold a challenge open forever; without
+        // credentials the request simply fails to authenticate.
+      } finally {
+        this._hydrated = true;
+        this._hydratePromise = null;
+      }
+    })();
+    return this._hydratePromise;
+  }
+
+  private _keyForProxy(proxy: { host?: string; port: number | undefined }): string {
+    const host = (proxy.host || '').toLowerCase();
+    return `${host}:${String(proxy.port)}`;
+  }
+
+  /**
+   * The keys a challenge may be stored under.
+   *
+   * Chromium reports IPv6 challengers in bracketed form (`[::1]`) while the
+   * profile stores the bare address, so both spellings are tried.
+   */
+  private _keysForChallenger(challenger: { host?: string; port: number | undefined }): string[] {
+    const host = (challenger.host || '').toLowerCase();
+    const port = challenger.port;
+    const keys = [`${host}:${String(port)}`];
+    if (host.length >= 2 && host[0] === '[' && host[host.length - 1] === ']') {
+      keys.push(`${host.substring(1, host.length - 1)}:${String(port)}`);
+    }
+    return keys;
+  }
+
+  /** Rebuild the credential map from the profiles the current profile uses. */
+  setProxies(profiles: Profile[]): void {
+    this._proxies = {};
+    this._fallbacks = [];
+
+    for (const profile of profiles) {
+      // Only FixedProfile carries `auth`, but the check stays value-based so
+      // that an unexpected profile type with credentials is still honoured.
+      const profileAuth = (profile as FixedProfile).auth;
+      if (!profileAuth) continue;
+
+      for (const scheme of Profiles.schemes) {
+        const proxy = (profile as FixedProfile)[scheme.prop];
+        if (!proxy) continue;
+        const auth = profileAuth[scheme.prop];
+        if (!auth?.username) continue;
+        const key = this._keyForProxy(proxy);
+        let list = this._proxies[key];
+        if (!list) {
+          list = [];
+          this._proxies[key] = list;
+        }
+        list.push({
+          config: proxy,
+          auth: { username: auth.username, password: auth.password ?? '' },
+          name: profile.name + '.' + scheme.prop,
+        });
+      }
+
+      const fallback = profileAuth['all'];
+      if (fallback?.username) {
+        this._fallbacks.push({
+          auth: { username: fallback.username, password: fallback.password ?? '' },
+          name: profile.name + '.all',
+        });
+      }
+    }
+
+    this._hydrated = true;
+    this._persist();
+  }
+
+  /** Whether any profile currently supplies proxy credentials. */
+  async hasCredentials(): Promise<boolean> {
+    await this._hydrate();
+    if (this._fallbacks.length > 0) return true;
+    return Object.values(this._proxies).some((list) => !!list && list.length > 0);
+  }
+
+  private _normalizeAuth(auth: LegacyAuth | null | undefined): ProxyCredentials | null {
+    if (!auth) return null;
+    const username = auth.username ?? auth.user;
+    if (username == null) return null;
+    return { username, password: auth.password ?? auth.pass ?? '' };
+  }
+
+  /**
+   * Pick the credentials for one challenge.
+   *
+   * Chromium re-fires `onAuthRequired` for the same requestId when the
+   * credentials are rejected, so `authTries` walks the candidates registered
+   * for the challenged proxy and then the profile-wide fallbacks, one per
+   * attempt, instead of replying with the same rejected password forever.
+   */
+  private _credentialsFor(
+    details: chrome.webRequest.WebAuthenticationChallengeDetails,
+  ): chrome.webRequest.BlockingResponse {
+    if (!details.isProxy) return {};
+    let req = this._requests[details.requestId];
+    if (!req) {
+      req = { authTries: 0 };
+      this._requests[details.requestId] = req;
+    }
+
+    let list: AuthEntry[] | undefined;
+    let key: string | undefined;
+    for (const k of this._keysForChallenger(details.challenger)) {
+      if (this._proxies[k]) {
+        list = this._proxies[k];
+        key = k;
+        break;
+      }
+    }
+    key ??= this._keyForProxy(details.challenger);
+    list ??= this._proxies[key];
+
+    const listLen = list ? list.length : 0;
+    const entry =
+      req.authTries < listLen
+        ? list?.[req.authTries]
+        : this._fallbacks[req.authTries - listLen];
+    this.log?.log('ProxyAuth', key, req.authTries, entry?.name);
+
+    if (!entry) return {};
+    const credentials = this._normalizeAuth(entry.auth);
+    if (!credentials) return {};
+    req.authTries++;
+    return { authCredentials: credentials };
+  }
+
+  /**
+   * @param asyncCallback present only when registered with `asyncBlocking`.
+   */
+  authHandler(
+    details: chrome.webRequest.WebAuthenticationChallengeDetails,
+    asyncCallback?: (response: chrome.webRequest.BlockingResponse) => void,
+  ): chrome.webRequest.BlockingResponse | undefined {
+    const respond = (
+      result: chrome.webRequest.BlockingResponse,
+    ): chrome.webRequest.BlockingResponse | undefined => {
+      if (typeof asyncCallback === 'function') {
+        asyncCallback(result);
+        return undefined;
+      }
+      return result;
+    };
+
+    if (!details.isProxy) return respond({});
+
+    // Fast path: credentials are already in memory.
+    if (this._hydrated) return respond(this._credentialsFor(details));
+
+    // The worker has just woken up. Only asyncBlocking lets us answer after
+    // reading storage; in plain blocking mode there is nothing to wait with.
+    if (typeof asyncCallback === 'function') {
+      void this._hydrate().then(
+        () => {
+          respond(this._credentialsFor(details));
+        },
+        () => {
+          respond({});
+        },
+      );
+      return undefined;
+    }
+
+    return respond(this._credentialsFor(details));
+  }
+
+  private _requestDone(details: { requestId: string }): void {
+    delete this._requests[details.requestId];
+  }
+}
+
+export default ProxyAuth;

--- a/packages/extension/src/proxy-settings.ts
+++ b/packages/extension/src/proxy-settings.ts
@@ -18,6 +18,8 @@ import type {
 import { Log } from '@switchydelta/target';
 import type { Logger } from '@switchydelta/target';
 
+import { ProxyAuth } from './proxy-auth.js';
+
 const PROTOCOLS = ['proxyForHttp', 'proxyForHttps', 'proxyForFtp'] as const;
 
 /**
@@ -72,7 +74,10 @@ export class ProxySettings {
     const opts = options ?? {};
 
     if (profile.profileType === 'SystemProfile') {
-      // Clear proxy settings, returning proxy control to Chromium.
+      // Drop any stored credentials so the popup no longer offers the host
+      // permission for a profile that is no longer applied, then hand proxy
+      // control back to Chromium.
+      await this.setProxyAuth(profile, opts);
       await settingsClear();
       return;
     }
@@ -97,6 +102,7 @@ export class ProxySettings {
       };
     }
 
+    await this.setProxyAuth(profile, opts);
     await settingsSet({ value: config });
   }
 
@@ -158,6 +164,25 @@ export class ProxySettings {
       profileType: 'VirtualProfile',
       defaultProfileName: 'direct',
     } as Profile);
+  }
+
+  /**
+   * Hand the credentials of every profile this one depends on to the auth
+   * singleton, which the service worker has already attached its listener to.
+   */
+  async setProxyAuth(profile: Profile, options: OptionsBag): Promise<void> {
+    const proxyAuth = ProxyAuth.shared(this.log);
+    proxyAuth.listen();
+
+    const referenced: Profile[] = [];
+    const refSet = Profiles.allReferenceSet(profile, options, {
+      profileNotFound: (name) => this._profileNotFound(name),
+    });
+    for (const name of Object.values(refSet)) {
+      const referencedProfile = Profiles.byName(name, options);
+      if (referencedProfile) referenced.push(referencedProfile);
+    }
+    proxyAuth.setProxies(referenced);
   }
 
   getProfilePacScript(profile: Profile, options: OptionsBag): string {

--- a/packages/extension/src/sw.ts
+++ b/packages/extension/src/sw.ts
@@ -2,6 +2,7 @@
  * MV3 service worker entry point.
  *
  * Responsibilities in this build, and nothing more:
+ *   - proxy authentication (the only context where onAuthRequired can live)
  *   - scheduled PAC / rule-list downloads, via chrome.alarms
  *   - applying the selected profile to chrome.proxy.settings
  *   - answering RPC from the options page and popup
@@ -15,7 +16,17 @@ import type { StorageItems } from '@switchydelta/target';
 
 import { ChromeOptions } from './chrome-options.js';
 import { ChromeStorage } from './chrome-storage.js';
+import { ProxyAuth } from './proxy-auth.js';
 import { ProxySettings } from './proxy-settings.js';
+
+/**
+ * Registered before anything async runs.
+ *
+ * MV3 delivers the event that woke the worker only if its listener was
+ * registered in the first turn of the event loop. Deferring this until boot()
+ * resolves would drop the auth challenge that started the worker.
+ */
+ProxyAuth.shared(Log).listen();
 
 /** An Error flattened for structured cloning back to the UI. */
 function encodeError(value: unknown): unknown {

--- a/packages/ui/options.html
+++ b/packages/ui/options.html
@@ -25,14 +25,16 @@
 
     <main class="om-main">
       <header class="om-toolbar">
-        <button type="button" id="om-apply" class="om-btn om-btn-primary" disabled>
-          <span data-i18n="options_apply">Apply changes</span>
-        </button>
-        <button type="button" id="om-revert" class="om-btn" disabled>
-          <span data-i18n="options_discard">Discard</span>
-        </button>
-        <span id="om-status" class="om-status" role="status"></span>
-        <!-- No catalogue string exists for this (side-panel-only feature). -->
+        <div class="om-toolbar-start">
+          <button type="button" id="om-apply" class="om-btn om-btn-primary" disabled>
+            <span data-i18n="options_apply">Apply changes</span>
+          </button>
+          <button type="button" id="om-revert" class="om-btn" disabled>
+            <span data-i18n="options_discard">Discard</span>
+          </button>
+          <span id="om-status" class="om-status" role="status"></span>
+        </div>
+        <!-- Side-panel escape hatch; hidden in wide/tab layouts via CSS. -->
         <button type="button" id="om-open-tab" class="om-btn">Open in tab</button>
       </header>
 

--- a/packages/ui/popup.html
+++ b/packages/ui/popup.html
@@ -11,6 +11,15 @@
       <p class="om-notice-detail" id="om-not-controllable-detail"></p>
     </div>
 
+    <div id="om-auth-permission" class="om-notice" hidden>
+      <p class="om-notice-detail" data-i18n="popup_proxyAuthPermission">
+        Signing in to authenticated proxies needs access to all websites.
+      </p>
+      <button type="button" class="om-notice-action" id="om-auth-grant" data-i18n="popup_proxyAuthPermissionGrant">
+        Grant access
+      </button>
+    </div>
+
     <nav id="om-root" aria-label="Profiles">
       <ul id="om-profiles" class="om-list"></ul>
 

--- a/packages/ui/src/lib/messaging.ts
+++ b/packages/ui/src/lib/messaging.ts
@@ -136,7 +136,18 @@ export const api = {
   setOptionsSync: (enabled: boolean, args?: { force?: boolean }) =>
     callBackground('setOptionsSync', enabled, args),
   resetOptionsSync: () => callBackground('resetOptionsSync'),
+
+  proxyAuthStatus: () =>
+    callBackground<{ hasCredentials: boolean; hostAccess: boolean }>('proxyAuthStatus'),
 };
+
+/**
+ * Ask for the optional `<all_urls>` host permission that proxy authentication
+ * needs. Must be called synchronously from a user gesture.
+ */
+export function requestHostAccess(): Promise<boolean> {
+  return chrome.permissions.request({ origins: ['<all_urls>'] });
+}
 
 // --- Tabs -------------------------------------------------------------------
 

--- a/packages/ui/src/options/main.ts
+++ b/packages/ui/src/options/main.ts
@@ -10,7 +10,7 @@
 
 import { must, on, render } from '../lib/dom.js';
 import { localizeDocument, profileDisplayName, t } from '../lib/i18n.js';
-import { api, callBackground, localState } from '../lib/messaging.js';
+import { api, callBackground, localState, requestHostAccess } from '../lib/messaging.js';
 import { colorFor, listProfiles } from '../lib/profile-view.js';
 import { deepEqual } from '../lib/equal.js';
 import {
@@ -21,7 +21,7 @@ import {
   renderProfile,
   renderUi,
 } from './views.js';
-import type { OptionsBag } from '@switchydelta/pac';
+import type { FixedProfile, OptionsBag } from '@switchydelta/pac';
 
 /** The saved state, used to decide what actually changed. */
 let pristine: OptionsBag = {};
@@ -53,6 +53,18 @@ export function adoptOptionsKey(key: string, value: unknown): void {
   markDirty();
 }
 
+/** True when any fixed profile carries proxy credentials. */
+function profilesNeedAuth(bag: OptionsBag): boolean {
+  for (const profile of listProfiles(bag)) {
+    const auth = (profile as FixedProfile).auth;
+    if (!auth) continue;
+    for (const entry of Object.values(auth)) {
+      if (entry?.username) return true;
+    }
+  }
+  return false;
+}
+
 export async function applyChanges(): Promise<void> {
   const changes: Record<string, unknown> = {};
   for (const key of changedKeys()) {
@@ -60,12 +72,20 @@ export async function applyChanges(): Promise<void> {
   }
   if (Object.keys(changes).length === 0) return;
 
+  // Start the optional host grant before any await so the call stays inside
+  // the Apply click gesture. Without `<all_urls>`, onAuthRequired never fires.
+  const hostAccess = profilesNeedAuth(options)
+    ? requestHostAccess()
+    : Promise.resolve(true);
+
   try {
     // `undefined` marks a removed key, matching the storage layer's convention.
     await callBackground('applyChanges', changes);
     pristine = structuredClone(options);
     markDirty();
     must('#om-status').textContent = t('options_saveSuccess');
+    // Settle the permission prompt after the save so a denial does not block it.
+    void hostAccess;
   } catch (err) {
     must('#om-status').textContent = err instanceof Error ? err.message : String(err);
   }
@@ -163,6 +183,17 @@ async function main(): Promise<void> {
   // particular are unusable at panel width).
   must('#om-open-tab').addEventListener('click', () => {
     void chrome.tabs.create({ url: chrome.runtime.getURL('options.html') + location.hash });
+  });
+
+  // External links (About privacy/FAQ/license, help text) cannot navigate
+  // inside the side panel / options page; open them in a normal browser tab.
+  document.addEventListener('click', (event) => {
+    const anchor = (event.target as Element | null)?.closest?.('a');
+    if (!anchor) return;
+    const href = anchor.getAttribute('href');
+    if (!href || !/^https?:\/\//i.test(href)) return;
+    event.preventDefault();
+    void chrome.tabs.create({ url: href });
   });
 
   // Any control carrying data-option writes straight into the working copy.

--- a/packages/ui/src/options/options.css
+++ b/packages/ui/src/options/options.css
@@ -45,6 +45,16 @@ body.om-options {
 /* Only useful when the page is cramped; in a full tab it is redundant. */
 #om-open-tab {
   display: none;
+  flex-shrink: 0;
+}
+
+.om-toolbar-start {
+  display: flex;
+  flex: 1 1 auto;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  min-width: 0;
 }
 
 .om-sidebar {
@@ -118,6 +128,7 @@ body.om-options {
   display: flex;
   gap: 8px;
   align-items: center;
+  justify-content: space-between;
   padding: 12px 24px;
   background: var(--om-bg);
   border-bottom: 1px solid var(--om-border);
@@ -403,6 +414,66 @@ body.om-options {
   gap: 8px;
 }
 
+/* Username / password for the single fixed proxy.
+   Stacked full-width so the side panel (~360px) never crushes fields. */
+.om-auth-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+/* Password field with the eye toggle inside the input (Bitwarden-style). */
+.om-auth-password {
+  position: relative;
+  display: block;
+  width: 100%;
+}
+
+.om-auth-password input {
+  width: 100%;
+  min-width: 0;
+  /* Room for the in-field eye button. */
+  padding-right: 2.5em;
+}
+
+.om-password-toggle {
+  position: absolute;
+  top: 50%;
+  right: 4px;
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2em;
+  height: 2em;
+  padding: 0;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--om-muted);
+  cursor: pointer;
+}
+
+.om-password-toggle:hover {
+  color: var(--om-fg);
+  background: color-mix(in srgb, currentcolor 8%, transparent);
+}
+
+.om-password-toggle:focus-visible {
+  outline: 2px solid var(--om-accent);
+  outline-offset: 1px;
+}
+
+.om-password-toggle svg {
+  display: block;
+  width: 18px;
+  height: 18px;
+}
+
+.om-auth-warning {
+  color: var(--om-danger);
+}
+
 .om-item-new {
   color: var(--om-accent);
 }
@@ -474,11 +545,24 @@ body.om-options {
     border-radius: 999px;
   }
 
-  /* Buttons wrap rather than forcing the toolbar wider than the panel. */
+  /* One compact row: [Apply] [Discard] … [Open in tab]. Avoids the old
+     flex-wrap + margin-left:auto layout that left Open in tab alone on a
+     second row, right-aligned under empty space. */
   .om-toolbar {
-    flex-wrap: wrap;
     top: 47px;
-    padding: 10px 14px;
+    padding: 8px 10px;
+    gap: 4px;
+  }
+
+  .om-toolbar-start {
+    gap: 4px;
+  }
+
+  .om-toolbar .om-btn {
+    padding: 3px 8px;
+    font-size: 12px;
+    border-radius: 5px;
+    white-space: nowrap;
   }
 
   .om-view {
@@ -486,8 +570,8 @@ body.om-options {
   }
 
   #om-open-tab {
-    display: inline-block;
-    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
   }
 }
 
@@ -506,6 +590,7 @@ body.om-options {
 .om-field input[type="text"],
 .om-field input[type="url"],
 .om-field input[type="number"],
+.om-field input[type="password"],
 .om-field select,
 .om-field textarea {
   width: 100%;

--- a/packages/ui/src/options/views.ts
+++ b/packages/ui/src/options/views.ts
@@ -426,8 +426,14 @@ export function renderAbout(container: HTMLElement): void {
   const version = chrome.runtime.getManifest().version;
   container.append(
     h('h2', { text: t('about_title') }),
-    h('p', { text: `${t('appNameShort')} ${version}` }),
-    h('p', {}, h('a', { href: 'https://github.com/madeye/SwitchyDelta', text: 'GitHub' })),
+    h('p', { text: t('about_app_description') }),
+    h('p', { text: t('about_version', [version]) }),
+    help('about_disclaimer_networkService'),
+    help('about_disclaimer_privacy'),
+    help('about_help'),
+    help('about_copyright'),
+    help('about_license'),
+    help('about_credits'),
   );
 }
 
@@ -1243,6 +1249,9 @@ export function renderNewProfile(container: HTMLElement): void {
   );
 }
 
+/** Chromium can answer HTTP(S) proxy 407 challenges via webRequestAuthProvider. */
+const AUTH_SUPPORTED = new Set(['http', 'https']);
+
 function renderFixedProfile(container: HTMLElement, profile: FixedProfile): void {
   const proxy: ProxyServer = profile.fallbackProxy ?? { scheme: 'http', host: '', port: 80 };
   profile.fallbackProxy = proxy;
@@ -1252,12 +1261,39 @@ function renderFixedProfile(container: HTMLElement, profile: FixedProfile): void
     markDirty();
   };
 
+  /** Keep `auth.fallbackProxy` in sync with the single proxy this editor owns. */
+  const writeAuth = (username: string, password: string) => {
+    if (!username) {
+      if (profile.auth) {
+        delete profile.auth.fallbackProxy;
+        if (Object.keys(profile.auth).length === 0) delete profile.auth;
+      }
+      return;
+    }
+    profile.auth ??= {};
+    profile.auth.fallbackProxy = { username, password };
+  };
+
   const scheme = h(
     'select',
     {
       onchange: (event: Event) => {
         proxy.scheme = (event.target as HTMLSelectElement).value;
         if (!port.value) proxy.port = DEFAULT_PORTS[proxy.scheme] ?? 80;
+        // Drop credentials when the protocol cannot carry them.
+        if (!AUTH_SUPPORTED.has(proxy.scheme)) {
+          writeAuth('', '');
+          username.value = '';
+          password.value = '';
+          password.disabled = true;
+          authWarning.hidden = false;
+          authWarning.innerHTML = t('options_proxy_authNotSupported', [
+            proxy.scheme.toUpperCase(),
+          ]);
+        } else {
+          authWarning.hidden = true;
+          password.disabled = !username.value;
+        }
         touch();
       },
     },
@@ -1286,6 +1322,73 @@ function renderFixedProfile(container: HTMLElement, profile: FixedProfile): void
     },
   });
 
+  const existing = profile.auth?.fallbackProxy;
+  const username = h('input', {
+    type: 'text',
+    value: existing?.username ?? '',
+    autocomplete: 'username',
+    placeholder: t('options_proxyAuthUsername'),
+    oninput: (event: Event) => {
+      const value = (event.target as HTMLInputElement).value;
+      password.disabled = !value;
+      if (!value) {
+        password.value = '';
+        password.placeholder = t('options_proxyAuthNone');
+      } else {
+        password.placeholder = t('options_proxyAuthPassword');
+      }
+      writeAuth(value, password.value);
+      touch();
+    },
+  });
+
+  const password = h('input', {
+    type: 'password',
+    value: existing?.password ?? '',
+    autocomplete: 'current-password',
+    placeholder: t(existing?.username ? 'options_proxyAuthPassword' : 'options_proxyAuthNone'),
+    disabled: !existing?.username,
+    oninput: (event: Event) => {
+      writeAuth(username.value, (event.target as HTMLInputElement).value);
+      touch();
+    },
+  });
+
+  // Bitwarden-style: simple eye outline + pupil; slashed when the password is visible.
+  const icon = (paths: string) =>
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${paths}</svg>`;
+  const eyeShape =
+    '<path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7S2 12 2 12Z"/><circle cx="12" cy="12" r="3"/>';
+  // Password hidden → click to show.
+  const eyeIcon = icon(eyeShape);
+  // Password visible → click to hide.
+  const eyeSlashIcon = icon(`${eyeShape}<line x1="3" y1="3" x2="21" y2="21"/>`);
+
+  const setPasswordVisible = (visible: boolean) => {
+    password.type = visible ? 'text' : 'password';
+    const label = t(visible ? 'options_proxyAuthHidePassword' : 'options_proxyAuthShowPassword');
+    showPassword.title = label;
+    showPassword.setAttribute('aria-label', label);
+    showPassword.setAttribute('aria-pressed', visible ? 'true' : 'false');
+    showPassword.innerHTML = visible ? eyeSlashIcon : eyeIcon;
+  };
+
+  const showPassword = h('button', {
+    type: 'button',
+    class: 'om-password-toggle',
+    title: t('options_proxyAuthShowPassword'),
+    'aria-label': t('options_proxyAuthShowPassword'),
+    'aria-pressed': 'false',
+    onclick: () => setPasswordVisible(password.type === 'password'),
+  });
+  showPassword.innerHTML = eyeIcon;
+
+  const authWarning = h('p', {
+    class: 'om-help om-auth-warning',
+    html: t('options_proxy_authNotSupported', [proxy.scheme.toUpperCase()]),
+    hidden: AUTH_SUPPORTED.has(proxy.scheme),
+  });
+
   const bypass = h('textarea', {
     value: (profile.bypassList ?? []).map((c) => c.pattern).join('\n'),
     oninput: (event: Event) => {
@@ -1306,6 +1409,18 @@ function renderFixedProfile(container: HTMLElement, profile: FixedProfile): void
       field('options_proxy_server', host),
       field('options_proxy_port', port),
     ),
+    h(
+      'div',
+      { class: 'om-auth-row' },
+      field('options_proxyAuthUsername', username),
+      h(
+        'label',
+        { class: 'om-field' },
+        h('span', { text: t('options_proxyAuthPassword') }),
+        h('div', { class: 'om-auth-password' }, password, showPassword),
+      ),
+    ),
+    authWarning,
     field('options_group_bypassList', bypass),
   );
 }

--- a/packages/ui/src/popup/main.ts
+++ b/packages/ui/src/popup/main.ts
@@ -10,7 +10,14 @@
 
 import { all, h, must, on, render } from '../lib/dom.js';
 import { localizeDocument, profileDisplayName, t } from '../lib/i18n.js';
-import { api, getState, openOptions, openSidePanel, refreshActivePage } from '../lib/messaging.js';
+import {
+  api,
+  getState,
+  openOptions,
+  openSidePanel,
+  refreshActivePage,
+  requestHostAccess,
+} from '../lib/messaging.js';
 
 /** A profile as summarised by the background for display. */
 interface AvailableProfile {
@@ -82,6 +89,9 @@ async function main(): Promise<void> {
   renderProfiles();
   wireActions();
   installKeyboard();
+
+  // Fire-and-forget so the profile list never waits on the permission check.
+  void maybeOfferAuthPermission();
 
   // Focus the current profile so keyboard use starts from a sensible place.
   const current = document.querySelector<HTMLElement>('.om-item[aria-current="true"]');
@@ -219,6 +229,31 @@ function installKeyboard(): void {
     event.preventDefault();
     const next = items[(activeIndex + delta + items.length) % items.length];
     next?.focus();
+  });
+}
+
+/**
+ * Proxy credentials only take effect once the optional `<all_urls>` host
+ * permission is granted, since webRequest events are gated by host access.
+ * Offer the grant when the applied profiles carry credentials but the
+ * permission is missing.
+ */
+async function maybeOfferAuthPermission(): Promise<void> {
+  let status: { hasCredentials: boolean; hostAccess: boolean };
+  try {
+    status = await api.proxyAuthStatus();
+  } catch {
+    return;
+  }
+  if (!status.hasCredentials || status.hostAccess) return;
+
+  const notice = must('#om-auth-permission');
+  notice.hidden = false;
+  must('#om-auth-grant').addEventListener('click', () => {
+    // requestHostAccess must be called synchronously inside the click gesture.
+    void requestHostAccess().then((granted) => {
+      if (granted) notice.hidden = true;
+    });
   });
 }
 

--- a/packages/ui/src/popup/popup.css
+++ b/packages/ui/src/popup/popup.css
@@ -138,6 +138,22 @@ body.om-popup {
   font-size: 12px;
 }
 
+.om-notice-action {
+  margin-top: 6px;
+  padding: 3px 10px;
+  font: inherit;
+  font-size: 12px;
+  color: inherit;
+  background: transparent;
+  border: 1px solid var(--om-border);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.om-notice-action:hover {
+  background: color-mix(in srgb, currentcolor 8%, transparent);
+}
+
 .om-error {
   margin: 6px 12px 0;
   color: var(--om-danger);

--- a/test/e2e/smoke.mjs
+++ b/test/e2e/smoke.mjs
@@ -146,11 +146,26 @@ if (!sw) {
   await s.send('Log.enable');
   await sleep(2500);
 
+  // Chrome logs this when webRequest listeners are registered while the
+  // optional <all_urls> grant is still ungranted. That is the intended state
+  // of a fresh profile: proxy-auth listeners must be registered in the
+  // worker's first turn, and stay silent until the user grants host access.
+  const expectedPreGrant =
+    'You need to request host permissions in the manifest file in order to' +
+    ' be notified about requests from the webRequest API.';
+
+  const errorText = (e) =>
+    e.params?.exceptionDetails?.exception?.description ??
+    e.params?.exceptionDetails?.text ??
+    e.params?.entry?.text ??
+    (e.params?.args?.map((a) => a.value ?? a.description).join(' ') || '');
+
   const errors = s.events.filter(
     (e) =>
-      e.method === 'Runtime.exceptionThrown' ||
-      (e.method === 'Log.entryAdded' && e.params?.entry?.level === 'error') ||
-      (e.method === 'Runtime.consoleAPICalled' && e.params?.type === 'error'),
+      (e.method === 'Runtime.exceptionThrown' ||
+        (e.method === 'Log.entryAdded' && e.params?.entry?.level === 'error') ||
+        (e.method === 'Runtime.consoleAPICalled' && e.params?.type === 'error')) &&
+      !errorText(e).includes(expectedPreGrant),
   );
 
   console.log(`\n=== service worker errors: ${errors.length} ===`);


### PR DESCRIPTION
## Summary
- Restore MV3 proxy authentication (`webRequest` + `webRequestAuthProvider`) without install-time host access: `<all_urls>` is optional and requested only when credentials are present.
- Persist credentials for service-worker restarts; register `onAuthRequired` on the first turn so wake-up challenges are not lost.
- Add fixed-profile username/password UI (in-field eye toggle), popup “Grant access” notice, About-page external links via `chrome.tabs.create`, compact side-panel toolbar, and copyright (Max Lv 2026 + SwitchyOmega authors).

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` (174)
- [x] `HEADLESS=1 npm run e2e`
- [ ] Manual: set proxy credentials → Apply → host permission prompt
- [ ] Manual: popup Grant access when credentials active without grant
- [ ] Manual: authenticated HTTP proxy receives credentials after grant
- [ ] Manual: About links open in a normal browser tab