### PR TITLE
Ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ packages/ui/dist/
 dist/
 .dev-chrome-profile/
 .env
+.DS_Store


### PR DESCRIPTION
Adds `.DS_Store` to `.gitignore` to keep macOS Finder metadata out of the repo.