### PR TITLE
Make the Web Store script upload-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ Supporting directories:
 - [`scripts/`](scripts) — the build pipeline: `build-extension.mjs` (esbuild
   worker bundle + asset assembly into `dist/`), `build-locales.mjs`,
   `render-icons.mjs`, `dev-chrome.mjs` (launch Chrome with the build loaded),
-  and `publish-chrome.mjs` (Chrome Web Store upload; see `env.example`).
+  and `upload-chrome.mjs` (uploads a draft to the Chrome Web Store — see
+  `env.example`; submitting for review stays a manual dashboard step).
 - [`test/e2e/`](test/e2e) — Puppeteer suites that exercise the built extension
   in a real headless Chrome, including PAC generation from a ~4.5k-rule list
   and traffic through a real CONNECT proxy.

--- a/env.example
+++ b/env.example
@@ -1,4 +1,5 @@
-# Chrome Web Store publishing (scripts/publish-chrome.mjs).
+# Chrome Web Store draft upload (scripts/upload-chrome.mjs).
+# Publishing (submitting for review) is a manual dashboard step.
 # Copy to .env and fill in; .env is gitignored — never commit real values.
 
 # Google Cloud service-account key, linked to the publisher in the CWS

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:ui": "npm run build -w @switchydelta/ui",
     "build:extension": "node scripts/build-extension.mjs",
     "e2e": "node test/e2e/smoke.mjs dist && node test/e2e/side-panel.mjs dist && node test/e2e/profiles.mjs dist && node test/e2e/rule-list.mjs dist",
-    "publish:chrome": "node scripts/publish-chrome.mjs"
+    "upload:chrome": "node scripts/upload-chrome.mjs"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.268",

--- a/scripts/upload-chrome.mjs
+++ b/scripts/upload-chrome.mjs
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 /**
- * Upload dist/ to the Chrome Web Store and submit it for publishing.
+ * Upload dist/ to the Chrome Web Store as a draft.
+ *
+ * Deliberately upload-only: publishing (submitting for review) is a manual
+ * step in the developer dashboard, where the permission justifications and
+ * review state are visible.
  *
  * Credentials come from a Google Cloud service account key referenced by
  * CWS_KEY_PATH in .env (the key itself must live outside the repo). The
@@ -15,7 +19,7 @@
  *                     (the V1.1 API works without it until 2026-10-15)
  *   HTTPS_PROXY       optional proxy for reaching googleapis.com
  *
- * Usage: node scripts/publish-chrome.mjs [--no-publish]
+ * Usage: node scripts/upload-chrome.mjs
  */
 
 import { spawnSync } from 'node:child_process';
@@ -29,7 +33,6 @@ import { fileURLToPath } from 'node:url';
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const DIST = resolve(root, 'dist');
 const SCOPE = 'https://www.googleapis.com/auth/chromewebstore';
-const publish = !process.argv.includes('--no-publish');
 
 // --- .env -------------------------------------------------------------------
 
@@ -184,27 +187,5 @@ if (!itemId && uploadedItemId) {
   console.log(`\nNEW ITEM CREATED — add this to .env:\n  CWS_ITEM_ID=${uploadedItemId}\n`);
 }
 
-if (!publish) {
-  console.log('upload done (--no-publish).');
-  process.exit(0);
-}
-
-let result;
-if (publisherId && uploadedItemId) {
-  const name = `publishers/${publisherId}/items/${uploadedItemId}`;
-  result = await call(
-    'POST',
-    `https://chromewebstore.googleapis.com/v2/${name}:publish`,
-    token,
-    JSON.stringify({}),
-    'application/json',
-  );
-} else {
-  result = await call(
-    'POST',
-    `https://www.googleapis.com/chromewebstore/v1.1/items/${uploadedItemId}/publish`,
-    token,
-  );
-}
-console.log('publish:', result.status, JSON.stringify(result.body, null, 2));
-process.exit(result.ok ? 0 : 1);
+console.log('upload done — the draft is on the dashboard; submit it for review there.');
+process.exit(0);


### PR DESCRIPTION
Removes the auto-publish step: `npm run upload:chrome` (renamed from `publish:chrome`, script renamed to `upload-chrome.mjs`) now only uploads `dist/` as a dashboard draft. Submitting for review/publication is a deliberate manual step in the developer dashboard, where the permission justifications and review state live. The `--no-publish` flag and both publish endpoints are removed; README and `env.example` updated.