### PR TITLE
Bump version to 3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "switchydelta",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "switchydelta",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "GPL-3.0-or-later",
       "workspaces": [
         "packages/*"
@@ -2066,7 +2066,7 @@
     },
     "packages/extension": {
       "name": "@switchydelta/extension",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "dependencies": {
         "@switchydelta/pac": "*",
         "@switchydelta/target": "*"
@@ -2074,14 +2074,14 @@
     },
     "packages/pac": {
       "name": "@switchydelta/pac",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "dependencies": {
         "tldts": "^6.1.47"
       }
     },
     "packages/target": {
       "name": "@switchydelta/target",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "dependencies": {
         "@switchydelta/pac": "*",
         "jsondiffpatch": "^0.6.0"
@@ -2089,7 +2089,7 @@
     },
     "packages/ui": {
       "name": "@switchydelta/ui",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "dependencies": {
         "@switchydelta/pac": "*"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchydelta",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "private": true,
   "description": "SwitchyDelta - proxy switching browser extension",
   "license": "GPL-3.0-or-later",

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_manifest_app_name__",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "__MSG_manifest_app_description__",
   "default_locale": "en",
   "minimum_chrome_version": "114",


### PR DESCRIPTION
Since 3.0.1: active-tab icon tinting in auto switch mode with the switch-colour boundary ring (#22, #25), the Add-condition prefill with the registrable domain of the current tab (#23, #24), and the return of the `tabs` permission the tracking requires — existing users will be prompted to re-approve on update.