### PR TITLE
Reduce runtime memory footprint

### DIFF
--- a/packages/extension/src/proxy-settings.ts
+++ b/packages/extension/src/proxy-settings.ts
@@ -83,6 +83,7 @@ export class ProxySettings {
     }
 
     let config: chrome.proxy.ProxyConfig;
+    let releaseCaches = false;
     if (profile.profileType === 'DirectProfile') {
       config = { mode: 'direct' };
     } else if (profile.profileType === 'PacProfile') {
@@ -100,10 +101,26 @@ export class ProxySettings {
         mode: 'pac_script',
         pacScript: { mandatory: true, data: this.getProfilePacScript(profile, opts) },
       };
+      releaseCaches = true;
     }
 
     await this.setProxyAuth(profile, opts);
     await settingsSet({ value: config });
+    if (releaseCaches) this._dropProfileCaches(profile, opts);
+  }
+
+  /**
+   * Once the compiled PAC string is in Chrome's settings, the analysis and
+   * codegen caches that produced it (parsed rules, regexes, code strings —
+   * megabytes for a large rule list) have no consumer left in the worker.
+   * They are rebuilt on demand, which the re-boot-on-wake model assumes.
+   */
+  private _dropProfileCaches(profile: Profile, options: OptionsBag): void {
+    const refSet = Profiles.allReferenceSet(profile, options, { profileNotFound: 'ignore' });
+    for (const name of Object.values(refSet)) {
+      const referenced = Profiles.byName(name, options);
+      if (referenced) Profiles.dropCache(referenced);
+    }
   }
 
   private _fixedProfileConfig(profile: FixedProfile): chrome.proxy.ProxyConfig {

--- a/packages/pac/src/profiles.ts
+++ b/packages/pac/src/profiles.ts
@@ -322,6 +322,14 @@ export interface RulesAnalysis {
   /** Per-rule: true when every pattern of the rule went into the trie. */
   simpleHost: boolean[];
   hasNonHostRules: boolean;
+  /** True once the trie has been materialised. Exposed for tests. */
+  readonly hostAnalysisBuilt: boolean;
+}
+
+interface HostRulesAnalysis {
+  domainTrie: DomainTrie<number>;
+  simpleHost: boolean[];
+  hasNonHostRules: boolean;
 }
 
 /** True when a domain still has wildcards after prefix forms are stripped. */
@@ -361,7 +369,33 @@ export function hostPatternToTrieKeys(pattern: string): string[] | null {
   return [source];
 }
 
+/**
+ * The trie only serves the in-process match() path; compile() never reads it.
+ * Deferring its construction keeps PAC generation — the sole consumer in the
+ * service worker — from paying its cost, which is several MB for a large
+ * rule list.
+ */
 export function buildRulesAnalysis(rules: Rule[]): RulesAnalysis {
+  let host: HostRulesAnalysis | null = null;
+  const analyzed = () => (host ??= buildHostRulesAnalysis(rules));
+  return {
+    rules,
+    get domainTrie() {
+      return analyzed().domainTrie;
+    },
+    get simpleHost() {
+      return analyzed().simpleHost;
+    },
+    get hasNonHostRules() {
+      return analyzed().hasNonHostRules;
+    },
+    get hostAnalysisBuilt() {
+      return host !== null;
+    },
+  };
+}
+
+function buildHostRulesAnalysis(rules: Rule[]): HostRulesAnalysis {
   const domainTrie = new DomainTrie<number>();
   const simpleHost = new Array<boolean>(rules.length).fill(false);
   let hasNonHostRules = false;
@@ -393,7 +427,7 @@ export function buildRulesAnalysis(rules: Rule[]): RulesAnalysis {
     }
   });
 
-  return { rules, domainTrie, simpleHost, hasNonHostRules };
+  return { domainTrie, simpleHost, hasNonHostRules };
 }
 
 // --- Handlers ---------------------------------------------------------------
@@ -659,10 +693,14 @@ const profileTypes: Record<string, AnyProfileHandler | string> = {
       if (formatHandler.preprocess) {
         ruleList = formatHandler.preprocess(ruleList);
       }
+      // The source line is only useful to rule-list editors, which parse the
+      // text themselves; dropping it here keeps a copy of every line out of
+      // the analysis retained by the profile cache.
       const rules = formatHandler.parse(
         ruleList,
         profile.matchProfileName,
         profile.defaultProfileName,
+        { source: false },
       );
       return buildRulesAnalysis(rules);
     },

--- a/packages/pac/src/rule-list.ts
+++ b/packages/pac/src/rule-list.ts
@@ -20,7 +20,12 @@ export interface FormatHandler {
   /** True/false when the format is certain, undefined when unknown. */
   detect?(text: string): boolean | undefined;
   preprocess?(text: string): string;
-  parse(text: string, matchProfileName: string, defaultProfileName: string): Rule[];
+  parse(
+    text: string,
+    matchProfileName: string,
+    defaultProfileName: string,
+    args?: ParseArgs,
+  ): Rule[];
   directReferenceSet?(profile: RuleListProfile): Record<string, string> | undefined;
 }
 
@@ -45,7 +50,8 @@ export const AutoProxy: FormatHandler = {
     return text.startsWith(AUTOPROXY_MAGIC_PREFIX) ? decodeBase64Utf8(text) : text;
   },
 
-  parse(text, matchProfileName, defaultProfileName) {
+  parse(text, matchProfileName, defaultProfileName, args) {
+    const includeSource = args?.source ?? true;
     const normalRules: Rule[] = [];
     const exclusiveRules: Rule[] = [];
 
@@ -80,7 +86,9 @@ export const AutoProxy: FormatHandler = {
         condition = { conditionType: 'UrlWildcardCondition', pattern: 'http://*' + line + '*' };
       }
 
-      list.push({ condition, profileName: profile, source });
+      const rule: Rule = { condition, profileName: profile };
+      if (includeSource) rule.source = source;
+      list.push(rule);
     }
 
     // Exclusive rules take priority, so they are evaluated first.
@@ -171,7 +179,9 @@ function parseLegacy(
   text: string,
   matchProfileName: string,
   defaultProfileName: string,
+  args: ParseArgs = {},
 ): Rule[] {
+  const includeSource = args.source ?? true;
   const normalRules: Rule[] = [];
   const exclusiveRules: Rule[] = [];
   let begin = false;
@@ -209,7 +219,9 @@ function parseLegacy(
     }
 
     if (condition) {
-      list.push({ condition, profileName: profile, source });
+      const rule: Rule = { condition, profileName: profile };
+      if (includeSource) rule.source = source;
+      list.push(rule);
     }
   }
 
@@ -346,11 +358,11 @@ export const Switchy: FormatHandler & {
     return undefined;
   },
 
-  parse(text, matchProfileName, defaultProfileName) {
+  parse(text, matchProfileName, defaultProfileName, args) {
     const parser = getParser(text);
     return parser === 'parseOmega'
-      ? parseOmega(text, matchProfileName, defaultProfileName)
-      : parseLegacy(text, matchProfileName, defaultProfileName);
+      ? parseOmega(text, matchProfileName, defaultProfileName, args)
+      : parseLegacy(text, matchProfileName, defaultProfileName, args);
   },
 
   directReferenceSet({ ruleList, defaultProfileName }) {

--- a/packages/pac/test/domain-trie.test.ts
+++ b/packages/pac/test/domain-trie.test.ts
@@ -252,6 +252,20 @@ describe('DomainTrie integration with profiles', () => {
       return Conditions.requestFromUrl(url);
     }
 
+    it('should not materialise the trie for compile(), only for match()', () => {
+      const profile = makeProfile([
+        {
+          condition: { conditionType: 'HostWildcardCondition', pattern: '*.example.com' },
+          profileName: 'proxy1',
+        },
+      ]);
+      Profiles.compile(profile);
+      const analysis = Profiles.analyze(profile) as Profiles.RulesAnalysis;
+      expect(analysis.hostAnalysisBuilt).toBe(false);
+      Profiles.match(profile, makeRequest('http://www.example.com/'));
+      expect(analysis.hostAnalysisBuilt).toBe(true);
+    });
+
     it('should match domains via the trie', () => {
       const profile = makeProfile([
         {

--- a/packages/pac/test/profiles.test.ts
+++ b/packages/pac/test/profiles.test.ts
@@ -11,8 +11,8 @@ import type {
   SwitchProfile,
 } from '../src/types.js';
 
-function ruleListResult(profileName: string, source: string): { profileName: string; source: string } {
-  return { profileName, source };
+function ruleListResult(profileName: string): { profileName: string; ruleList: true } {
+  return { profileName, ruleList: true };
 }
 
 /**
@@ -57,9 +57,11 @@ function testProfile(
 
   if (expected !== null && expected !== undefined) {
     const matchResult = Profiles.match(profile, req);
-    if (expected.source !== undefined) {
+    if (expected.ruleList) {
       expect((matchResult as Rule | undefined)?.profileName).toBe(expected.profileName);
-      expect((matchResult as Rule | undefined)?.source).toBe(expected.source);
+      // The analyze path parses with `source: false` to keep a second copy of
+      // every rule line off the heap.
+      expect((matchResult as Rule | undefined)?.source).toBeUndefined();
     } else {
       expect(matchResult).toEqual(expected);
     }
@@ -394,7 +396,7 @@ describe('Profiles', () => {
       testProfile(
         profile,
         'http://localhost/example.com',
-        ruleListResult('example', 'example.com'),
+        ruleListResult('example'),
       );
       testProfile(profile, 'http://localhost/example.org', ['+default', null]);
     });
@@ -406,7 +408,7 @@ describe('Profiles', () => {
       testProfile(
         profile,
         'http://localhost/example.org',
-        ruleListResult('example', 'example.org'),
+        ruleListResult('example'),
       );
     });
 
@@ -435,7 +437,7 @@ describe('Profiles', () => {
       testProfile(
         profile,
         'http://localhost/example.org',
-        ruleListResult('example', 'example.org'),
+        ruleListResult('example'),
       );
     });
   });

--- a/packages/ui/src/options/main.ts
+++ b/packages/ui/src/options/main.ts
@@ -28,6 +28,22 @@ let pristine: OptionsBag = {};
 /** The live, edited copy bound to the form controls. */
 export let options: OptionsBag = {};
 
+/**
+ * Clone the options bag for dirty tracking. Unlike structuredClone this
+ * shares strings between the copies — rule-list texts are the bulk of the bag
+ * and every edit path assigns a new string rather than mutating — while
+ * object and array nodes still get distinct identities, which the in-place
+ * edits and deepEqual comparisons rely on. The bag is JSON-shaped by
+ * construction (it round-trips chrome.storage), so no other types occur.
+ */
+function snapshot<T>(value: T): T {
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map(snapshot) as unknown as T;
+  const out: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value as object)) out[key] = snapshot(entry);
+  return out as T;
+}
+
 export function isDirty(): boolean {
   return changedKeys().length > 0;
 }
@@ -48,8 +64,8 @@ function changedKeys(): string[] {
 
 /** Adopt a background-refreshed value for one key without marking it dirty. */
 export function adoptOptionsKey(key: string, value: unknown): void {
-  pristine[key] = structuredClone(value);
-  options[key] = structuredClone(value);
+  pristine[key] = snapshot(value);
+  options[key] = snapshot(value);
   markDirty();
 }
 
@@ -81,7 +97,7 @@ export async function applyChanges(): Promise<void> {
   try {
     // `undefined` marks a removed key, matching the storage layer's convention.
     await callBackground('applyChanges', changes);
-    pristine = structuredClone(options);
+    pristine = snapshot(options);
     markDirty();
     must('#om-status').textContent = t('options_saveSuccess');
     // Settle the permission prompt after the save so a denial does not block it.
@@ -172,7 +188,7 @@ async function main(): Promise<void> {
     must('#om-view').textContent = err instanceof Error ? err.message : String(err);
     return;
   }
-  options = structuredClone(pristine);
+  options = snapshot(pristine);
 
   renderProfileNav();
 

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -9,7 +9,7 @@ import { defineConfig } from 'vite';
  * inline script) and `cssCodeSplit` off (avoids the inline style injector).
  * Everything Vite emits is then an external file the manifest can load.
  */
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   // The extension loads pages from its own package root, so asset URLs must be
   // relative rather than server-absolute.
   base: './',
@@ -27,7 +27,9 @@ export default defineConfig({
     // Polyfill stays off so nothing is inlined (MV3 script-src 'self').
     modulePreload: false,
     cssCodeSplit: false,
-    sourcemap: true,
+    // Maps are dev-only: build-extension.mjs copies this output into the
+    // release zip verbatim, and shipped maps are pure package weight.
+    sourcemap: mode === 'development',
 
     rollupOptions: {
       input: {
@@ -41,4 +43,4 @@ export default defineConfig({
       },
     },
   },
-});
+}));

--- a/scripts/build-extension.mjs
+++ b/scripts/build-extension.mjs
@@ -15,6 +15,11 @@ import { fileURLToPath } from 'node:url';
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const out = resolve(root, 'dist');
 
+// Minified is the default: publish-chrome.mjs zips dist/ as-is, so an ambient
+// env var must not be able to leak a debug build (or its sourcemaps) into a
+// release. `--dev` opts into readable output.
+const dev = process.argv.includes('--dev');
+
 async function exists(path) {
   try {
     await stat(path);
@@ -46,8 +51,8 @@ await build({
   format: 'esm',
   // Matches minimum_chrome_version in the manifest.
   target: 'chrome109',
-  minify: process.env['NODE_ENV'] === 'production',
-  sourcemap: true,
+  minify: !dev,
+  sourcemap: dev,
   logLevel: 'warning',
 });
 


### PR DESCRIPTION
## Summary

Result of a multi-agent memory audit (5 domain analyzers + adversarial verification of the top findings, with measured numbers from an instrumented 6k-rule GFWList: ~8.9 MB retained in the service-worker heap while awake).

- **Lazy DomainTrie** (`packages/pac/src/profiles.ts`): the trie only serves the in-process `match()` path, but was built eagerly as a side effect of PAC compilation in the service worker — where it is never consulted (`matchProfile` currently has no RPC callers). Measured 1.7 MB at 6k rules, 3.6 MB at 14k. It's now materialised on first `match()` access via getters; `compile()` never triggers it. A regression test asserts this.
- **Release caches after PAC apply** (`packages/extension/src/proxy-settings.ts`): once the compiled PAC string is handed to `chrome.proxy.settings`, the parsed rules, per-condition RegExps and codegen strings (~7 MB for a gfwlist-scale list) have no remaining consumer in the worker. They're dropped and rebuilt on demand — pure CPU, which the re-boot-on-wake model already assumes.
- **Rule lists parse with `source: false` on the analyze path**: keeps a second copy of every rule line off the heap (~20–30 B/rule). Editors that need the source still get it via the default `source: true`.
- **`sw.js` minified by default** (188 KB → 86 KB parsed source per worker wake): the gate was `NODE_ENV=production`, which no documented build path sets, so releases shipped unminified. Minification is now the default with an explicit `--dev` opt-out, so no ambient env can leak a debug build into a release.
- **Sourcemaps are dev-only** (esbuild `--dev` flag / Vite development mode): `dist` drops **1.5 MB → 820 KB**, and ~600 KB of maps no longer ship in the CWS zip.
- **Options page (side panel, long-lived)**: replaced `structuredClone` of the whole options bag with a `snapshot()` clone that shares strings — rule-list texts are the bulk of the bag and every edit path assigns new strings rather than mutating, so the page no longer holds two copies of each list, and `deepEqual` short-circuits on shared strings.

## Testing

- `npm run typecheck` — clean
- `npm test` — 175/175 (includes the new trie-laziness test and match/compile parity suites)
- `HEADLESS=1 npm run e2e` against the minified build — all checks pass: gfwlist download + base64 decode + AutoProxy detection, PAC generation from ~4.5k rules, fixed_servers config, and real-URL resolution (twitter/google/youtube/wikipedia → PROXY, baidu/qq/localhost → DIRECT)
- `eslint` is not installed in the repo (missing from devDependencies), so lint could not run — pre-existing.