### PR TITLE
Move the Open-in-tab button to the top of the side panel

### DIFF
--- a/packages/ui/options.html
+++ b/packages/ui/options.html
@@ -17,6 +17,8 @@
           <li><a class="om-item" href="#/io" data-i18n="options_tab_importExport">Import / Export</a></li>
           <li><a class="om-item" href="#/about" data-i18n="about_title">About</a></li>
         </ul>
+        <!-- Side-panel escape hatch; hidden in wide/tab layouts via CSS. -->
+        <button type="button" id="om-open-tab" class="om-btn">Open in tab</button>
 
         <p class="om-group-label" data-i18n="options_navHeader_profiles">Profiles</p>
         <ul class="om-list" id="om-nav-profiles"></ul>
@@ -34,8 +36,6 @@
           </button>
           <span id="om-status" class="om-status" role="status"></span>
         </div>
-        <!-- Side-panel escape hatch; hidden in wide/tab layouts via CSS. -->
-        <button type="button" id="om-open-tab" class="om-btn">Open in tab</button>
       </header>
 
       <section id="om-view" class="om-view"></section>

--- a/packages/ui/src/options/options.css
+++ b/packages/ui/src/options/options.css
@@ -523,12 +523,27 @@ body.om-options {
 
   /* Two chip rows: settings pages on top, profiles below. Each row scrolls
      sideways on its own, so profiles are always visible instead of being
-     buried at the end of one long strip. */
+     buried at the end of one long strip. The Open-in-tab escape hatch shares
+     the first row, pinned after the scrolling settings chips. */
   .om-sidebar nav {
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
     gap: 6px;
     padding: 0 10px;
+    align-items: center;
+  }
+
+  #om-nav-profiles {
+    grid-column: 1 / -1;
+  }
+
+  #om-open-tab {
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 10px;
+    font-size: 12px;
+    border-radius: 999px;
+    white-space: nowrap;
   }
 
   .om-sidebar .om-list {
@@ -545,9 +560,7 @@ body.om-options {
     border-radius: 999px;
   }
 
-  /* One compact row: [Apply] [Discard] … [Open in tab]. Avoids the old
-     flex-wrap + margin-left:auto layout that left Open in tab alone on a
-     second row, right-aligned under empty space. */
+  /* One compact row: [Apply] [Discard] [status]. */
   .om-toolbar {
     top: 47px;
     padding: 8px 10px;
@@ -567,11 +580,6 @@ body.om-options {
 
   .om-view {
     padding: 14px;
-  }
-
-  #om-open-tab {
-    display: inline-flex;
-    align-items: center;
   }
 }
 

--- a/test/e2e/side-panel.mjs
+++ b/test/e2e/side-panel.mjs
@@ -120,7 +120,9 @@ const layout = JSON.parse(await op.evalGesture(`JSON.stringify({
 })`));
 check('no horizontal overflow of the page', layout.overflowsX, false);
 check('body fits the panel width', layout.bodyScrollW, layout.clientW);
-check('nav collapsed to a scrollable strip', layout.sidebarDisplay, 'flex');
+// Grid since the Open-in-tab button moved into the nav's first row; the
+// rows-scroll check below is what actually guards against page widening.
+check('nav collapsed to a scrollable strip', layout.sidebarDisplay, 'grid');
 check('nav rows scroll internally instead of widening the page', layout.navScrollable, true);
 check('open-in-tab escape hatch is visible', layout.openInTabVisible, true);
 if (failures) console.log('\n=== elements exceeding 360px ===');


### PR DESCRIPTION
## Summary

In the side-panel layout, **Open in tab** sat in the Apply/Discard toolbar (the second sticky row). It now sits at the top of the panel: the nav strip becomes a two-column grid — settings chips scroll in the first cell with the button pinned to the right of them, profiles chips span the full second row — and the toolbar returns to Apply/Discard/status only. Wide/tab layouts hide the button as before.

The side-panel e2e asserted the nav collapses to `display: flex`; updated to `grid` (the adjacent rows-scroll-internally check is what actually guards against page widening, and it still passes).

## Testing

- Screenshots verified at 380px (button top-right in the first chip row) and 1200px (button hidden, layout unchanged)
- `npm run typecheck`, `npm test` (175/175), `HEADLESS=1 npm run e2e` — all pass