### PR TITLE
Tint the action icon per active tab in auto switch mode

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -195,6 +195,14 @@ icons/titles, the request monitor, the inspect context menus, and the
 SwitchySharp / external-extension bridges. `proxy_impl_script` and
 `proxy_impl_listener` are Firefox-only and were already dead on Chromium.
 
+The per-tab icon later returned in reduced form: with an auto-switch (or
+rule-list) profile active, the single global icon is tinted with the profile
+that the *active tab's* URL matches (`active-tab-icon.ts`). Unlike the
+original, no per-tab state is kept and only active-tab changes wake the
+worker — and with a static profile a session-storage flag short-circuits the
+event before the options controller boots. This is what brought the `tabs`
+permission back.
+
 Also dropped, UI-side only: the popup's temp-rule dropdown (and its `t`
 shortcut), which let the user route the current domain through another profile
 without saving a permanent rule. Unlike the drops above, the backend capability

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -41,6 +41,7 @@
     "unlimitedStorage",
     "alarms",
     "activeTab",
+    "tabs",
     "webRequest",
     "webRequestAuthProvider",
     "sidePanel"

--- a/packages/extension/src/active-tab-icon.ts
+++ b/packages/extension/src/active-tab-icon.ts
@@ -1,0 +1,48 @@
+/**
+ * Active-tab icon tracking.
+ *
+ * When the current profile is inclusive (auto switch / rule list), the icon
+ * colour should follow the profile that the *active tab's URL* resolves to.
+ * The original painted a per-tab icon for every tab from tabs.coffee; this
+ * build tracks only the active tab and paints the single global icon, so the
+ * worker wakes far less often and no per-tab state has to survive suspension.
+ */
+
+const TRACKING_FLAG = 'activeTabIconTracking';
+
+/**
+ * Remember whether the current profile's colour depends on the tab URL.
+ *
+ * Stored in session storage so a tab-switch event can check it without
+ * booting the options controller: with a static profile the worker returns
+ * to idle immediately instead of loading and matching for nothing.
+ */
+export function setActiveTabIconTracking(enabled: boolean): void {
+  void chrome.storage.session?.set({ [TRACKING_FLAG]: enabled });
+}
+
+/**
+ * Repaint on every event that changes which tab is active or what URL it
+ * shows. Must be called from the worker's first turn so the events can wake
+ * a suspended worker.
+ */
+export function watchActiveTab(repaint: () => void): void {
+  const maybeRepaint = (): void => {
+    void (async () => {
+      const flags = await chrome.storage.session?.get(TRACKING_FLAG);
+      // An absent flag (first event of the browser session) falls through to
+      // repaint, which re-derives and re-stores it.
+      if (flags?.[TRACKING_FLAG] === false) return;
+      repaint();
+    })();
+  };
+  chrome.tabs.onActivated.addListener(() => maybeRepaint());
+  chrome.tabs.onUpdated.addListener((_tabId, changeInfo, tab) => {
+    if (!tab.active || changeInfo.url === undefined) return;
+    maybeRepaint();
+  });
+  chrome.windows.onFocusChanged.addListener((windowId) => {
+    if (windowId === chrome.windows.WINDOW_ID_NONE) return;
+    maybeRepaint();
+  });
+}

--- a/packages/extension/src/chrome-options.ts
+++ b/packages/extension/src/chrome-options.ts
@@ -3,17 +3,20 @@
  *
  * This build is deliberately minimal: the service worker exists to handle proxy
  * authentication, to run scheduled downloads, and to apply the proxy. The
- * per-tab icons, request monitor, context menus, quick-switch cycling, badge
- * and the SwitchySharp / external-extension bridges are not part of it.
+ * request monitor, context menus, quick-switch cycling, badge and the
+ * SwitchySharp / external-extension bridges are not part of it. The original's
+ * per-tab icons survive only as the reduced active-tab-only variant
+ * (updateIconForActiveTab).
  */
 
 import { Options, Log, NoOptionsError, upgradeLegacyOptions } from '@switchydelta/target';
 import type { StorageItems } from '@switchydelta/target';
 import type { OmegaOptions } from '@switchydelta/target';
-import { Profiles } from '@switchydelta/pac';
+import { Conditions, Profiles } from '@switchydelta/pac';
 import type { Profile } from '@switchydelta/pac';
 
 import { clearBadge, setActionIcon, setControlLostBadge } from './action-icon.js';
+import { setActiveTabIconTracking } from './active-tab-icon.js';
 import { fetchUrl } from './fetch-url.js';
 import { ProxyAuth } from './proxy-auth.js';
 
@@ -179,12 +182,63 @@ export class ChromeOptions extends Options {
       );
       if (target) display = target;
     }
+    this.#lastActiveTabPaint = '';
     void setActionIcon(display?.color ?? '#1a73e8');
 
     if (profile) {
       const name = chrome.i18n.getMessage('profile_' + profile.name) || profile.name;
       void chrome.action.setTitle({ title: name });
     }
+
+    // An inclusive profile's effective colour depends on the tab URL: refine
+    // the paint above from the active tab, and arm the tab-event listeners.
+    const inclusive = profile != null && Profiles.isInclusive(profile);
+    setActiveTabIconTracking(inclusive);
+    if (inclusive) void this.updateIconForActiveTab();
+  }
+
+  /** Dedupe key of the last active-tab paint, so tab events that resolve to
+   *  the same colour and title do not redraw the canvas. Reset whenever the
+   *  current profile changes, because that path repaints unconditionally. */
+  #lastActiveTabPaint = '';
+
+  /**
+   * Tint the action icon with the profile that the active tab's URL matches.
+   *
+   * Only the single global icon is painted — the per-tab icons of the
+   * original were dropped (see MIGRATION.md); this is the reduced,
+   * active-tab-only successor. URLs a PAC script would never see
+   * (chrome://, about:, the new tab page) keep the profile's own colour.
+   */
+  async updateIconForActiveTab(): Promise<void> {
+    const profile = this._currentProfileName ? this.currentProfile() : null;
+    if (!profile || !Profiles.isInclusive(profile)) return;
+
+    let matched: Profile | undefined;
+    const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+    if (tab?.url && /^(https?|ftp|ws|wss):/i.test(tab.url)) {
+      try {
+        matched = (await this.matchProfile(Conditions.requestFromUrl(tab.url))).profile ?? undefined;
+      } catch {
+        // Unparsable URL: keep the profile's own colour.
+      }
+    }
+    // The profile may have been switched while we awaited; that switch's own
+    // currentProfileChanged repaint wins.
+    if (profile.name !== this._currentProfileName) return;
+
+    const color = matched?.color ?? profile.color ?? '#1a73e8';
+    const currentName = chrome.i18n.getMessage('profile_' + profile.name) || profile.name;
+    const title =
+      matched && matched.name !== profile.name
+        ? `${currentName} → ${chrome.i18n.getMessage('profile_' + matched.name) || matched.name}`
+        : currentName;
+
+    const key = `${color}\n${title}`;
+    if (key === this.#lastActiveTabPaint) return;
+    this.#lastActiveTabPaint = key;
+    void chrome.action.setTitle({ title });
+    await setActionIcon(color);
   }
 
   // --- Proxy control loss ---------------------------------------------------

--- a/packages/extension/src/sw.ts
+++ b/packages/extension/src/sw.ts
@@ -14,6 +14,7 @@
 import { BrowserStorage, OptionsSync, Options, Log } from '@switchydelta/target';
 import type { StorageItems } from '@switchydelta/target';
 
+import { watchActiveTab } from './active-tab-icon.js';
 import { ChromeOptions } from './chrome-options.js';
 import { ChromeStorage } from './chrome-storage.js';
 import { ProxyAuth } from './proxy-auth.js';
@@ -70,6 +71,16 @@ const ready = boot().catch((err: unknown) => {
 
 // Paint the action icon for the restored profile on every worker start.
 void ready.then(() => options?.currentProfileChanged('boot'));
+
+/**
+ * Still the first turn (module evaluation is synchronous), so these events
+ * can wake the worker: tab switches and navigations retint the icon when the
+ * current profile is an auto switch. The callback boots the options first;
+ * for static profiles a session-storage flag short-circuits before boot.
+ */
+watchActiveTab(() => {
+  void ready.then(() => options?.updateIconForActiveTab());
+});
 
 /**
  * Track who controls the proxy setting.

--- a/test/e2e/profiles.mjs
+++ b/test/e2e/profiles.mjs
@@ -148,12 +148,32 @@ check('other.org -> DIRECT (default)',
 check('127.0.0.1 -> DIRECT (bypass inside proxy profile)',
   await resolve('http://127.0.0.1/', '127.0.0.1'), 'DIRECT');
 
+// --- Active-tab icon tracking ----------------------------------------------
+console.log('\n=== active-tab icon follows the matched profile ===');
+// Navigating a tab wakes the worker's tab listeners, which retint the icon
+// with the matched profile's colour. The icon canvas is not readable over
+// CDP, but the same repaint writes the "current → matched" action title.
+// Both names here are custom, so i18n falls through to the raw names.
+const actionTitle = () => sw.eval(`new Promise(r => chrome.action.getTitle({}, r))`);
+const pollTitle = async (expected) => {
+  for (let i = 0; i < 25; i++) {
+    const title = await actionTitle();
+    if (title === expected) return title;
+    await sleep(200);
+  }
+  return actionTitle();
+};
+await fetch(`http://127.0.0.1:${PORT}/json/new?http://www.example.com/`, { method: 'PUT' });
+check('title shows the rule match', await pollTitle('auto switch → proxy'), 'auto switch → proxy');
+
 // --- DirectProfile ---------------------------------------------------------
 console.log('\n=== apply "direct" ===');
 console.log('  rpc reply: ' + (await applyProfile('direct')));
 await sleep(800);
 cfg = await proxyConfig();
 check('mode is direct', cfg.mode, 'direct');
+// A static profile paints its own identity; no match arrow.
+check('title reverts to the static profile', await pollTitle('[Direct]'), '[Direct]');
 
 console.log(`\n=== RESULT: ${failures === 0 ? 'all checks passed' : failures + ' FAILURES'} ===`);
 


### PR DESCRIPTION
Fixes the report that in auto-switch mode the toolbar indicator never changes to the matched profile's colour.

**Root cause:** the original's per-tab icon tracking (`tabs.coffee`) was deliberately dropped in the MV3 rewrite, so `currentProfileChanged` painted one global icon with the SwitchProfile's own colour and nothing ever repainted per URL.

**Fix — the active-tab-only variant:**
- `active-tab-icon.ts`: `tabs.onActivated` / `tabs.onUpdated` (active tab URL changes) / `windows.onFocusChanged` listeners, registered in the worker's first turn so they can wake it.
- `ChromeOptions.updateIconForActiveTab()`: resolves the active tab's URL through `Options.matchProfile` and tints the single global icon with the matched profile's colour; the action title becomes `current → matched`. Deduped so repeat events that resolve to the same colour skip the canvas redraw.
- Cheap when it doesn't matter: with a static profile a `chrome.storage.session` flag short-circuits the tab event before the options controller boots; unlike the original there is no per-tab state to keep alive.

**Permission note:** this brings back the `tabs` permission (dropped in #10) — reading tab URLs requires it. Chrome will disable the extension on update until existing users re-approve ("Read your browsing history" warning). This is the unavoidable cost of the feature.

**Verification:** the profiles e2e now exercises the real event path — navigating a tab to `www.example.com` under "auto switch" must produce the `auto switch → proxy` action title (written by the same repaint as the icon), and applying `direct` must revert it to `[Direct]`. All 221 unit tests + 4 e2e suites pass locally.