### PR TITLE
Update README and PR template for the TypeScript rewrite

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,8 @@ Please describe any possible breaking changes (or surprising UX differences).
 
 After creating the PR:
 
-- Please make sure the CircleCI test passes. Feel free to add more commits for
+- Please make sure the CI (GitHub Actions: typecheck, unit tests and the
+headless-Chrome e2e suite) passes. Feel free to add more commits for
 bug or style fixes.
 - Any merge conflicts should be fixed on *your* side. Prefer rebasing to merging.
 - Allow some time for project maintainers to review and merge the change.

--- a/README.md
+++ b/README.md
@@ -5,36 +5,26 @@ Manage and switch between multiple proxies quickly & easily.
 
 [![Translation status](https://hosted.weblate.org/widgets/switchyomega/-/svg-badge.svg)](https://hosted.weblate.org/engage/switchyomega/?utm_source=widget)
 
-Chromium Extension
-------------------
-The project is available as a Chromium Extension.
+SwitchyDelta is a Manifest V3 proxy-switching extension for Chromium-based
+browsers (Chrome 114+). It is a ground-up TypeScript rewrite of the
+SwitchyOmega codebase — same profile model and PAC generator semantics, none of
+the legacy runtime. See [MIGRATION.md](MIGRATION.md) for the full story of the
+rewrite, the bugs it found, and the measured results.
 
-Grab a packaged extension file (CRX) for offline installation on the [Releases page](https://github.com/madeye/SwitchyDelta/releases),
-or load the unpacked build as a Chromium extension (see Building below).
+Installing
+----------
 
-Please [report issues on the issue tracker.](https://github.com/madeye/SwitchyDelta/issues)
+- Load the unpacked build: `npm install && npm run build`, then load the
+  `dist/` folder via `chrome://extensions` → Developer mode → *Load unpacked*
+  (see Building below).
+- Or grab a packaged build from the
+  [Releases page](https://github.com/madeye/SwitchyDelta/releases).
 
-Firefox Addon (Experimental)
-----------------------------
+Please [report issues on the issue tracker](https://github.com/madeye/SwitchyDelta/issues).
 
-There is also an experimental WebExtension port, which allows installing in
-**Firefox Nightly Version >= 56**.
-
-**Since the WebExtensions API is still under heavy development on Mozilla's side,
-we strongly recommended using the Nightly channel (>= 56.0) and update frequently.**
-
-The Developer Edition and Beta channels will not receive fixes as often and
-therefore unsupported by SwitchyDelta. Some users report that it works with the
-Firefox Developer Edition (>= 55) as well, but we strongly advise against doing
-so. It won't work at all in Firefox 54 Stable.
-
-Grab a packaged extension file (XPI) for offline installation on the [Releases page](https://github.com/madeye/SwitchyDelta/releases).
-
-Please make sure that you are using the latest Nightly build before you
-[report issues](https://github.com/madeye/SwitchyDelta/issues).
-Build number AND build date should be mentioned somewhere in the issue.
-
-NOTE: PAC Profiles DO NOT work on Firefox due to AMO review policies. We will see what we can do.
+Firefox is not supported: this build targets Chromium's `chrome.proxy.settings`
+and side panel APIs, and the old Firefox-only proxy paths were retired in the
+rewrite.
 
 Memory footprint
 ----------------
@@ -50,85 +40,57 @@ worker is awake; at idle the extension costs no memory at all.
 For the detailed breakdown, methodology and a comparison against other popular
 extensions, see [MIGRATION.md](MIGRATION.md#measured-memory-footprint).
 
-Development status
-------------------
+Architecture
+------------
 
-## PAC generator
-This project contains a PAC generating module called `omega-pac`, which handles
-the profiles model and compile profiles into PAC scripts. This module is standalone
-and can be published to npm when the documentation is ready.
+The project is an npm workspace of four TypeScript packages:
 
-## Options manager
-The folder `omega-target` contains browser-independent logic for managing the
-options and applying profiles. Every public method is well documented in the comments.
-Functions related to browser are not included, and shall be implemented in subclasses
-of the `omega-target` classes.
+| Package | What it is |
+| --- | --- |
+| [`packages/pac`](packages/pac) (`@switchydelta/pac`) | The profile model and PAC generator: conditions, rule-list parsing (AutoProxy/Switchy formats), a domain trie for fast matching, and a precedence-aware code emitter that compiles profiles into compact PAC scripts with no minifier. Standalone — nothing in it touches browser APIs. The public-suffix list lives behind the separate `@switchydelta/pac/psl` entry point so it stays out of the service worker. |
+| [`packages/target`](packages/target) (`@switchydelta/target`) | Browser-independent options management: the options controller, storage abstraction, options sync with rate limiting and quota handling, and the upgrader for legacy SwitchyOmega 2.x / SwitchySharp options blobs. |
+| [`packages/extension`](packages/extension) | The Chromium glue: the MV3 service worker, `chrome.storage` / `chrome.proxy.settings` bindings, proxy authentication, scheduled rule-list downloads via `chrome.alarms`, and the action icon. Deliberately reduced to what only a worker can do — see [MIGRATION.md](MIGRATION.md#scope-of-the-service-worker). |
+| [`packages/ui`](packages/ui) | The popup and the options page (also registered as a Chrome side panel), built with Vite. Plain DOM TypeScript — no framework, no runtime dependencies. |
 
-`omega-web` is a web-based configuration interface for various options and profiles.
-The interface works great with `omega-target` as the back-end.
+Supporting directories:
 
-`omega-web` alone is incomplete and requires a file named `omega_target_web.js`
-containing an angular module `omegaTarget`. The module contains browser-dependent
-code to communicate with `omega-target` back-end, and other code retrieving
-browser-related state and information.
-See the `omega-target-chromium-extension/omega_target_web.coffee` file for an
-example of such module.
+- [`omega-locales/`](omega-locales) — gettext translation catalogues, compiled
+  into `_locales/*/messages.json` at build time.
+- [`scripts/`](scripts) — the build pipeline: `build-extension.mjs` (esbuild
+  worker bundle + asset assembly into `dist/`), `build-locales.mjs`,
+  `render-icons.mjs`, `dev-chrome.mjs` (launch Chrome with the build loaded),
+  and `publish-chrome.mjs` (Chrome Web Store upload; see `env.example`).
+- [`test/e2e/`](test/e2e) — Puppeteer suites that exercise the built extension
+  in a real headless Chrome, including PAC generation from a ~4.5k-rule list
+  and traffic through a real CONNECT proxy.
 
-## Targets
-The `omega-target-*` folders should contain environment-dependent code such as
-browser API calls.
+Building
+--------
 
-Each target folder should contain an extended `OmegaTarget` object, which
-contains subclasses of the abstract base classes like `Options`. The classes
-contains implementation of the abstract methods, and can override other methods
-at will.
+Requires Node 18+ (22+ for the e2e suite, which uses the global `WebSocket`).
 
-A target can copy the files in `omega-web` into its build to provide a web-based
-configuration interface. If so, the target must provide the `omega_target_web.js`
-file as described in the Options manager section.
+```sh
+npm install        # workspace root
+npm run build      # typecheck + UI + worker bundle -> dist/
+npm test           # vitest unit suites (packages/pac, packages/target)
+npm run e2e        # end-to-end: drives the built extension in headless Chrome
+node scripts/dev-chrome.mjs   # manual testing: Chrome with dist/ installed
+```
 
-Additionally, each target can contain other files and resources required for the
-target, such as background pages and extension manifests.
+`dist/` is a complete unpacked extension. For development, rebuild and reload;
+`dev-chrome.mjs` keeps a persistent profile between runs.
 
-For now, only one target has been implemented: The WebExtension target.
-This target allows the project to be used as a Chromium extension in most
-Chromium-based browsers and also as a Firefox Addon as mentioned above.
-
-## Translation
+Translation
+-----------
 
 Translation is hosted on Weblate. If you want to help improve the translated
-text or start translation for your language, please follow the link of the picture
-below.
+text or start translation for your language, please follow the link of the
+picture below.
 
 本项目翻译由Weblate托管。如果您希望帮助改进翻译，或将本项目翻译成一种新的语言，请
 点击下方图片链接进入翻译。
 
 [![Translation status](https://hosted.weblate.org/widgets/switchyomega/-/287x66-white.png)](https://hosted.weblate.org/engage/switchyomega/?utm_source=widget)
-
-## Building the project
-
-SwitchyDelta has migrated to use npm and grunt for building. Please note that
-npm 2.x is required for this project.
-
-To build the project:
-
-    # Install node and npm first (make sure npm --version > 2.0), then:
-    
-    sudo npm install -g grunt-cli@1.2.0 bower
-    # In the project folder:
-    cd omega-build
-    npm run deps # This runs npm install in every module.
-    npm run dev # This runs npm link to aid local development.
-    # Note: the previous command may require sudo in some environments.
-    # The modules are now working. We can build now:
-    grunt
-    # After building, a folder will be generated:
-    cd .. # Return to project root.
-    ls omega-chromium-extension/build/
-    # The folder above can be loaded as an unpacked extension in Chromium now.
-
-To enable `grunt watch`, run `grunt watch` once in the `omega-build` directory.
-This will effectively run `grunt watch` in every module in this project.
 
 License
 -------


### PR DESCRIPTION
The README still described the CoffeeScript-era project: `omega-*` modules, Grunt/Bower/npm-2.x build instructions, and the 2017 experimental Firefox Nightly port. This replaces it with the current state:

- **Architecture**: the four workspace packages (`pac`, `target`, `extension`, `ui`) with a table of what each does, plus `omega-locales/`, `scripts/`, and `test/e2e/`
- **Building**: `npm install` / `npm run build` / `npm test` / `npm run e2e` / `dev-chrome.mjs`, Node version requirements
- **Installing**: unpacked `dist/` build or the Releases page; a note that the MV3 build is Chromium-only (Chrome 114+) and Firefox is not supported
- Points to MIGRATION.md as the record of the rewrite

Memory footprint, translation, license and notice sections are unchanged. The PR template's stale CircleCI reference now names the actual GitHub Actions CI.