### PR TITLE
Fix popup 'Add condition' doing nothing

### DIFF
--- a/packages/ui/src/popup/main.ts
+++ b/packages/ui/src/popup/main.ts
@@ -163,9 +163,12 @@ function wireActions(): void {
   if (state.currentProfileCanAddRule) {
     addRule.hidden = false;
     addRule.addEventListener('click', () => {
-      // The full condition editor lives on the options page.
-      void openOptions('#/profile/' + encodeURIComponent(state.currentProfileName ?? ''));
-      window.close();
+      // The full condition editor lives on the options page. Close only once
+      // openOptions has settled: window.close() tears down this context, and
+      // the tab query/create still pending inside openOptions dies with it.
+      void openOptions('#/profile/' + encodeURIComponent(state.currentProfileName ?? '')).finally(
+        () => window.close(),
+      );
     });
   }
 
@@ -173,10 +176,11 @@ function wireActions(): void {
   // unavailable. openSidePanel must run before any await, or the user gesture
   // that authorises it is gone.
   must('#om-options').addEventListener('click', () => {
-    if (!openSidePanel()) {
-      void openOptions();
+    if (openSidePanel()) {
+      window.close();
+    } else {
+      void openOptions().finally(() => window.close());
     }
-    window.close();
   });
 }
 


### PR DESCRIPTION
## Summary

Clicking **Add condition** in the popup closed the popup without opening the condition editor. `wireActions` called the async `openOptions(...)` and then `window.close()` synchronously — but `openOptions` awaits `chrome.tabs.query` before it ever reaches `chrome.tabs.create`, and `window.close()` destroys the popup's JS context while that query is still in flight, so the tab never opens. The `#om-options` handler's side-panel-unavailable fallback had the same race.

The fix closes the popup only after `openOptions` settles (`.finally(() => window.close())`); the synchronous side-panel path still closes immediately, preserving the user-gesture requirement.

Also ruled out a second suspect: `chrome.tabs.query({url})` works for the extension's own pages without the `tabs` permission (dropped in #10), verified by probe.

## Testing

- CDP repro script driving the built extension in headless Chrome: on master, clicking `#om-add-rule` closes the popup and no options target appears; with the fix, `options.html#/profile/<name>` opens and the query probe passes.
- `npm run typecheck`, `npm test` (175/175), and `HEADLESS=1 npm run e2e` all pass.