### PR TITLE
Read pendingUrl so the auto-switch icon tracks uncommitted navigations

### DIFF
--- a/packages/extension/src/active-tab-icon.ts
+++ b/packages/extension/src/active-tab-icon.ts
@@ -38,7 +38,13 @@ export function watchActiveTab(repaint: () => void): void {
   };
   chrome.tabs.onActivated.addListener(() => maybeRepaint());
   chrome.tabs.onUpdated.addListener((_tabId, changeInfo, tab) => {
-    if (!tab.active || changeInfo.url === undefined) return;
+    if (!tab.active) return;
+    // Repaint on URL changes and on load-state changes. The status events
+    // matter: a navigation that fails (error page) commits without ever
+    // firing a `url` change, and the activation-time paint may have run
+    // while the URL was still pending — the 'complete'/'loading' events are
+    // what correct it.
+    if (changeInfo.url === undefined && changeInfo.status === undefined) return;
     maybeRepaint();
   });
   chrome.windows.onFocusChanged.addListener((windowId) => {

--- a/packages/extension/src/chrome-options.ts
+++ b/packages/extension/src/chrome-options.ts
@@ -216,9 +216,14 @@ export class ChromeOptions extends Options {
 
     let matched: Profile | undefined;
     const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
-    if (tab?.url && /^(https?|ftp|ws|wss):/i.test(tab.url)) {
+    // While a navigation is uncommitted (slow site, DNS failure, error page)
+    // `tab.url` is empty and the destination sits in `pendingUrl` — and a
+    // failed navigation never fires an onUpdated `url` change afterwards, so
+    // reading only `tab.url` left the icon stuck on the fallback paint.
+    const url = tab?.pendingUrl || tab?.url;
+    if (url && /^(https?|ftp|ws|wss):/i.test(url)) {
       try {
-        matched = (await this.matchProfile(Conditions.requestFromUrl(tab.url))).profile ?? undefined;
+        matched = (await this.matchProfile(Conditions.requestFromUrl(url))).profile ?? undefined;
       } catch {
         // Unparsable URL: keep the profile's own colour.
       }

--- a/test/e2e/profiles.mjs
+++ b/test/e2e/profiles.mjs
@@ -165,6 +165,11 @@ const pollTitle = async (expected) => {
 };
 await fetch(`http://127.0.0.1:${PORT}/json/new?http://www.example.com/`, { method: 'PUT' });
 check('title shows the rule match', await pollTitle('auto switch → proxy'), 'auto switch → proxy');
+// A page matching no rule must resolve through defaultProfileName — the icon
+// paints the default profile, not the switch's own colour. The CDP endpoint
+// commits reliably, exercising the pendingUrl -> url handoff either way.
+await fetch(`http://127.0.0.1:${PORT}/json/new?http://127.0.0.1:${PORT}/json/version`, { method: 'PUT' });
+check('title shows the default match', await pollTitle('auto switch → [Direct]'), 'auto switch → [Direct]');
 
 // --- Add-condition prefill --------------------------------------------------
 console.log('\n=== ?addRuleHost pre-fills a rule in the switch editor ===');


### PR DESCRIPTION
Fixes the report that the indicator icon doesn't change correctly in auto switch mode.

**Root cause (found by wrapping `chrome.action.setIcon` in an instrumented worker and sampling painted pixels):** while a navigation is uncommitted — slow site, DNS failure, error page — `tab.url` is empty and the destination sits in `tab.pendingUrl`, which the repaint never read. The activation-time paint therefore fell back to the switch profile's plain colour, and since a failed navigation never fires an `onUpdated` `url` change, nothing corrected it: the icon stayed stuck. `Options.matchProfile` itself was verified correct over RPC for both the rule-match and default cases.

**Fix:**
- `updateIconForActiveTab` reads `tab.pendingUrl || tab.url`.
- The `onUpdated` listener also repaints on `status` changes (`loading`/`complete`) — that's what fires when an error page commits or a pending paint needs its final correction. The dedupe key absorbs the extra events without redundant canvas work.

**Verified:** instrumented worker now shows the no-match case painting the default profile's fill (`#aaaaaa`) with the switch-colour ring (`#99dd99`) and the `auto switch → [Direct]` title across repeated tab switches. The profiles e2e now pins the default-match title. All 221 unit tests + 4 e2e suites pass.