### PR TITLE
Pre-fill the popup's Add condition with the current tab's host

### DIFF
--- a/packages/ui/src/options/main.ts
+++ b/packages/ui/src/options/main.ts
@@ -98,7 +98,7 @@ export async function applyChanges(): Promise<void> {
 
 // --- Routing ----------------------------------------------------------------
 
-type View = (container: HTMLElement, param: string) => void;
+type View = (container: HTMLElement, param: string, query?: URLSearchParams) => void;
 
 /**
  * A view-installed veto on leaving the current route. The switch profile's
@@ -134,13 +134,20 @@ function route(): void {
     revertingHash = false;
     return;
   }
-  const hash = location.hash || '#/about';
+  const rawHash = location.hash || '#/about';
+  // One-shot query parameters (e.g. the popup's `?addRuleHost=…`) ride on the
+  // fragment. Routes match on the path alone, and the query is stripped from
+  // the address bar so a reload or revisit does not repeat the action.
+  const queryAt = rawHash.indexOf('?');
+  const hash = queryAt < 0 ? rawHash : rawHash.slice(0, queryAt);
+  const query = queryAt < 0 ? undefined : new URLSearchParams(rawHash.slice(queryAt + 1));
   if (currentHash && hash !== currentHash && navigationGuard && !navigationGuard()) {
     revertingHash = true;
     location.hash = currentHash;
     return;
   }
   navigationGuard = null;
+  if (queryAt >= 0) history.replaceState(null, '', location.pathname + location.search + hash);
   const container = must('#om-view');
 
   for (const [pattern, view] of routes) {
@@ -148,7 +155,7 @@ function route(): void {
     if (match) {
       currentHash = hash;
       container.replaceChildren();
-      view(container, decodeURIComponent(match[1] ?? ''));
+      view(container, decodeURIComponent(match[1] ?? ''), query);
       localizeDocument(container);
       highlightNav(hash);
       localState.set('lastUrl', hash);

--- a/packages/ui/src/options/views.ts
+++ b/packages/ui/src/options/views.ts
@@ -466,7 +466,11 @@ function normalizeHex(color: string): string {
   return profileColors[0]!;
 }
 
-export function renderProfile(container: HTMLElement, name: string): void {
+export function renderProfile(
+  container: HTMLElement,
+  name: string,
+  query?: URLSearchParams,
+): void {
   const profile = Profiles.byName(name, options);
   if (!profile) {
     container.append(h('p', { class: 'om-error', text: t('options_profileNotFound') }));
@@ -678,7 +682,7 @@ export function renderProfile(container: HTMLElement, name: string): void {
   if (profile.profileType === 'FixedProfile') {
     renderFixedProfile(container, profile as FixedProfile);
   } else if (profile.profileType === 'SwitchProfile') {
-    renderSwitchProfile(container, profile as SwitchProfile, actionsRow);
+    renderSwitchProfile(container, profile as SwitchProfile, actionsRow, query);
   } else if (profile.profileType === 'PacProfile') {
     renderPacProfile(container, profile as PacProfile);
   } else {
@@ -844,6 +848,7 @@ function renderSwitchProfile(
   container: HTMLElement,
   profile: SwitchProfile,
   actions?: HTMLElement,
+  query?: URLSearchParams,
 ): void {
   const wrap = h('div');
 
@@ -1621,6 +1626,31 @@ function renderSwitchProfile(
       attachedListError,
       text,
     ];
+  }
+
+  // The popup's "Add condition" button routes here with the current tab's
+  // host, and expects a rule for it pre-filled as a pending edit — the user
+  // still picks the target profile and applies. The pattern mirrors what the
+  // original popup suggested: the bare host for IP literals (the URL parser
+  // brackets IPv6), `*.host` otherwise, which the wildcard magic makes match
+  // the apex as well as subdomains.
+  const addRuleHost = query?.get('addRuleHost');
+  if (addRuleHost) {
+    const looksLikeIp = addRuleHost.startsWith('[') || /\d$/.test(addRuleHost);
+    const pattern = looksLikeIp ? addRuleHost : '*.' + addRuleHost;
+    const exists = profile.rules.some(
+      (rule) =>
+        rule.condition.conditionType === 'HostWildcardCondition' &&
+        'pattern' in rule.condition &&
+        rule.condition.pattern === pattern,
+    );
+    if (!exists) {
+      profile.rules.push({
+        condition: { conditionType: 'HostWildcardCondition', pattern },
+        profileName: effectiveDefault(),
+      });
+      touch();
+    }
   }
 
   rerender();

--- a/packages/ui/src/popup/main.ts
+++ b/packages/ui/src/popup/main.ts
@@ -163,12 +163,28 @@ function wireActions(): void {
   if (state.currentProfileCanAddRule) {
     addRule.hidden = false;
     addRule.addEventListener('click', () => {
-      // The full condition editor lives on the options page. Close only once
-      // openOptions has settled: window.close() tears down this context, and
-      // the tab query/create still pending inside openOptions dies with it.
-      void openOptions('#/profile/' + encodeURIComponent(state.currentProfileName ?? '')).finally(
-        () => window.close(),
-      );
+      // The full condition editor lives on the options page; the current
+      // tab's host rides along so the editor pre-fills the new rule with it.
+      // Close only once openOptions has settled: window.close() tears down
+      // this context, and the tab query/create still pending inside
+      // openOptions dies with it.
+      void (async () => {
+        let suffix = '';
+        try {
+          const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+          const url = tab?.url ?? '';
+          // Only schemes a PAC script would see; hostname is '' for the rest.
+          if (/^(https?|ftp|ws|wss):/i.test(url)) {
+            const host = new URL(url).hostname;
+            if (host) suffix = '?addRuleHost=' + encodeURIComponent(host);
+          }
+        } catch {
+          // No readable tab URL: open the editor without a prefill.
+        }
+        await openOptions(
+          '#/profile/' + encodeURIComponent(state.currentProfileName ?? '') + suffix,
+        );
+      })().finally(() => window.close());
     });
   }
 

--- a/test/e2e/profiles.mjs
+++ b/test/e2e/profiles.mjs
@@ -166,6 +166,24 @@ const pollTitle = async (expected) => {
 await fetch(`http://127.0.0.1:${PORT}/json/new?http://www.example.com/`, { method: 'PUT' });
 check('title shows the rule match', await pollTitle('auto switch → proxy'), 'auto switch → proxy');
 
+// --- Add-condition prefill --------------------------------------------------
+console.log('\n=== ?addRuleHost pre-fills a rule in the switch editor ===');
+// The popup's "Add condition" button opens the editor with the active tab's
+// host in the fragment query; the editor must add a pending `*.host` rule and
+// strip the one-shot query from the address bar.
+const editorTab = await (await fetch(
+  `http://127.0.0.1:${PORT}/json/new?chrome-extension://${extId}/options.html%23/profile/auto%2520switch?addRuleHost=foo.example.com`,
+  { method: 'PUT' })).json();
+const editor = await Session.open(editorTab.webSocketDebuggerUrl);
+await sleep(1500);
+const prefill = JSON.parse(await editor.eval(`JSON.stringify({
+  hash: location.hash,
+  patterns: [...document.querySelectorAll('input')].map(i => i.value)
+    .filter(v => v === '*.foo.example.com'),
+})`));
+check('rule pre-filled with the tab host', prefill.patterns, ['*.foo.example.com']);
+check('one-shot query stripped from the hash', prefill.hash, '#/profile/auto%20switch');
+
 // --- DirectProfile ---------------------------------------------------------
 console.log('\n=== apply "direct" ===');
 console.log('  rpc reply: ' + (await applyProfile('direct')));


### PR DESCRIPTION
The popup's "Add condition" button opened the switch profile editor empty — the original pre-filled the condition with the current page's domain, which was the point of the button.

**Flow:**
- The popup queries the active tab (the `tabs` permission landed in #22) and appends `?addRuleHost=<hostname>` to the `#/profile/<name>` fragment it opens.
- The options router now splits one-shot query parameters off the fragment before route matching and strips them from the address bar via `history.replaceState`, so reloads and revisits don't repeat the action.
- The switch editor turns the parameter into a **pending** rule: `HostWildcardCondition` with the original popup's suggestion (`*.host`, or the bare host for IP literals — matching apex + subdomains via the wildcard magic), targeting the effective default. The user picks the target profile and hits Apply, same as a manually added rule. An existing rule with the same pattern is not duplicated.

**Verification:** the profiles e2e now opens `options.html#/profile/auto%20switch?addRuleHost=foo.example.com` in the test Chrome and asserts the editor shows a `*.foo.example.com` pattern input with the query stripped from the hash. All 221 unit tests + 4 e2e suites pass locally.