### PR TITLE
Offer the host-permission grant even without stored credentials

### DIFF
--- a/packages/ui/src/options/main.ts
+++ b/packages/ui/src/options/main.ts
@@ -21,7 +21,7 @@ import {
   renderProfile,
   renderUi,
 } from './views.js';
-import type { FixedProfile, OptionsBag } from '@switchydelta/pac';
+import type { OptionsBag } from '@switchydelta/pac';
 
 /** The saved state, used to decide what actually changed. */
 let pristine: OptionsBag = {};
@@ -69,18 +69,6 @@ export function adoptOptionsKey(key: string, value: unknown): void {
   markDirty();
 }
 
-/** True when any fixed profile carries proxy credentials. */
-function profilesNeedAuth(bag: OptionsBag): boolean {
-  for (const profile of listProfiles(bag)) {
-    const auth = (profile as FixedProfile).auth;
-    if (!auth) continue;
-    for (const entry of Object.values(auth)) {
-      if (entry?.username) return true;
-    }
-  }
-  return false;
-}
-
 export async function applyChanges(): Promise<void> {
   const changes: Record<string, unknown> = {};
   for (const key of changedKeys()) {
@@ -89,10 +77,10 @@ export async function applyChanges(): Promise<void> {
   if (Object.keys(changes).length === 0) return;
 
   // Start the optional host grant before any await so the call stays inside
-  // the Apply click gesture. Without `<all_urls>`, onAuthRequired never fires.
-  const hostAccess = profilesNeedAuth(options)
-    ? requestHostAccess()
-    : Promise.resolve(true);
+  // the Apply click gesture. Without `<all_urls>`, onAuthRequired never
+  // fires; asked even with no credentials configured yet, so auth works the
+  // moment one is added. Resolves silently when already granted.
+  const hostAccess = requestHostAccess();
 
   try {
     // `undefined` marks a removed key, matching the storage layer's convention.

--- a/packages/ui/src/popup/main.ts
+++ b/packages/ui/src/popup/main.ts
@@ -91,7 +91,7 @@ async function main(): Promise<void> {
   installKeyboard();
 
   // Fire-and-forget so the profile list never waits on the permission check.
-  void maybeOfferAuthPermission();
+  void maybeOfferHostPermission();
 
   // Focus the current profile so keyboard use starts from a sensible place.
   const current = document.querySelector<HTMLElement>('.om-item[aria-current="true"]');
@@ -239,17 +239,17 @@ function installKeyboard(): void {
 /**
  * Proxy credentials only take effect once the optional `<all_urls>` host
  * permission is granted, since webRequest events are gated by host access.
- * Offer the grant when the applied profiles carry credentials but the
- * permission is missing.
+ * Offer the grant whenever the permission is missing — even with no
+ * credentials configured yet, so auth works the moment one is added.
  */
-async function maybeOfferAuthPermission(): Promise<void> {
-  let status: { hasCredentials: boolean; hostAccess: boolean };
+async function maybeOfferHostPermission(): Promise<void> {
+  let hostAccess: boolean;
   try {
-    status = await api.proxyAuthStatus();
+    hostAccess = await chrome.permissions.contains({ origins: ['<all_urls>'] });
   } catch {
     return;
   }
-  if (!status.hasCredentials || status.hostAccess) return;
+  if (hostAccess) return;
 
   const notice = must('#om-auth-permission');
   notice.hidden = false;


### PR DESCRIPTION
## Summary

Previously the `<all_urls>` grant was only offered when a profile already carried proxy credentials (popup notice gated on `hasCredentials`; options Apply gated on `profilesNeedAuth`). Now the extension asks whenever the permission is missing:

- The popup shows the grant notice until host access is granted, credentials or not.
- Apply on the options page always starts `chrome.permissions.request` inside the click gesture — silently resolves once granted.
- The popup checks `chrome.permissions.contains` directly; the `proxyAuthStatus` RPC's credential flag no longer gates anything.

Side effects: users who grant stop seeing Chrome's "You need to request host permissions…" webRequest warning on worker starts, and proxy auth works immediately when a credential is first added rather than needing a later grant.

## Testing

- CDP check on a fresh profile with zero credentials: `hostAccess:false`, notice visible, Grant button rendered.
- `npm run typecheck`, `npm test` (175/175), `HEADLESS=1 npm run e2e` — all pass.