### PR TITLE
Ring the icon with the switch profile colour in auto switch mode

### DIFF
--- a/packages/extension/src/action-icon.ts
+++ b/packages/extension/src/action-icon.ts
@@ -5,11 +5,16 @@
  * colour fills the rounded square and the white delta outline sits on top,
  * so the icon both brands the extension and shows which profile is active —
  * the same job the original's dynamically drawn omega icon did.
+ *
+ * With an auto switch active the icon carries two colours: the matched
+ * profile fills the square and the switch profile's own colour rings its
+ * boundary, so the icon says both "auto switch is on" and "this is where
+ * the current tab goes".
  */
 
 const SIZES = [16, 24, 32];
 
-export async function setActionIcon(color: string): Promise<void> {
+export async function setActionIcon(color: string, borderColor?: string): Promise<void> {
   const imageData: Record<number, ImageData> = {};
   for (const size of SIZES) {
     const canvas = new OffscreenCanvas(size, size);
@@ -21,6 +26,23 @@ export async function setActionIcon(color: string): Promise<void> {
     ctx.roundRect(0, 0, size, size, 26 * scale);
     ctx.fillStyle = color;
     ctx.fill();
+
+    if (borderColor && borderColor !== color) {
+      // Stroke centred on an inset path, so its outer edge lands exactly on
+      // the square's edge and nothing bleeds outside the rounded silhouette.
+      const border = Math.max(1.5, 14 * scale);
+      ctx.beginPath();
+      ctx.roundRect(
+        border / 2,
+        border / 2,
+        size - border,
+        size - border,
+        Math.max(1, 26 * scale - border / 2),
+      );
+      ctx.strokeStyle = borderColor;
+      ctx.lineWidth = border;
+      ctx.stroke();
+    }
 
     ctx.beginPath();
     ctx.moveTo(64 * scale, 31 * scale);

--- a/packages/extension/src/chrome-options.ts
+++ b/packages/extension/src/chrome-options.ts
@@ -227,18 +227,21 @@ export class ChromeOptions extends Options {
     // currentProfileChanged repaint wins.
     if (profile.name !== this._currentProfileName) return;
 
+    // The matched profile fills the icon; the switch profile's own colour
+    // becomes its boundary ring, so both stay visible at once.
     const color = matched?.color ?? profile.color ?? '#1a73e8';
+    const border = matched ? profile.color : undefined;
     const currentName = chrome.i18n.getMessage('profile_' + profile.name) || profile.name;
     const title =
       matched && matched.name !== profile.name
         ? `${currentName} → ${chrome.i18n.getMessage('profile_' + matched.name) || matched.name}`
         : currentName;
 
-    const key = `${color}\n${title}`;
+    const key = `${color}\n${border ?? ''}\n${title}`;
     if (key === this.#lastActiveTabPaint) return;
     this.#lastActiveTabPaint = key;
     void chrome.action.setTitle({ title });
-    await setActionIcon(color);
+    await setActionIcon(color, border);
   }
 
   // --- Proxy control loss ---------------------------------------------------


### PR DESCRIPTION
With an auto switch active, the icon showed only the matched profile's colour (#22), making it indistinguishable from that profile being applied directly. The icon now carries both colours: the **matched profile fills** the rounded square and the **switch profile's own colour rings its boundary** — "auto switch is on" and "this is where the current tab goes", in one glance.

Rendering details:
- The ring is stroked centred on an inset path so its outer edge lands exactly on the square's silhouette — nothing bleeds outside the rounded shape.
- Skipped when it would be invisible: same colour as the fill, or no match to show (chrome:// pages fall back to the plain switch-colour icon).
- Static profiles are unchanged; the repaint dedupe key now includes the ring colour.

Rendered with the exact drawing code at the real 16/24/32 px sizes to verify the ring stays legible and the delta mark unobstructed.

All 221 unit tests + 4 e2e suites pass locally.