### PR TITLE
Suggest the registrable domain in the Add-condition prefill

### DIFF
--- a/packages/ui/src/options/views.ts
+++ b/packages/ui/src/options/views.ts
@@ -1630,27 +1630,29 @@ function renderSwitchProfile(
 
   // The popup's "Add condition" button routes here with the current tab's
   // host, and expects a rule for it pre-filled as a pending edit — the user
-  // still picks the target profile and applies. The pattern mirrors what the
-  // original popup suggested: the bare host for IP literals (the URL parser
-  // brackets IPv6), `*.host` otherwise, which the wildcard magic makes match
-  // the apex as well as subdomains.
+  // still picks the target profile and applies. The original suggested the
+  // wildcard for the *registrable* domain (www.google.com -> *.google.com,
+  // tldjs in the old background); the ported helper sits behind the separate
+  // psl entry point because it carries the public suffix list, so it loads
+  // only when this path actually runs. IP literals stay exact.
   const addRuleHost = query?.get('addRuleHost');
   if (addRuleHost) {
-    const looksLikeIp = addRuleHost.startsWith('[') || /\d$/.test(addRuleHost);
-    const pattern = looksLikeIp ? addRuleHost : '*.' + addRuleHost;
-    const exists = profile.rules.some(
-      (rule) =>
-        rule.condition.conditionType === 'HostWildcardCondition' &&
-        'pattern' in rule.condition &&
-        rule.condition.pattern === pattern,
-    );
-    if (!exists) {
+    void import('@switchydelta/pac/psl').then(({ wildcardForDomain }) => {
+      const pattern = wildcardForDomain(addRuleHost);
+      const exists = profile.rules.some(
+        (rule) =>
+          rule.condition.conditionType === 'HostWildcardCondition' &&
+          'pattern' in rule.condition &&
+          rule.condition.pattern === pattern,
+      );
+      if (exists) return;
       profile.rules.push({
         condition: { conditionType: 'HostWildcardCondition', pattern },
         profileName: effectiveDefault(),
       });
       touch();
-    }
+      rerender();
+    });
   }
 
   rerender();

--- a/test/e2e/profiles.mjs
+++ b/test/e2e/profiles.mjs
@@ -169,19 +169,20 @@ check('title shows the rule match', await pollTitle('auto switch → proxy'), 'a
 // --- Add-condition prefill --------------------------------------------------
 console.log('\n=== ?addRuleHost pre-fills a rule in the switch editor ===');
 // The popup's "Add condition" button opens the editor with the active tab's
-// host in the fragment query; the editor must add a pending `*.host` rule and
-// strip the one-shot query from the address bar.
+// host in the fragment query; the editor must add a pending rule for the
+// *registrable* domain (www.other-site.org -> *.other-site.org, the psl
+// helper) and strip the one-shot query from the address bar.
 const editorTab = await (await fetch(
-  `http://127.0.0.1:${PORT}/json/new?chrome-extension://${extId}/options.html%23/profile/auto%2520switch?addRuleHost=foo.example.com`,
+  `http://127.0.0.1:${PORT}/json/new?chrome-extension://${extId}/options.html%23/profile/auto%2520switch?addRuleHost=www.other-site.org`,
   { method: 'PUT' })).json();
 const editor = await Session.open(editorTab.webSocketDebuggerUrl);
 await sleep(1500);
 const prefill = JSON.parse(await editor.eval(`JSON.stringify({
   hash: location.hash,
   patterns: [...document.querySelectorAll('input')].map(i => i.value)
-    .filter(v => v === '*.foo.example.com'),
+    .filter(v => v.includes('other-site')),
 })`));
-check('rule pre-filled with the tab host', prefill.patterns, ['*.foo.example.com']);
+check('rule pre-filled with the registrable domain', prefill.patterns, ['*.other-site.org']);
 check('one-shot query stripped from the hash', prefill.hash, '#/profile/auto%20switch');
 
 // --- DirectProfile ---------------------------------------------------------


### PR DESCRIPTION
Fixes the report that Add condition pre-fills `*.www.google.com` for `www.google.com`.

**Root cause:** #23 built the suggestion from the raw tab hostname. The original ran the host through tldjs' `getBaseDomain` first (`www.google.com` → `google.com` → `*.google.com`), so the suggested rule covered the apex and sibling subdomains — the point of the suggestion. The ported equivalent, `@switchydelta/pac/psl` (the entry point MIGRATION.md carved out for exactly this call site), was never wired in.

**Fix:** the switch editor now routes `addRuleHost` through `wildcardForDomain`, which uses the public suffix list (`images.google.co.uk` → `*.google.co.uk`) and keeps IP literals exact. The import is dynamic, so the PSL data becomes a lazily loaded 103 KB chunk fetched only on this path — the options bundle stays at 67 KB and the service worker never sees it.

**Verification:** the profiles e2e now asserts `www.other-site.org` pre-fills as `*.other-site.org`. All 221 unit tests + 4 e2e suites pass locally.