### PR TITLE
Allow changing profile color; bump to 3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchydelta",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": true,
   "description": "SwitchyDelta - proxy switching browser extension",
   "license": "GPL-3.0-or-later",

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_manifest_app_name__",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "__MSG_manifest_app_description__",
   "default_locale": "en",
   "minimum_chrome_version": "114",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@switchydelta/extension",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": true,
   "type": "module",
   "description": "Chromium MV3 service worker and platform bindings for SwitchyDelta",

--- a/packages/pac/package.json
+++ b/packages/pac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@switchydelta/pac",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": true,
   "type": "module",
   "description": "Profile, condition and PAC-script logic for SwitchyDelta",

--- a/packages/target/package.json
+++ b/packages/target/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@switchydelta/target",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": true,
   "type": "module",
   "description": "Platform-independent core logic for SwitchyDelta",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@switchydelta/ui",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": true,
   "type": "module",
   "description": "Options and popup UI for SwitchyDelta",

--- a/packages/ui/src/options/options.css
+++ b/packages/ui/src/options/options.css
@@ -115,6 +115,12 @@ body.om-options {
   border: 1px solid rgb(0 0 0 / 0.15);
 }
 
+.om-swatch-lg {
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+}
+
 .om-main {
   display: flex;
   flex-direction: column;
@@ -384,12 +390,50 @@ body.om-options {
 
 .om-profile-head {
   display: flex;
+  flex-wrap: wrap;
   gap: 10px;
   align-items: center;
 }
 
 .om-profile-head h2 {
   margin: 0;
+}
+
+/* Compact palette next to the profile title (replaces the spectrum picker). */
+.om-color-palette {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-left: 4px;
+}
+
+.om-color-chip {
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: 1px solid rgb(0 0 0 / 0.2);
+  border-radius: 4px;
+  cursor: pointer;
+  background-clip: padding-box;
+}
+
+.om-color-chip:hover {
+  transform: scale(1.1);
+}
+
+.om-color-chip[aria-current="true"] {
+  outline: 2px solid var(--om-accent);
+  outline-offset: 1px;
+}
+
+.om-color-input {
+  width: 28px;
+  height: 22px;
+  padding: 0;
+  border: 1px solid var(--om-border);
+  border-radius: 4px;
+  background: transparent;
+  cursor: pointer;
 }
 
 .om-actions-row {

--- a/packages/ui/src/options/views.ts
+++ b/packages/ui/src/options/views.ts
@@ -442,6 +442,20 @@ export function renderAbout(container: HTMLElement): void {
 const PROXY_SCHEMES = ['http', 'https', 'socks4', 'socks5'];
 const DEFAULT_PORTS: Record<string, number> = { http: 80, https: 443, socks4: 1080, socks5: 1080 };
 
+/** Expand `#rgb` to `#rrggbb` so `<input type="color">` accepts the value. */
+function normalizeHex(color: string): string {
+  const raw = color.trim();
+  const short = /^#([0-9a-fA-F]{3})$/.exec(raw);
+  if (short) {
+    const [r, g, b] = short[1]!;
+    return `#${r}${r}${g}${g}${b}${b}`.toLowerCase();
+  }
+  const full = /^#([0-9a-fA-F]{6})$/.exec(raw);
+  if (full) return `#${full[1]!}`.toLowerCase();
+  // Fall back to a palette colour when the stored value is not a hex string.
+  return profileColors[0]!;
+}
+
 export function renderProfile(container: HTMLElement, name: string): void {
   const profile = Profiles.byName(name, options);
   if (!profile) {
@@ -546,12 +560,70 @@ export function renderProfile(container: HTMLElement, name: string): void {
     }),
   );
 
+  // Virtual profiles inherit colour from their target; only concrete profiles
+  // store an editable colour of their own (matches the original spectrum picker).
+  const colorEditable = profile.profileType !== 'VirtualProfile';
+  const headSwatch = h('span', {
+    class: 'om-swatch om-swatch-lg',
+    style: { background: colorFor(profile, options) },
+    title: colorEditable ? undefined : colorFor(profile, options),
+  });
+
+  const setProfileColor = (hex: string) => {
+    if (!colorEditable) return;
+    profile.color = normalizeHex(hex);
+    headSwatch.style.background = profile.color;
+    // Keep the sidebar chip in step with the working copy.
+    const href = '#/profile/' + encodeURIComponent(profile.name);
+    const navLink = document.querySelector<HTMLElement>(
+      `.om-sidebar a[href=${JSON.stringify(href)}]`,
+    );
+    const navSwatch = navLink?.querySelector<HTMLElement>('.om-swatch');
+    if (navSwatch) navSwatch.style.background = profile.color;
+    for (const chip of colorPalette.querySelectorAll<HTMLButtonElement>('.om-color-chip')) {
+      chip.setAttribute('aria-current', chip.dataset['color'] === profile.color ? 'true' : 'false');
+    }
+    if (colorInput) colorInput.value = profile.color;
+    Profiles.updateRevision(profile);
+    markDirty();
+  };
+
+  const colorPalette = h(
+    'div',
+    { class: 'om-color-palette', hidden: !colorEditable, role: 'group', 'aria-label': 'Profile color' },
+    ...profileColors.map((hex) =>
+      h('button', {
+        type: 'button',
+        class: 'om-color-chip',
+        title: hex,
+        dataset: { color: hex },
+        style: { background: hex },
+        'aria-label': hex,
+        'aria-current':
+          normalizeHex(profile.color ?? '') === normalizeHex(hex) ? 'true' : 'false',
+        onclick: () => setProfileColor(hex),
+      }),
+    ),
+  );
+
+  const colorInput = colorEditable
+    ? h('input', {
+        type: 'color',
+        class: 'om-color-input',
+        value: normalizeHex(profile.color ?? profileColors[0]!),
+        title: profile.color ?? '',
+        oninput: (event: Event) => setProfileColor((event.target as HTMLInputElement).value),
+      })
+    : null;
+
   container.append(
     h(
       'div',
       { class: 'om-profile-head' },
-      h('span', { class: 'om-swatch', style: { background: colorFor(profile, options) } }),
+      headSwatch,
       h('h2', { text: profile.name }),
+      colorPalette,
+      colorInput,
     ),
     h('p', { class: 'om-help', text: typeName }),
     h(


### PR DESCRIPTION
## Summary
- Profile editor: palette + native color input for Fixed/Switch profiles; sidebar chips update live; Virtual profiles stay read-only.
- Version bump to **3.0.1** (manifest + packages).

## Test plan
- [x] `npm run typecheck`
- [x] `npm test`
- [ ] Open a proxy profile → pick palette/custom color → Apply → sidebar + popup swatch match