### PR TITLE
Harden RPC, storage, PAC, and fetch paths from the security audit

### DIFF
--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -38,9 +38,7 @@
   "permissions": [
     "proxy",
     "storage",
-    "unlimitedStorage",
     "alarms",
-    "activeTab",
     "tabs",
     "webRequest",
     "webRequestAuthProvider",

--- a/packages/extension/src/chrome-storage.ts
+++ b/packages/extension/src/chrome-storage.ts
@@ -5,12 +5,7 @@
  * contents, which is how the options bag is stored.
  */
 
-import {
-  QuotaExceededError,
-  RateLimitExceededError,
-  Storage,
-  StorageUnavailableError,
-} from '@switchydelta/target';
+import { parseStorageErrors, Storage } from '@switchydelta/target';
 import type { StorageItems, Unwatch, WatchCallback } from '@switchydelta/target';
 
 interface Watcher {
@@ -19,8 +14,6 @@ interface Watcher {
   callback: WatchCallback;
 }
 
-const SUSTAINED_PER_MINUTE = 'MAX_SUSTAINED_WRITE_OPERATIONS_PER_MINUTE';
-
 /** Monotonic, so two watchers registered in the same tick cannot collide. */
 let nextWatcherId = 0;
 
@@ -28,56 +21,6 @@ export class ChromeStorage extends Storage {
   /** Watchers by area name, then by id. */
   static readonly watchers: Record<string, Map<number, Watcher> | undefined> = {};
   static onChangedListenerInstalled = false;
-
-  /**
-   * Translate a `chrome.runtime.lastError` message into one of the typed
-   * storage errors, so that callers can react to a quota or rate limit without
-   * matching on English prose.
-   */
-  static parseStorageErrors(err: unknown): Promise<never> {
-    const message = (err as { message?: unknown } | null | undefined)?.message;
-    if (typeof message !== 'string') return Promise.reject(err);
-
-    if (message.indexOf('QUOTA_BYTES_PER_ITEM') >= 0) {
-      const error = new QuotaExceededError(message);
-      error.perItem = true;
-      return Promise.reject(error);
-    }
-    if (message.indexOf('QUOTA_BYTES') >= 0) {
-      return Promise.reject(new QuotaExceededError(message));
-    }
-    if (message.indexOf('MAX_ITEMS') >= 0) {
-      const error = new QuotaExceededError(message);
-      error.maxItems = true;
-      return Promise.reject(error);
-    }
-    if (message.indexOf('MAX_WRITE_OPERATIONS_') >= 0) {
-      const error = new RateLimitExceededError(message);
-      // FIX: the original tested these on the freshly constructed error, whose
-      // message is empty, so neither flag was ever set.
-      if (message.indexOf('MAX_WRITE_OPERATIONS_PER_HOUR') >= 0) {
-        error.perHour = true;
-      } else if (message.indexOf('MAX_WRITE_OPERATIONS_PER_MINUTE') >= 0) {
-        error.perMinute = true;
-      }
-      return Promise.reject(error);
-    }
-    if (message.indexOf(SUSTAINED_PER_MINUTE) >= 0) {
-      const error = new RateLimitExceededError(message);
-      error.perMinute = true;
-      error.sustained = true;
-      return Promise.reject(error);
-    }
-    if (message.indexOf('is not available') >= 0) {
-      // Some Chromium-based browsers disable access to the sync storage.
-      return Promise.reject(new StorageUnavailableError(message));
-    }
-    if (message.indexOf('Please set webextensions.storage.sync.enabled to true') >= 0) {
-      // Sync storage disabled in flags.
-      return Promise.reject(new StorageUnavailableError(message));
-    }
-    return Promise.reject(err);
-  }
 
   /** The single `onChanged` listener, shared by every instance and area. */
   static readonly onChangedListener = (
@@ -130,7 +73,7 @@ export class ChromeStorage extends Storage {
   private async _run<T>(operation: (area: chrome.storage.StorageArea) => Promise<T>): Promise<T> {
     const area = this._area;
     if (!area) {
-      return ChromeStorage.parseStorageErrors(
+      return parseStorageErrors(
         new Error(`Storage area ${this.areaName} is not available`),
       );
     }
@@ -138,10 +81,10 @@ export class ChromeStorage extends Storage {
     try {
       result = await operation(area);
     } catch (e) {
-      return ChromeStorage.parseStorageErrors(e);
+      return parseStorageErrors(e);
     }
     const message = chrome.runtime?.lastError?.message;
-    if (message) return ChromeStorage.parseStorageErrors(new Error(message));
+    if (message) return parseStorageErrors(new Error(message));
     return result;
   }
 

--- a/packages/extension/src/fetch-url.ts
+++ b/packages/extension/src/fetch-url.ts
@@ -4,6 +4,11 @@
  * Replaces the `xhr` package with `fetch`, which is available in the MV3
  * service worker and removes the dependency along with its
  * `request`-style error shape.
+ *
+ * Only `http:` and `https:` URLs are fetched. Redirects that land on
+ * loopback, RFC1918, link-local, or cloud-metadata hosts are refused so a
+ * hostile list URL cannot be used to probe the user's network. Responses
+ * are stream-read with a byte cap and the request is aborted on timeout.
  */
 
 import {
@@ -19,6 +24,13 @@ interface Response_ {
   body: string;
 }
 
+/** Tunable limits; tests shrink these so they need not wait or buffer megabytes. */
+export const fetchLimits = {
+  timeoutMs: 30_000,
+  maxBytes: 2 * 1024 * 1024,
+  maxRedirects: 5,
+};
+
 /**
  * The media type without its parameters, lowercased.
  *
@@ -31,51 +43,314 @@ function mediaType(header: string | null): string {
   return (header ?? '').split(';')[0]!.trim().toLowerCase();
 }
 
-async function request(url: string): Promise<Response_> {
-  let response: Response;
-  try {
-    response = await fetch(url, { credentials: 'omit', redirect: 'follow' });
-  } catch (e) {
-    // fetch only rejects for transport-level failures.
-    throw new NetworkError(e);
-  }
+const HTML_MARKERS =
+  /<!doctype\b|<\/?(?:html|head|body|script|style|meta|title|link)\b/i;
 
-  if (!response.ok) {
-    const detail = { statusCode: response.status };
-    if (response.status === 404) throw new HttpNotFoundError(detail);
-    if (response.status >= 500 && response.status < 600) throw new HttpServerError(detail);
-    throw new HttpError(detail);
-  }
+/**
+ * Cheap sniff for an HTML document or error page.
+ *
+ * Case-insensitive, and matches opening or closing structural tags — not just
+ * `<!DOCTYPE` / `</html>` / `</body>`. Only the first 8 KiB is inspected so a
+ * huge PAC cannot trip this by accident later in the file.
+ */
+export function looksLikeHtml(body: string): boolean {
+  return HTML_MARKERS.test(body.slice(0, 8192));
+}
 
-  return {
-    contentType: mediaType(response.headers.get('content-type')),
-    body: await response.text(),
+function parseDottedIPv4(host: string): [number, number, number, number] | null {
+  const parts = host.split('.');
+  if (parts.length === 0 || parts.length > 4) return null;
+  const nums: number[] = [];
+  for (const part of parts) {
+    if (!/^\d{1,10}$/.test(part)) return null;
+    const n = Number(part);
+    if (!Number.isInteger(n) || n < 0) return null;
+    nums.push(n);
+  }
+  if (parts.length === 4) {
+    if (nums.some((n) => n > 255)) return null;
+    return [nums[0]!, nums[1]!, nums[2]!, nums[3]!];
+  }
+  if (parts.length === 1) {
+    const n = nums[0]!;
+    if (n > 0xffffffff) return null;
+    return [(n >>> 24) & 255, (n >>> 16) & 255, (n >>> 8) & 255, n & 255];
+  }
+  if (parts.length === 2) {
+    if (nums[0]! > 255 || nums[1]! > 0xffffff) return null;
+    const rest = nums[1]!;
+    return [nums[0]!, (rest >>> 16) & 255, (rest >>> 8) & 255, rest & 255];
+  }
+  if (nums[0]! > 255 || nums[1]! > 255 || nums[2]! > 0xffff) return null;
+  const rest = nums[2]!;
+  return [nums[0]!, nums[1]!, (rest >>> 8) & 255, rest & 255];
+}
+
+function isBlockedIPv4(octets: [number, number, number, number]): boolean {
+  const a = octets[0];
+  const b = octets[1];
+  if (a === 0) return true;
+  if (a === 127) return true;
+  if (a === 10) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 169 && b === 254) return true;
+  return false;
+}
+
+function parseIPv6(host: string): number[] | null {
+  const lower = host.toLowerCase();
+  if (lower.includes('.')) {
+    const lastColon = lower.lastIndexOf(':');
+    if (lastColon < 0) return null;
+    const v4 = parseDottedIPv4(lower.slice(lastColon + 1));
+    if (!v4) return null;
+    const head = lower.slice(0, lastColon + 1);
+    const hexTail =
+      ((v4[0]! << 8) | v4[1]!).toString(16) + ':' + ((v4[2]! << 8) | v4[3]!).toString(16);
+    return parseIPv6(head + hexTail);
+  }
+  const sides = lower.split('::');
+  if (sides.length > 2) return null;
+  const parseSide = (side: string): number[] | null => {
+    if (side === '') return [];
+    const groups = side.split(':');
+    const out: number[] = [];
+    for (const group of groups) {
+      if (!/^[0-9a-f]{1,4}$/.test(group)) return null;
+      out.push(parseInt(group, 16));
+    }
+    return out;
   };
+  if (sides.length === 1) {
+    const groups = parseSide(sides[0]!);
+    if (!groups || groups.length !== 8) return null;
+    return groups;
+  }
+  const left = parseSide(sides[0]!);
+  const right = parseSide(sides[1]!);
+  if (!left || !right) return null;
+  const fill = 8 - left.length - right.length;
+  if (fill < 0) return null;
+  return [...left, ...Array<number>(fill).fill(0), ...right];
+}
+
+function isBlockedIPv6(groups: number[]): boolean {
+  if (groups.every((g, i) => (i === 7 ? g === 1 : g === 0))) return true;
+  if (groups.every((g) => g === 0)) return true;
+  if ((groups[0]! & 0xffc0) === 0xfe80) return true;
+  if ((groups[0]! & 0xfe00) === 0xfc00) return true;
+  if (
+    groups[0] === 0 &&
+    groups[1] === 0 &&
+    groups[2] === 0 &&
+    groups[3] === 0 &&
+    groups[4] === 0 &&
+    groups[5] === 0xffff
+  ) {
+    return isBlockedIPv4([
+      groups[6]! >> 8,
+      groups[6]! & 0xff,
+      groups[7]! >> 8,
+      groups[7]! & 0xff,
+    ]);
+  }
+  return false;
+}
+
+/** True for loopback, RFC1918, link-local, ULA, and well-known metadata hosts. */
+export function isNonPublicHostname(host: string): boolean {
+  let raw = host.toLowerCase();
+  if (raw.endsWith('.')) raw = raw.slice(0, -1);
+  const unbracketed =
+    raw.charCodeAt(0) === 0x5b /* [ */ && raw.charCodeAt(raw.length - 1) === 0x5d /* ] */
+      ? raw.slice(1, -1)
+      : raw;
+  if (unbracketed === 'localhost' || unbracketed.endsWith('.localhost')) return true;
+  if (
+    unbracketed === 'metadata.google.internal' ||
+    unbracketed === 'metadata.goog' ||
+    unbracketed.endsWith('.metadata.google.internal')
+  ) {
+    return true;
+  }
+  const v4 = parseDottedIPv4(unbracketed);
+  if (v4) return isBlockedIPv4(v4);
+  if (unbracketed.includes(':')) {
+    const v6 = parseIPv6(unbracketed);
+    if (v6) return isBlockedIPv6(v6);
+  }
+  return false;
+}
+
+function assertAllowedUrl(urlString: string): URL {
+  let url: URL;
+  try {
+    url = new URL(urlString);
+  } catch {
+    throw new NetworkError(undefined, 'Invalid URL');
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new NetworkError(undefined, 'Only http(s) URLs are allowed');
+  }
+  if (isNonPublicHostname(url.hostname)) {
+    throw new NetworkError(undefined, 'Refused to fetch a non-public host');
+  }
+  return url;
+}
+
+function isRedirectStatus(status: number): boolean {
+  return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
+}
+
+async function readBodyCapped(response: Response, signal: AbortSignal): Promise<string> {
+  const declared = Number(response.headers.get('content-length'));
+  if (Number.isFinite(declared) && declared > fetchLimits.maxBytes) {
+    throw new NetworkError(undefined, 'Response exceeded size limit');
+  }
+
+  if (!response.body) {
+    const text = await response.text();
+    if (new TextEncoder().encode(text).length > fetchLimits.maxBytes) {
+      throw new NetworkError(undefined, 'Response exceeded size limit');
+    }
+    return text;
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  const chunks: string[] = [];
+  let received = 0;
+  try {
+    for (;;) {
+      if (signal.aborted) {
+        throw new NetworkError(signal.reason, 'Request aborted');
+      }
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      received += value.byteLength;
+      if (received > fetchLimits.maxBytes) {
+        await reader.cancel();
+        throw new NetworkError(undefined, 'Response exceeded size limit');
+      }
+      chunks.push(decoder.decode(value, { stream: true }));
+    }
+    chunks.push(decoder.decode());
+    return chunks.join('');
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // Already released by cancel().
+    }
+  }
+}
+
+async function fetchFollowing(urlString: string, signal: AbortSignal): Promise<Response> {
+  let current = assertAllowedUrl(urlString).href;
+
+  for (let hops = 0; hops <= fetchLimits.maxRedirects; hops++) {
+    assertAllowedUrl(current);
+    let response: Response;
+    try {
+      response = await fetch(current, {
+        credentials: 'omit',
+        redirect: 'manual',
+        signal,
+      });
+    } catch (e) {
+      if (e instanceof NetworkError) throw e;
+      if (e instanceof DOMException && e.name === 'AbortError') {
+        throw new NetworkError(e, 'Request timed out');
+      }
+      throw new NetworkError(e);
+    }
+
+    // Page/worker fetch with redirect: 'manual' yields an opaque-redirect
+    // filtered response (no Location). Follow automatically and refuse a
+    // non-public final URL. Node's undici exposes the real 3xx, so tests
+    // (and any host that does the same) walk hops and can reject mid-chain.
+    if (response.type === 'opaqueredirect') {
+      let followed: Response;
+      try {
+        followed = await fetch(current, {
+          credentials: 'omit',
+          redirect: 'follow',
+          signal,
+        });
+      } catch (e) {
+        if (e instanceof NetworkError) throw e;
+        if (e instanceof DOMException && e.name === 'AbortError') {
+          throw new NetworkError(e, 'Request timed out');
+        }
+        throw new NetworkError(e);
+      }
+      assertAllowedUrl(followed.url || current);
+      return followed;
+    }
+
+    if (!isRedirectStatus(response.status)) {
+      if (response.url) assertAllowedUrl(response.url);
+      return response;
+    }
+
+    const location = response.headers.get('location');
+    if (!location) throw new NetworkError(undefined, 'Redirect missing Location');
+    let next: URL;
+    try {
+      next = new URL(location, current);
+    } catch {
+      throw new NetworkError(undefined, 'Redirect to an invalid URL');
+    }
+    current = next.href;
+  }
+  throw new NetworkError(undefined, 'Too many redirects');
+}
+
+async function request(url: string): Promise<Response_> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), fetchLimits.timeoutMs);
+  try {
+    const response = await fetchFollowing(url, controller.signal);
+
+    if (!response.ok) {
+      const detail = { statusCode: response.status };
+      if (response.status === 404) throw new HttpNotFoundError(detail);
+      if (response.status >= 500 && response.status < 600) throw new HttpServerError(detail);
+      throw new HttpError(detail);
+    }
+
+    return {
+      contentType: mediaType(response.headers.get('content-type')),
+      body: await readBodyCapped(response, controller.signal),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 type HintHandler = (res: Response_, hint: string) => string | undefined;
 
-function looksLikeHtml(body: string): boolean {
-  return (
-    body.indexOf('<!DOCTYPE') >= 0 ||
-    body.indexOf('<!doctype') >= 0 ||
-    body.indexOf('</html>') >= 0 ||
-    body.indexOf('</body>') >= 0
-  );
+function rejectIfHtml(body: string): void {
+  if (looksLikeHtml(body)) {
+    throw new ContentTypeRejectedError('Response must not be HTML.');
+  }
 }
 
 const rejectHtml: HintHandler = (res, hint) => {
   if (res.contentType !== hint.substring(1)) return undefined;
   // Other content is sometimes served as text/html, so only reject when the
   // body really does look like markup.
-  if (looksLikeHtml(res.body)) {
-    throw new ContentTypeRejectedError('Response must not be HTML.');
-  }
+  rejectIfHtml(res.body);
   return undefined;
 };
 
 const hintHandlers: Record<string, HintHandler> = {
-  '*': (res) => res.body,
+  '*': (res) => {
+    rejectIfHtml(res.body);
+    return res.body;
+  },
 
   '!text/html': rejectHtml,
   '!application/xhtml+xml': rejectHtml,
@@ -99,11 +374,16 @@ const defaultHintHandler: HintHandler = (res, hint) => {
     }
     return undefined;
   }
-  return res.contentType === hint ? res.body : undefined;
+  if (res.contentType !== hint) return undefined;
+  rejectIfHtml(res.body);
+  return res.body;
 };
 
 function bodyForHints(res: Response_, typeHints?: string[]): string {
-  if (!typeHints || typeHints.length === 0) return res.body;
+  if (!typeHints || typeHints.length === 0) {
+    rejectIfHtml(res.body);
+    return res.body;
+  }
 
   for (const hint of typeHints) {
     const handler = hintHandlers[hint] ?? defaultHintHandler;
@@ -116,16 +396,18 @@ function bodyForHints(res: Response_, typeHints?: string[]): string {
 /**
  * Fetch a URL, optionally defeating the HTTP cache.
  *
- * Cache busting appends a throwaway query parameter, and only when the URL has
- * no query of its own, so that servers reading their own parameters are not
- * disturbed. If that request fails the original URL is tried, since some
- * servers reject unexpected parameters outright.
+ * Only `http:` / `https:` are accepted. Cache busting appends a throwaway
+ * query parameter, and only when the URL has no query of its own, so that
+ * servers reading their own parameters are not disturbed. If that request
+ * fails the original URL is tried, since some servers reject unexpected
+ * parameters outright.
  */
 export async function fetchUrl(
   destUrl: string,
   bypassCache?: boolean,
   typeHints?: string[],
 ): Promise<string> {
+  assertAllowedUrl(destUrl);
   if (bypassCache && destUrl.indexOf('?') < 0) {
     const url = new URL(destUrl);
     url.searchParams.set('_', String(Date.now()));

--- a/packages/extension/src/proxy-auth.ts
+++ b/packages/extension/src/proxy-auth.ts
@@ -34,6 +34,11 @@ const STORAGE_KEY = 'deltaProxyAuth';
 /** Pre-rename key; still read so an upgrade does not drop saved credentials. */
 const LEGACY_STORAGE_KEY = 'omegaProxyAuth';
 
+/** Drop request-id retry state after this; challenges rarely last this long. */
+export const AUTH_REQUEST_TTL_MS = 60_000;
+/** Bound on in-flight challenge records so a long session cannot grow forever. */
+export const AUTH_REQUEST_CAP = 256;
+
 /** One candidate credential for a challenge. Fallbacks carry no `config`. */
 interface AuthEntry {
   config?: ProxyServer;
@@ -82,8 +87,14 @@ export class ProxyAuth {
   log: Logger | null;
   listening = false;
 
-  /** Per-request state, keyed by requestId; see {@link _credentialsFor}. */
-  private _requests: Record<string, { authTries: number } | undefined> = {};
+  /**
+   * Per-request retry state, keyed by requestId.
+   *
+   * Insertion order is LRU. Entries expire after {@link AUTH_REQUEST_TTL_MS}
+   * so we do not need `onCompleted` / `onErrorOccurred` listeners — those
+   * would observe every request once `<all_urls>` is granted.
+   */
+  private _requests = new Map<string, { authTries: number; seenAt: number }>();
   private _proxies: Record<string, AuthEntry[] | undefined> = {};
   private _fallbacks: AuthEntry[] = [];
   private _hydrated = false;
@@ -129,12 +140,6 @@ export class ProxyAuth {
       ]);
     }
 
-    chrome.webRequest.onCompleted.addListener((details) => this._requestDone(details), {
-      urls: ['<all_urls>'],
-    });
-    chrome.webRequest.onErrorOccurred.addListener((details) => this._requestDone(details), {
-      urls: ['<all_urls>'],
-    });
     this.listening = true;
 
     // Warm the credentials from the last applyProfile so that the common case
@@ -154,24 +159,57 @@ export class ProxyAuth {
   }
 
   /**
-   * Write to both session and local storage.
+   * Persist credentials for the next worker wake-up.
    *
-   * Session storage covers worker restarts within a browser session and is
-   * never written to disk. Local storage covers a full browser restart, where
-   * the first proxied request can easily beat `Options.init` to re-applying the
-   * profile — without it, that request would get no credentials at all.
+   * Session storage is preferred: it survives worker restarts and is never
+   * written to disk. Local is only used when session is missing or the write
+   * fails (cold start before `applyProfile` on hosts without session storage,
+   * leftover from older builds). A successful session write clears local so
+   * passwords do not sit on disk after the profile is re-applied.
+   *
+   * Never written to `chrome.storage.sync`.
    */
   private _persist(): void {
     const payload = { [STORAGE_KEY]: this._payload() };
-    for (const areaName of ['session', 'local'] as const) {
-      const area = storageArea(areaName);
-      if (!area) continue;
+    const session = storageArea('session');
+    if (session) {
       try {
-        void Promise.resolve(area.set(payload)).catch(() => undefined);
+        void Promise.resolve(session.set(payload)).then(
+          () => {
+            this._clearLocal();
+          },
+          () => {
+            this._writeLocal(payload);
+          },
+        );
+        return;
       } catch {
-        // A storage area that throws synchronously is unusable; the in-memory
-        // credentials still work for as long as this worker lives.
+        // Session threw synchronously; fall back to local.
       }
+    }
+    this._writeLocal(payload);
+  }
+
+  private _writeLocal(payload: Record<string, AuthPayload>): void {
+    const local = storageArea('local');
+    if (!local) return;
+    try {
+      void Promise.resolve(local.set(payload)).catch(() => undefined);
+    } catch {
+      // In-memory credentials still work for as long as this worker lives.
+    }
+  }
+
+  private _clearLocal(): void {
+    const local = storageArea('local');
+    if (!local) return;
+    try {
+      void Promise.resolve(local.remove([STORAGE_KEY, LEGACY_STORAGE_KEY])).catch(
+        () => undefined,
+      );
+    } catch {
+      // Leftover local credentials are a disk-exposure issue, not a
+      // functional one; the next successful persist will try again.
     }
   }
 
@@ -327,11 +365,7 @@ export class ProxyAuth {
     details: chrome.webRequest.WebAuthenticationChallengeDetails,
   ): chrome.webRequest.BlockingResponse {
     if (!details.isProxy) return {};
-    let req = this._requests[details.requestId];
-    if (!req) {
-      req = { authTries: 0 };
-      this._requests[details.requestId] = req;
-    }
+    const req = this._stateFor(details.requestId);
 
     let list: AuthEntry[] | undefined;
     let key: string | undefined;
@@ -398,8 +432,27 @@ export class ProxyAuth {
     return respond(this._credentialsFor(details));
   }
 
-  private _requestDone(details: { requestId: string }): void {
-    delete this._requests[details.requestId];
+  /** LRU + TTL bookkeeping for one `requestId`. */
+  private _stateFor(requestId: string): { authTries: number } {
+    const now = Date.now();
+    for (const [id, rec] of this._requests) {
+      if (now - rec.seenAt > AUTH_REQUEST_TTL_MS) this._requests.delete(id);
+    }
+    const existing = this._requests.get(requestId);
+    if (existing) {
+      this._requests.delete(requestId);
+      existing.seenAt = now;
+      this._requests.set(requestId, existing);
+      return existing;
+    }
+    while (this._requests.size >= AUTH_REQUEST_CAP) {
+      const oldest = this._requests.keys().next().value;
+      if (oldest === undefined) break;
+      this._requests.delete(oldest);
+    }
+    const created = { authTries: 0, seenAt: now };
+    this._requests.set(requestId, created);
+    return created;
   }
 }
 

--- a/packages/extension/src/rpc.ts
+++ b/packages/extension/src/rpc.ts
@@ -1,0 +1,148 @@
+/**
+ * Explicit RPC surface of the service worker.
+ *
+ * Method names are mapped to functions — never looked up by reflection on
+ * `ChromeOptions` — so a compromised page cannot reach `fetchUrl`, `upgrade`,
+ * or other worker-only hooks. Callers must be this extension (`sender.id`);
+ * when `sender.origin` is present it must be an extension-page origin.
+ * Profile `auth` is stripped from replies unless the sender is a trusted
+ * extension page (popup / options / side panel).
+ */
+
+import type { Profile } from '@switchydelta/pac';
+import type { BrowserStorage, StorageItems } from '@switchydelta/target';
+
+import type { ChromeOptions } from './chrome-options.js';
+
+export interface RpcContext {
+  options: ChromeOptions;
+  state: BrowserStorage;
+}
+
+type RpcHandler = (ctx: RpcContext, args: unknown[]) => unknown;
+
+/**
+ * Origin of this extension's pages (`chrome-extension://<id>` or
+ * `moz-extension://<uuid>`). Derived from `getURL` so Firefox's internal
+ * UUID matches `sender.origin`. `URL.origin` is not used: Node (and some
+ * hosts) treat these as non-special schemes and would report `"null"`.
+ */
+export function extensionPageOrigin(): string {
+  try {
+    if (typeof chrome !== 'undefined' && chrome.runtime?.getURL) {
+      const base = chrome.runtime.getURL('');
+      return base.endsWith('/') ? base.slice(0, -1) : base;
+    }
+  } catch {
+    // Tests, or a runtime without getURL: fall through to the Chrome form.
+  }
+  return `chrome-extension://${chrome.runtime.id}`;
+}
+
+function isExtensionPageUrl(url: string, extOrigin: string): boolean {
+  return url === extOrigin || url.startsWith(`${extOrigin}/`);
+}
+
+export interface SenderAuthorization {
+  allowed: boolean;
+  /** Popup, options page, or side panel — may receive profile `auth`. */
+  trustedPage: boolean;
+}
+
+/**
+ * Gate an `onMessage` sender.
+ *
+ * `sender.id` must be this extension. A present `origin` must be the
+ * extension-page origin: content scripts share `sender.id` but carry the
+ * tab's origin. `url` is used the same way when present.
+ */
+export function authorizeSender(sender: chrome.runtime.MessageSender): SenderAuthorization {
+  if (typeof chrome === 'undefined' || !chrome.runtime?.id) {
+    return { allowed: false, trustedPage: false };
+  }
+  if (sender.id !== chrome.runtime.id) {
+    return { allowed: false, trustedPage: false };
+  }
+
+  const extOrigin = extensionPageOrigin();
+  if (sender.origin != null && sender.origin !== '' && sender.origin !== extOrigin) {
+    return { allowed: false, trustedPage: false };
+  }
+  if (sender.url != null && sender.url !== '' && !isExtensionPageUrl(sender.url, extOrigin)) {
+    return { allowed: false, trustedPage: false };
+  }
+
+  const trustedPage =
+    sender.origin === extOrigin ||
+    (typeof sender.url === 'string' && isExtensionPageUrl(sender.url, extOrigin));
+  return { allowed: true, trustedPage };
+}
+
+function isProfileLike(value: Record<string, unknown>): boolean {
+  return typeof value['profileType'] === 'string' && typeof value['name'] === 'string';
+}
+
+/** Deep-clone `value`, dropping `auth` on profile-shaped objects. */
+export function stripAuthFromResult(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map(stripAuthFromResult);
+  const input = value as Record<string, unknown>;
+  const output: Record<string, unknown> = {};
+  const dropAuth = isProfileLike(input);
+  for (const [key, child] of Object.entries(input)) {
+    if (dropAuth && key === 'auth') continue;
+    output[key] = stripAuthFromResult(child);
+  }
+  return output;
+}
+
+export const RPC_METHODS: Record<string, RpcHandler> = {
+  getState: (ctx, args) => ctx.state.get(args[0] as string | string[] | StorageItems),
+  setState: (ctx, args) => ctx.state.set(args[0] as StorageItems),
+
+  getAll: (ctx) => ctx.options.getAll(),
+  patch: (ctx, args) => ctx.options.patch(args[0] as never),
+  reset: (ctx, args) => ctx.options.reset(args[0] as never),
+  applyChanges: (ctx, args) => ctx.options.applyChanges(args[0] as StorageItems),
+
+  applyProfile: (ctx, args) => ctx.options.applyProfile(args[0] as string),
+  addProfile: (ctx, args) => ctx.options.addProfile(args[0] as Profile),
+  renameProfile: (ctx, args) => ctx.options.renameProfile(args[0] as string, args[1] as string),
+  replaceRef: (ctx, args) => ctx.options.replaceRef(args[0] as string, args[1] as string),
+  setDefaultProfile: (ctx, args) =>
+    ctx.options.setDefaultProfile(args[0] as string, args[1] as string),
+
+  addTempRule: (ctx, args) => ctx.options.addTempRule(args[0] as string, args[1] as string),
+  addCondition: (ctx, args) => ctx.options.addCondition(args[0] as never, args[1] as string),
+
+  updateProfile: (ctx, args) =>
+    ctx.options.updateProfile(
+      args[0] as string | string[] | null | undefined,
+      args[1] as boolean | undefined,
+    ),
+  pacForProfile: (ctx, args) => ctx.options.pacForProfile(args[0] as string),
+
+  setOptionsSync: (ctx, args) =>
+    ctx.options.setOptionsSync(args[0] as boolean, args[1] as { force?: boolean } | undefined),
+  resetOptionsSync: (ctx) => ctx.options.resetOptionsSync(),
+  proxyAuthStatus: (ctx) => ctx.options.proxyAuthStatus(),
+
+  // e2e introspection; not part of the UI messaging layer.
+  lastActionIconPaint: (ctx) => ctx.options.lastActionIconPaint(),
+  sampleActionIcon: (ctx, args) =>
+    ctx.options.sampleActionIcon(
+      args[0] as string,
+      args[1] as string | undefined,
+      args[2] as number | undefined,
+    ),
+};
+
+export async function dispatchRpc(
+  method: string,
+  ctx: RpcContext,
+  args: unknown[],
+): Promise<unknown> {
+  const handler = RPC_METHODS[method];
+  if (!handler) throw new Error(`No such method: ${method}`);
+  return handler(ctx, args);
+}

--- a/packages/extension/src/sw.ts
+++ b/packages/extension/src/sw.ts
@@ -12,13 +12,13 @@
  */
 
 import { BrowserStorage, OptionsSync, Options, Log } from '@switchydelta/target';
-import type { StorageItems } from '@switchydelta/target';
 
 import { watchActiveTab } from './active-tab-icon.js';
 import { ChromeOptions } from './chrome-options.js';
 import { ChromeStorage } from './chrome-storage.js';
 import { ProxyAuth } from './proxy-auth.js';
 import { ProxySettings } from './proxy-settings.js';
+import { authorizeSender, dispatchRpc, stripAuthFromResult } from './rpc.js';
 
 /**
  * Registered before anything async runs.
@@ -159,9 +159,11 @@ void ready.then(() => chrome.proxy.settings.get({}, handleProxyChange));
 /**
  * RPC dispatcher.
  *
- * The UI sends `{method, args}` and expects `{result}` or `{error}`.
+ * The UI sends `{method, args}` and expects `{result}` or `{error}`. Methods
+ * are dispatched through the allowlist in `rpc.ts`, not by reflecting on
+ * `ChromeOptions`.
  */
-chrome.runtime.onMessage.addListener((request, _sender, respond) => {
+chrome.runtime.onMessage.addListener((request, sender, respond) => {
   const { method, args = [], noReply } = (request ?? {}) as {
     method?: string;
     args?: unknown[];
@@ -169,32 +171,30 @@ chrome.runtime.onMessage.addListener((request, _sender, respond) => {
   };
   if (!method) return false;
 
+  const authz = authorizeSender(sender);
+  if (!authz.allowed) {
+    if (!noReply) respond({ error: encodeError(new Error('Unauthorized')) });
+    return !noReply;
+  }
+
   void (async () => {
     try {
       await ready;
       const target = options;
       if (!target) throw new Error('Options are not ready');
 
-      let result: unknown;
-      if (method === 'getState') {
-        result = await state.get(args[0] as string | string[] | StorageItems);
-      } else if (method === 'setState') {
-        result = await state.set(args[0] as StorageItems);
-      } else {
-        const fn = (target as unknown as Record<string, unknown>)[method];
-        if (typeof fn !== 'function') throw new Error(`No such method: ${method}`);
-        result = await (fn as (...a: unknown[]) => unknown).apply(target, args);
-      }
+      let result: unknown = await dispatchRpc(method, { options: target, state }, args);
 
       if (noReply) return;
       // updateProfile resolves to a map that may contain Errors per profile.
       if (method === 'updateProfile' && result && typeof result === 'object') {
         const encoded: Record<string, unknown> = {};
-        for (const [key, value] of Object.entries(result)) {
+        for (const [key, value] of Object.entries(result as Record<string, unknown>)) {
           encoded[key] = encodeError(value);
         }
         result = encoded;
       }
+      if (!authz.trustedPage) result = stripAuthFromResult(result);
       respond({ result });
     } catch (error) {
       if (!noReply) respond({ error: encodeError(error) });

--- a/packages/extension/test/fetch-url.test.ts
+++ b/packages/extension/test/fetch-url.test.ts
@@ -1,0 +1,237 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  ContentTypeRejectedError,
+  HttpNotFoundError,
+  NetworkError,
+} from '@switchydelta/target';
+
+import {
+  fetchLimits,
+  fetchUrl,
+  isNonPublicHostname,
+  looksLikeHtml,
+} from '../src/fetch-url.js';
+
+const defaults = { ...fetchLimits };
+
+afterEach(() => {
+  Object.assign(fetchLimits, defaults);
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+function textResponse(
+  body: string,
+  contentType = 'text/plain',
+  init: { status?: number; url?: string; headers?: Record<string, string> } = {},
+): Response {
+  const headers = new Headers(init.headers);
+  if (contentType && !headers.has('content-type')) headers.set('content-type', contentType);
+  const response = new Response(body, { status: init.status ?? 200, headers });
+  if (init.url) {
+    Object.defineProperty(response, 'url', { value: init.url });
+  }
+  return response;
+}
+
+function stubFetch(impl: (url: string, init?: RequestInit) => Promise<Response> | Response): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      return Promise.resolve(impl(url, init));
+    }),
+  );
+}
+
+describe('looksLikeHtml', () => {
+  it('is case-insensitive and matches structural tags', () => {
+    expect(looksLikeHtml('<!DOCTYPE html>')).toBe(true);
+    expect(looksLikeHtml('<HTML LANG="en">')).toBe(true);
+    expect(looksLikeHtml('<Head><Title>x</Title></Head>')).toBe(true);
+    expect(looksLikeHtml('<script>alert(1)</script>')).toBe(true);
+    expect(looksLikeHtml('||example.com')).toBe(false);
+    expect(looksLikeHtml('function FindProxyForURL(url, host) { return "DIRECT"; }')).toBe(false);
+  });
+});
+
+describe('isNonPublicHostname', () => {
+  it('flags loopback, RFC1918, link-local, and metadata', () => {
+    expect(isNonPublicHostname('127.0.0.1')).toBe(true);
+    expect(isNonPublicHostname('10.1.2.3')).toBe(true);
+    expect(isNonPublicHostname('172.16.0.1')).toBe(true);
+    expect(isNonPublicHostname('192.168.1.1')).toBe(true);
+    expect(isNonPublicHostname('169.254.169.254')).toBe(true);
+    expect(isNonPublicHostname('localhost')).toBe(true);
+    expect(isNonPublicHostname('foo.localhost')).toBe(true);
+    expect(isNonPublicHostname('[::1]')).toBe(true);
+    expect(isNonPublicHostname('::1')).toBe(true);
+    expect(isNonPublicHostname('metadata.google.internal')).toBe(true);
+    expect(isNonPublicHostname('[::ffff:127.0.0.1]')).toBe(true);
+    expect(isNonPublicHostname('127.1')).toBe(true);
+  });
+
+  it('allows public hosts', () => {
+    expect(isNonPublicHostname('example.com')).toBe(false);
+    expect(isNonPublicHostname('8.8.8.8')).toBe(false);
+    expect(isNonPublicHostname('172.32.0.1')).toBe(false);
+  });
+});
+
+describe('fetchUrl', () => {
+  it('rejects non-http(s) URLs without calling fetch', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    await expect(fetchUrl('file:///etc/passwd')).rejects.toBeInstanceOf(NetworkError);
+    await expect(fetchUrl('data:text/plain,hi')).rejects.toBeInstanceOf(NetworkError);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects loopback and metadata URLs without calling fetch', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    await expect(fetchUrl('http://127.0.0.1/x')).rejects.toMatchObject({
+      message: 'Refused to fetch a non-public host',
+    });
+    await expect(fetchUrl('http://169.254.169.254/latest/meta-data/')).rejects.toBeInstanceOf(
+      NetworkError,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses a redirect hop to a private host', async () => {
+    stubFetch((url) => {
+      if (url === 'https://lists.example/list.txt') {
+        return new Response(null, {
+          status: 302,
+          headers: { Location: 'http://127.0.0.1/secret' },
+        });
+      }
+      return textResponse('should-not-fetch');
+    });
+    await expect(fetchUrl('https://lists.example/list.txt')).rejects.toMatchObject({
+      message: 'Refused to fetch a non-public host',
+    });
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses an opaque-redirect final URL on a private host', async () => {
+    stubFetch((_url, init) => {
+      if (init?.redirect === 'manual') {
+        return { type: 'opaqueredirect', status: 0, ok: false, url: '', headers: new Headers() } as Response;
+      }
+      const followed = textResponse('meta');
+      Object.defineProperty(followed, 'url', { value: 'http://169.254.169.254/latest' });
+      return followed;
+    });
+    await expect(fetchUrl('https://lists.example/list.txt')).rejects.toMatchObject({
+      message: 'Refused to fetch a non-public host',
+    });
+  });
+
+  it('passes an AbortSignal so a stalling server cannot hang the worker', async () => {
+    let signal: AbortSignal | undefined;
+    stubFetch((_url, init) => {
+      signal = init?.signal;
+      return textResponse('||example.com\n');
+    });
+    await fetchUrl('https://lists.example/list.txt');
+    expect(signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('aborts a body past the byte cap', async () => {
+    fetchLimits.maxBytes = 32;
+    stubFetch(() => {
+      const chunk = new Uint8Array(16);
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(chunk);
+          controller.enqueue(chunk);
+          controller.enqueue(chunk);
+          controller.close();
+        },
+      });
+      return new Response(stream, { status: 200, headers: { 'content-type': 'text/plain' } });
+    });
+    await expect(fetchUrl('https://lists.example/list.txt')).rejects.toMatchObject({
+      message: 'Response exceeded size limit',
+    });
+  });
+
+  it('rejects HTML error pages even when the catch-all hint would accept them', async () => {
+    stubFetch(() =>
+      textResponse('<!DOCTYPE html><html><body>404</body></html>', 'application/octet-stream'),
+    );
+    await expect(
+      fetchUrl('https://lists.example/list.txt', false, [
+        '!text/html',
+        '!application/xhtml+xml',
+        'text/plain',
+        '*',
+      ]),
+    ).rejects.toBeInstanceOf(ContentTypeRejectedError);
+  });
+
+  it('rejects uppercase HTML served as text/html', async () => {
+    stubFetch(() => textResponse('<HTML><HEAD></HEAD><BODY>nope</BODY></HTML>', 'text/html'));
+    await expect(
+      fetchUrl('https://lists.example/list.txt', false, ['!text/html', 'text/plain', '*']),
+    ).rejects.toBeInstanceOf(ContentTypeRejectedError);
+  });
+
+  it('accepts a rule list that is not HTML', async () => {
+    stubFetch(() => textResponse('||example.com\n@@||ok.example\n', 'text/plain'));
+    await expect(
+      fetchUrl('https://lists.example/list.txt', false, [
+        '!text/html',
+        '!application/xhtml+xml',
+        'text/plain',
+        '*',
+      ]),
+    ).resolves.toContain('||example.com');
+  });
+
+  it('maps an aborted fetch to a timeout NetworkError', async () => {
+    fetchLimits.timeoutMs = 20;
+    stubFetch((_url, init) => {
+      return new Promise((_resolve, reject) => {
+        const signal = init?.signal;
+        if (!signal) {
+          reject(new Error('missing AbortSignal'));
+          return;
+        }
+        if (signal.aborted) {
+          reject(new DOMException('The operation was aborted.', 'AbortError'));
+          return;
+        }
+        signal.addEventListener('abort', () => {
+          reject(new DOMException('The operation was aborted.', 'AbortError'));
+        });
+      });
+    });
+    await expect(fetchUrl('https://lists.example/list.txt')).rejects.toMatchObject({
+      message: 'Request timed out',
+    });
+  });
+
+  it('rejects a Content-Length over the byte cap before reading', async () => {
+    fetchLimits.maxBytes = 8;
+    stubFetch(() =>
+      new Response('0123456789', {
+        status: 200,
+        headers: { 'content-type': 'text/plain', 'content-length': '64' },
+      }),
+    );
+    await expect(fetchUrl('https://lists.example/list.txt')).rejects.toMatchObject({
+      message: 'Response exceeded size limit',
+    });
+  });
+
+  it('maps 404 to HttpNotFoundError', async () => {
+    stubFetch(() => textResponse('missing', 'text/plain', { status: 404 }));
+    await expect(fetchUrl('https://lists.example/missing.txt')).rejects.toBeInstanceOf(
+      HttpNotFoundError,
+    );
+  });
+});

--- a/packages/extension/test/proxy-auth.test.ts
+++ b/packages/extension/test/proxy-auth.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { FixedProfile } from '@switchydelta/pac';
+
+import { AUTH_REQUEST_CAP, AUTH_REQUEST_TTL_MS, ProxyAuth } from '../src/proxy-auth.js';
+
+interface AreaMock {
+  data: Record<string, unknown>;
+  get: (keys: string[]) => Promise<Record<string, unknown>>;
+  set: (items: Record<string, unknown>) => Promise<void>;
+  remove: (keys: string | string[]) => Promise<void>;
+}
+
+function mockArea(): AreaMock {
+  const data: Record<string, unknown> = {};
+  return {
+    data,
+    async get(keys: string[]) {
+      const out: Record<string, unknown> = {};
+      for (const key of keys) {
+        if (key in data) out[key] = data[key];
+      }
+      return out;
+    },
+    async set(items: Record<string, unknown>) {
+      Object.assign(data, items);
+    },
+    async remove(keys: string | string[]) {
+      for (const key of Array.isArray(keys) ? keys : [keys]) delete data[key];
+    },
+  };
+}
+
+function installChrome(areas: {
+  session?: AreaMock;
+  local?: AreaMock;
+  sync?: AreaMock;
+  webRequest?: boolean;
+}): {
+  onAuthRequired: { addListener: ReturnType<typeof vi.fn> };
+  onCompleted: { addListener: ReturnType<typeof vi.fn> };
+  onErrorOccurred: { addListener: ReturnType<typeof vi.fn> };
+} {
+  const onAuthRequired = { addListener: vi.fn() };
+  const onCompleted = { addListener: vi.fn() };
+  const onErrorOccurred = { addListener: vi.fn() };
+  (globalThis as unknown as { chrome: unknown }).chrome = {
+    storage: {
+      session: areas.session,
+      local: areas.local,
+      sync: areas.sync,
+    },
+    webRequest: areas.webRequest
+      ? {
+          onAuthRequired,
+          onCompleted,
+          onErrorOccurred,
+        }
+      : undefined,
+    runtime: { lastError: undefined },
+  };
+  return { onAuthRequired, onCompleted, onErrorOccurred };
+}
+
+function fixedProfile(): FixedProfile {
+  return {
+    name: 'proxy',
+    profileType: 'FixedProfile',
+    fallbackProxy: { scheme: 'http', host: 'proxy.example', port: 8080 },
+    auth: { fallbackProxy: { username: 'alice', password: 's3cret' } },
+  };
+}
+
+function challenge(requestId: string): chrome.webRequest.WebAuthenticationChallengeDetails {
+  return {
+    isProxy: true,
+    requestId,
+    challenger: { host: 'proxy.example', port: 8080 },
+  } as chrome.webRequest.WebAuthenticationChallengeDetails;
+}
+
+beforeEach(() => {
+  vi.useRealTimers();
+});
+
+afterEach(() => {
+  delete (globalThis as { chrome?: unknown }).chrome;
+  vi.useRealTimers();
+});
+
+describe('ProxyAuth.listen', () => {
+  it('does not register <all_urls> completion listeners', () => {
+    const listeners = installChrome({
+      session: mockArea(),
+      local: mockArea(),
+      webRequest: true,
+    });
+    new ProxyAuth(null).listen();
+    expect(listeners.onAuthRequired.addListener).toHaveBeenCalledOnce();
+    expect(listeners.onCompleted.addListener).not.toHaveBeenCalled();
+    expect(listeners.onErrorOccurred.addListener).not.toHaveBeenCalled();
+  });
+});
+
+describe('ProxyAuth persist', () => {
+  it('writes credentials to session and clears leftover local', async () => {
+    const session = mockArea();
+    const local = mockArea();
+    const sync = mockArea();
+    local.data['deltaProxyAuth'] = { leftover: true };
+    installChrome({ session, local, sync });
+
+    new ProxyAuth(null).setProxies([fixedProfile()]);
+    await vi.waitFor(() => {
+      expect(session.data['deltaProxyAuth']).toBeDefined();
+      expect(local.data['deltaProxyAuth']).toBeUndefined();
+    });
+    expect(sync.data['deltaProxyAuth']).toBeUndefined();
+  });
+
+  it('falls back to local when session storage is missing', async () => {
+    const local = mockArea();
+    const sync = mockArea();
+    installChrome({ local, sync });
+
+    new ProxyAuth(null).setProxies([fixedProfile()]);
+    await vi.waitFor(() => {
+      expect(local.data['deltaProxyAuth']).toBeDefined();
+    });
+    expect(sync.data['deltaProxyAuth']).toBeUndefined();
+    const payload = local.data['deltaProxyAuth'] as {
+      proxies: Record<string, { auth: { username: string } }[]>;
+    };
+    expect(payload.proxies['proxy.example:8080']?.[0]?.auth.username).toBe('alice');
+  });
+});
+
+describe('ProxyAuth request cache', () => {
+  it('expires retry state by TTL instead of a completion listener', () => {
+    installChrome({ session: mockArea(), local: mockArea() });
+    vi.useFakeTimers();
+    const auth = new ProxyAuth(null);
+    auth.setProxies([fixedProfile()]);
+
+    const first = auth.authHandler(challenge('r1'));
+    expect(first).toEqual({
+      authCredentials: { username: 'alice', password: 's3cret' },
+    });
+    expect(auth.authHandler(challenge('r1'))).toEqual({});
+
+    vi.advanceTimersByTime(AUTH_REQUEST_TTL_MS + 1);
+    expect(auth.authHandler(challenge('r1'))).toEqual({
+      authCredentials: { username: 'alice', password: 's3cret' },
+    });
+  });
+
+  it('evicts the oldest requestId once the cap is reached', () => {
+    installChrome({ session: mockArea(), local: mockArea() });
+    const auth = new ProxyAuth(null);
+    auth.setProxies([fixedProfile()]);
+
+    auth.authHandler(challenge('keep-me'));
+    expect(auth.authHandler(challenge('keep-me'))).toEqual({});
+
+    for (let i = 0; i < AUTH_REQUEST_CAP; i++) {
+      auth.authHandler(challenge(`n${i}`));
+    }
+    // `keep-me` was LRU-oldest and must have been evicted: a new try is issued.
+    expect(auth.authHandler(challenge('keep-me'))).toEqual({
+      authCredentials: { username: 'alice', password: 's3cret' },
+    });
+  });
+});

--- a/packages/extension/test/rpc.test.ts
+++ b/packages/extension/test/rpc.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  authorizeSender,
+  dispatchRpc,
+  extensionPageOrigin,
+  RPC_METHODS,
+  stripAuthFromResult,
+} from '../src/rpc.js';
+import type { RpcContext } from '../src/rpc.js';
+
+const EXT_ID = 'abcdefghijklmnopqrstuvwxyzabcdef';
+
+function installChrome(overrides: { id?: string; getURL?: (path: string) => string } = {}): void {
+  const id = overrides.id ?? EXT_ID;
+  const getURL =
+    overrides.getURL ?? ((path: string) => `chrome-extension://${id}/${path.replace(/^\//, '')}`);
+  (globalThis as unknown as { chrome: unknown }).chrome = {
+    runtime: { id, getURL },
+  };
+}
+
+beforeEach(() => {
+  installChrome();
+});
+
+afterEach(() => {
+  delete (globalThis as { chrome?: unknown }).chrome;
+});
+
+describe('RPC_METHODS', () => {
+  it('lists the UI and e2e methods and excludes worker-only hooks', () => {
+    const names = Object.keys(RPC_METHODS);
+    for (const name of [
+      'getState',
+      'setState',
+      'getAll',
+      'patch',
+      'reset',
+      'applyChanges',
+      'applyProfile',
+      'addProfile',
+      'renameProfile',
+      'replaceRef',
+      'setDefaultProfile',
+      'addTempRule',
+      'addCondition',
+      'updateProfile',
+      'pacForProfile',
+      'setOptionsSync',
+      'resetOptionsSync',
+      'proxyAuthStatus',
+      'lastActionIconPaint',
+      'sampleActionIcon',
+    ]) {
+      expect(names).toContain(name);
+    }
+    expect(names).not.toContain('fetchUrl');
+    expect(names).not.toContain('upgrade');
+    expect(names).not.toContain('schedule');
+    expect(names).not.toContain('setProxyNotControllable');
+  });
+});
+
+describe('authorizeSender', () => {
+  it('rejects a missing or foreign extension id', () => {
+    expect(authorizeSender({} as chrome.runtime.MessageSender)).toEqual({
+      allowed: false,
+      trustedPage: false,
+    });
+    expect(authorizeSender({ id: 'other' } as chrome.runtime.MessageSender)).toEqual({
+      allowed: false,
+      trustedPage: false,
+    });
+  });
+
+  it('rejects a matching id with a web origin (content script)', () => {
+    expect(
+      authorizeSender({
+        id: EXT_ID,
+        origin: 'https://evil.example',
+        url: 'https://evil.example/page',
+      }),
+    ).toEqual({ allowed: false, trustedPage: false });
+  });
+
+  it('accepts an extension-page origin as a trusted page', () => {
+    const origin = extensionPageOrigin();
+    expect(
+      authorizeSender({
+        id: EXT_ID,
+        origin,
+        url: `${origin}/popup.html`,
+      }),
+    ).toEqual({ allowed: true, trustedPage: true });
+  });
+
+  it('allows a matching id with no origin but strips trust', () => {
+    expect(authorizeSender({ id: EXT_ID })).toEqual({
+      allowed: true,
+      trustedPage: false,
+    });
+  });
+
+  it('uses getURL so Firefox moz-extension origins match', () => {
+    const uuid = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    installChrome({
+      id: 'switchydelta@madeye.github.io',
+      getURL: (path) => `moz-extension://${uuid}/${path.replace(/^\//, '')}`,
+    });
+    expect(
+      authorizeSender({
+        id: 'switchydelta@madeye.github.io',
+        origin: `moz-extension://${uuid}`,
+        url: `moz-extension://${uuid}/options.html`,
+      }),
+    ).toEqual({ allowed: true, trustedPage: true });
+  });
+});
+
+describe('stripAuthFromResult', () => {
+  it('drops auth from nested profiles and leaves other keys', () => {
+    const input = {
+      schemaVersion: 2,
+      '+proxy': {
+        name: 'proxy',
+        profileType: 'FixedProfile',
+        color: '#000',
+        auth: { all: { username: 'u', password: 'secret' } },
+      },
+      '-downloadInterval': 15,
+    };
+    expect(stripAuthFromResult(input)).toEqual({
+      schemaVersion: 2,
+      '+proxy': { name: 'proxy', profileType: 'FixedProfile', color: '#000' },
+      '-downloadInterval': 15,
+    });
+    // Original is untouched.
+    expect((input['+proxy'] as { auth?: unknown }).auth).toBeDefined();
+  });
+
+  it('does not strip an unrelated auth key on a non-profile object', () => {
+    expect(stripAuthFromResult({ auth: 'keep', name: 1 })).toEqual({ auth: 'keep', name: 1 });
+  });
+});
+
+describe('dispatchRpc', () => {
+  it('rejects unknown methods without reflecting', async () => {
+    const ctx = { options: {}, state: {} } as unknown as RpcContext;
+    await expect(dispatchRpc('fetchUrl', ctx, ['http://example.com'])).rejects.toThrow(
+      'No such method: fetchUrl',
+    );
+  });
+
+  it('forwards allowlisted calls', async () => {
+    const getAll = vi.fn(() => ({ ok: 1 }));
+    const ctx = { options: { getAll }, state: {} } as unknown as RpcContext;
+    await expect(dispatchRpc('getAll', ctx, [])).resolves.toEqual({ ok: 1 });
+    expect(getAll).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/pac/src/codegen.ts
+++ b/packages/pac/src/codegen.ts
@@ -101,9 +101,9 @@ export function string(value: string): Expr {
 }
 
 export function num(value: number): Expr {
-  // Negative literals must be parenthesised so that `a-` + `-1` cannot glue
-  // into the decrement operator `--`.
-  return value < 0 ? raw(String(value), Prec.Unary) : raw(String(value));
+  // Negative literals are wrapped so that `a-` + `-1` cannot glue into the
+  // decrement operator `--`. Primary prec keeps the parens in place.
+  return value < 0 ? raw(`(${String(value)})`, Prec.Primary) : raw(String(value));
 }
 
 export const TRUE: Expr = raw('true');

--- a/packages/pac/src/rule-list.ts
+++ b/packages/pac/src/rule-list.ts
@@ -30,9 +30,13 @@ export interface FormatHandler {
 }
 
 function decodeBase64Utf8(text: string): string {
-  const binary = atob(text);
-  const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
-  return new TextDecoder().decode(bytes);
+  try {
+    const binary = atob(text.replace(/\s+/g, ''));
+    const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+    return new TextDecoder().decode(bytes);
+  } catch {
+    return text;
+  }
 }
 
 // --- AutoProxy --------------------------------------------------------------

--- a/packages/pac/src/shexp.ts
+++ b/packages/pac/src/shexp.ts
@@ -9,6 +9,13 @@ const CHAR_BACKSLASH = 92; // \
 const CHAR_ASTERISK = 42; // *
 const CHAR_QUESTION = 63; // ?
 
+/** Patterns longer than this are treated as never-matching. */
+export const MAX_REGEXP_SOURCE_LENGTH = 2048;
+/** Wildcard patterns longer than this are treated as never-matching. */
+export const MAX_SHEXP_LENGTH = 1024;
+
+const NEVER_MATCH = /(?!)/;
+
 /**
  * Escape forward slashes that are not already escaped, so the pattern is safe
  * to embed in a `/.../` regular expression literal.
@@ -37,9 +44,32 @@ export interface ShExpOptions {
   trimAsterisk?: boolean;
 }
 
-/** Translate a shell wildcard pattern into regular expression source. */
+function escapeRegExpLiteral(text: string): string {
+  let out = '';
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i);
+    if (REGEXP_META_CHARS.has(code)) out += '\\';
+    out += text[i];
+  }
+  return out;
+}
+
+/**
+ * Translate a shell wildcard pattern into regular expression source.
+ *
+ * Interior `*` before a literal is emitted as a first-occurrence loop rather
+ * than `.*`, so `*a*a*…*b` cannot backtrack quadratically. Leading/trailing
+ * `.*` are kept so host-wildcard post-processing (`^` → `(?:^|\.)`, strip
+ * `.*$`) still sees the same shape.
+ */
 export function shExp2RegExp(pattern: string, options?: ShExpOptions): string {
   const trimAsterisk = options?.trimAsterisk ?? false;
+  if (pattern.length > MAX_SHEXP_LENGTH) {
+    // `^(?!)` survives the host-wildcard first-char replace; `(?!)` is used
+    // when anchors are already being dropped (trimAsterisk).
+    return trimAsterisk ? '(?!)' : '^(?!)';
+  }
+
   let start = 0;
   let end = pattern.length;
 
@@ -55,7 +85,20 @@ export function shExp2RegExp(pattern: string, options?: ShExpOptions): string {
   for (let i = start; i < end; i++) {
     const code = pattern.charCodeAt(i);
     if (code === CHAR_ASTERISK) {
-      regex += '.*';
+      while (i + 1 < end && pattern.charCodeAt(i + 1) === CHAR_ASTERISK) i++;
+      let j = i + 1;
+      while (j < end) {
+        const next = pattern.charCodeAt(j);
+        if (next === CHAR_ASTERISK || next === CHAR_QUESTION) break;
+        j++;
+      }
+      if (j > i + 1) {
+        const lit = escapeRegExpLiteral(pattern.substring(i + 1, j));
+        regex += `(?:(?!${lit}).)*${lit}`;
+        i = j - 1;
+      } else {
+        regex += '.*';
+      }
     } else if (code === CHAR_QUESTION) {
       regex += '.';
     } else {
@@ -70,12 +113,172 @@ export function shExp2RegExp(pattern: string, options?: ShExpOptions): string {
 
 /**
  * Compile a regular expression, falling back to a never-matching expression
- * when the source is invalid. User-authored patterns reach this directly.
+ * when the source is invalid, too long, or uses nested/catastrophic
+ * quantifiers. User-authored patterns reach this directly.
  */
 export function safeRegExp(source: string): RegExp {
+  if (source.length > MAX_REGEXP_SOURCE_LENGTH || hasCatastrophicConstruct(source)) {
+    return NEVER_MATCH;
+  }
   try {
     return new RegExp(source);
   } catch {
-    return /(?!)/;
+    return NEVER_MATCH;
   }
+}
+
+/**
+ * True when `source` has nested unbounded quantifiers, a quantified empty
+ * alternative, or overlapping alternatives under an unbounded quantifier
+ * (e.g. `(a+)+`, `(a|)*`, `(a|ab)+`).
+ */
+function hasCatastrophicConstruct(source: string): boolean {
+  let i = 0;
+  let unsafe = false;
+
+  const peek = (): string => source[i] ?? '';
+
+  const parseQuantifier = (): { unbounded: boolean } | null => {
+    const c = peek();
+    if (c === '*' || c === '+') {
+      i++;
+      if (peek() === '?') i++;
+      return { unbounded: true };
+    }
+    if (c === '?') {
+      i++;
+      if (peek() === '?') i++;
+      return { unbounded: false };
+    }
+    if (c === '{') {
+      const start = i;
+      i++;
+      while (i < source.length && source[i] !== '}') i++;
+      if (i >= source.length) {
+        i = start;
+        return null;
+      }
+      const body = source.slice(start + 1, i);
+      i++;
+      if (peek() === '?') i++;
+      const comma = body.indexOf(',');
+      if (comma < 0) return { unbounded: false };
+      if (comma === body.length - 1) return { unbounded: true };
+      const min = Number(body.slice(0, comma));
+      const max = Number(body.slice(comma + 1));
+      if (Number.isFinite(min) && Number.isFinite(max) && max - min >= 64) {
+        return { unbounded: true };
+      }
+      return { unbounded: false };
+    }
+    return null;
+  };
+
+  const parseClass = (): void => {
+    i++;
+    if (peek() === '^') i++;
+    if (peek() === ']') i++;
+    while (i < source.length) {
+      const c = source[i];
+      if (c === '\\') {
+        i += 2;
+        continue;
+      }
+      if (c === ']') {
+        i++;
+        return;
+      }
+      i++;
+    }
+  };
+
+  const parseGroupKind = (): void => {
+    if (peek() !== '?') return;
+    i++;
+    const c = peek();
+    if (c === ':' || c === '=' || c === '!') {
+      i++;
+      return;
+    }
+    if (c === '<') {
+      i++;
+      const d = peek();
+      if (d === '=' || d === '!') {
+        i++;
+        return;
+      }
+      while (i < source.length && source[i] !== '>') i++;
+      if (peek() === '>') i++;
+    }
+  };
+
+  const parseAlternation = (endAt: ')' | ''): { hasQuantifier: boolean; alts: string[] } => {
+    const alts: string[] = [];
+    let altStart = i;
+    let hasQuantifier = false;
+
+    const finishAlt = (): void => {
+      alts.push(source.slice(altStart, i));
+    };
+
+    while (i < source.length) {
+      const c = source[i]!;
+      if (endAt === ')' && c === ')') break;
+      if (c === '|') {
+        finishAlt();
+        i++;
+        altStart = i;
+        continue;
+      }
+      if (c === '\\') {
+        i += 2;
+        const q = parseQuantifier();
+        if (q) hasQuantifier = true;
+        continue;
+      }
+      if (c === '[') {
+        parseClass();
+        const q = parseQuantifier();
+        if (q) hasQuantifier = true;
+        continue;
+      }
+      if (c === '(') {
+        i++;
+        parseGroupKind();
+        const inner = parseAlternation(')');
+        if (peek() === ')') i++;
+        const q = parseQuantifier();
+        if (inner.hasQuantifier) hasQuantifier = true;
+        if (q) {
+          hasQuantifier = true;
+          if (q.unbounded && inner.hasQuantifier) unsafe = true;
+          if (q.unbounded && inner.alts.some((alt) => alt.length === 0)) unsafe = true;
+          if (q.unbounded && inner.alts.length > 1 && altsOverlap(inner.alts)) unsafe = true;
+        }
+        continue;
+      }
+      i++;
+      const q = parseQuantifier();
+      if (q) hasQuantifier = true;
+    }
+    finishAlt();
+    return { hasQuantifier, alts };
+  };
+
+  parseAlternation('');
+  return unsafe;
+}
+
+function altsOverlap(alts: string[]): boolean {
+  for (let i = 0; i < alts.length; i++) {
+    const a = alts[i]!;
+    if (a.length === 0) continue;
+    for (let j = 0; j < alts.length; j++) {
+      if (i === j) continue;
+      const b = alts[j]!;
+      if (b.length === 0) continue;
+      if (b.startsWith(a) || a.startsWith(b)) return true;
+    }
+  }
+  return false;
 }

--- a/packages/pac/src/utils.ts
+++ b/packages/pac/src/utils.ts
@@ -65,7 +65,7 @@ export class AttachedCache<T extends object, V> {
  * that reach it from a URL.
  */
 export function isIp(domain: string): boolean {
-  if (domain.indexOf(':') > 0) return true; // IPv6
+  if (domain.indexOf(':') >= 0) return true; // IPv6 (including :: and :1)
   const lastCharCode = domain.charCodeAt(domain.length - 1);
   return lastCharCode >= 48 && lastCharCode <= 57; // trailing digit => IPv4
 }

--- a/packages/pac/test/codegen.test.ts
+++ b/packages/pac/test/codegen.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { binary, ref, num, str } from '../src/codegen.js';
+import * as PacGenerator from '../src/pac-generator.js';
+import * as Profiles from '../src/profiles.js';
+import * as Conditions from '../src/conditions.js';
+import type { FixedProfile, OptionsBag, SwitchProfile } from '../src/types.js';
+
+describe('codegen', () => {
+  it('parenthesises a negative numeric right operand of subtraction', () => {
+    const expr = binary('-', ref('x'), num(-1));
+    expect(expr.code).toBe('x-(-1)');
+    const fn = new Function('x', `return (${expr.code});`) as (x: number) => number;
+    expect(fn(5)).toBe(5 - -1);
+    expect(fn(5)).toBe(6);
+  });
+});
+
+function evalStringLiteral(literal: string): string {
+  return new Function(`return (${literal});`)() as string;
+}
+
+function evalPac(script: string): (url: string, host: string) => string {
+  return new Function(script + '; return FindProxyForURL;')() as (
+    url: string,
+    host: string,
+  ) => string;
+}
+
+/** Walk the in-process profile chain to the leaf PAC result string. */
+function inProcessPacResult(options: OptionsBag, profileName: string, url: string): string {
+  const req = Conditions.requestFromUrl(url);
+  let profile = Profiles.byName(profileName, options);
+  const visited = new Set<string>();
+  let last: string | undefined;
+  while (profile) {
+    const key = Profiles.nameAsKey(profile);
+    if (visited.has(key)) break;
+    visited.add(key);
+    const result = Profiles.match(profile, req);
+    if (result == null) break;
+    if (Array.isArray(result)) {
+      const next = result[0];
+      if (typeof next !== 'string') break;
+      // PAC compilation maps the builtin +direct key to the DIRECT result.
+      if (next === '+direct' || next === 'DIRECT') return 'DIRECT';
+      last = next;
+      if (next.charCodeAt(0) !== 43 /* + */) return next;
+      profile = Profiles.byKey(next, options);
+    } else if (result.profileName) {
+      last = result.profileName;
+      profile = Profiles.byName(result.profileName, options);
+    } else {
+      break;
+    }
+  }
+  return last ?? 'DIRECT';
+}
+
+function bagWithNamedProxy(name: string): OptionsBag {
+  return {
+    '+auto': {
+      name: 'auto',
+      profileType: 'SwitchProfile',
+      revision: 'test',
+      defaultProfileName: 'direct',
+      rules: [
+        {
+          profileName: name,
+          condition: { conditionType: 'HostWildcardCondition', pattern: '*.example.com' },
+        },
+      ],
+    } satisfies SwitchProfile,
+    ['+' + name]: {
+      name,
+      profileType: 'FixedProfile',
+      revision: 'test',
+      fallbackProxy: { scheme: 'http', host: 'proxy.example.com', port: 8080 },
+    } satisfies FixedProfile,
+  };
+}
+
+describe('codegen str() / PAC injection', () => {
+  const names = [
+    'quo"te',
+    'back\\slash',
+    'new\nline',
+    'car\rriage',
+    'tab\there',
+    'café',
+    '名字',
+    'line\u2028sep',
+    'para\u2029sep',
+  ];
+
+  it('emits a JS string literal that round-trips every special character', () => {
+    for (const value of names) {
+      const literal = str(value);
+      expect(literal.startsWith('"') && literal.endsWith('"')).toBe(true);
+      expect(evalStringLiteral(literal)).toBe(value);
+      // PAC is handed to the browser with no declared encoding.
+      expect(/[^\x00-\x7F]/.test(literal)).toBe(false);
+    }
+  });
+
+  it.each(names)(
+    'generates valid PAC for a profile named %j whose match agrees with in-process',
+    (name) => {
+      const options = bagWithNamedProxy(name);
+      const pac = PacGenerator.script(options, 'auto');
+      expect(/[^\x00-\x7F]/.test(pac)).toBe(false);
+
+      const FindProxyForURL = evalPac(pac);
+      const hit = 'http://www.example.com/';
+      const miss = 'http://other.test/';
+      expect(FindProxyForURL(hit, 'www.example.com')).toBe(
+        inProcessPacResult(options, 'auto', hit),
+      );
+      expect(FindProxyForURL(hit, 'www.example.com')).toBe('PROXY proxy.example.com:8080');
+      expect(FindProxyForURL(miss, 'other.test')).toBe(inProcessPacResult(options, 'auto', miss));
+      expect(FindProxyForURL(miss, 'other.test')).toBe('DIRECT');
+    },
+  );
+});

--- a/packages/pac/test/conditions.test.ts
+++ b/packages/pac/test/conditions.test.ts
@@ -86,6 +86,22 @@ describe('Conditions', () => {
         false,
       );
     });
+    it('should fallback to not match if the pattern is a nested-quantifier ReDoS', () => {
+      const started = Date.now();
+      testCond(
+        { conditionType: 'UrlRegexCondition', pattern: '^(a+)+$' },
+        'http://' + 'a'.repeat(31) + 'x/',
+        false,
+      );
+      expect(Date.now() - started).toBeLessThan(100);
+    });
+    it('should fallback to not match if the pattern is over-long', () => {
+      testCond(
+        { conditionType: 'UrlRegexCondition', pattern: 'a'.repeat(3000) },
+        'http://www.example.com/',
+        false,
+      );
+    });
   });
 
   describe('UrlWildcardCondition', () => {
@@ -122,6 +138,20 @@ describe('Conditions', () => {
       testCond(multi, 'http://b.example.net/def', true);
       testCond(multi, 'http://c.example.org/ghi', false);
     });
+    it('should match linearized multi-star wildcards without hanging', () => {
+      const cond: Condition = {
+        conditionType: 'UrlWildcardCondition',
+        pattern: '*foo*bar*',
+      };
+      testCond(cond, 'http://foo.example.com/bar', true);
+      const started = Date.now();
+      testCond(
+        { conditionType: 'UrlWildcardCondition', pattern: '*a*a*a*a*a*b' },
+        'http://' + 'a'.repeat(40) + '/',
+        false,
+      );
+      expect(Date.now() - started).toBeLessThan(100);
+    });
   });
 
   describe('HostRegexCondition', () => {
@@ -137,6 +167,15 @@ describe('Conditions', () => {
     });
     it('should not match URL parts other than the host', () => {
       expect(testCond(cond, 'http://example.net/www.example.com', false)).toBe(false);
+    });
+    it('should fallback to not match if the pattern is a nested-quantifier ReDoS', () => {
+      const started = Date.now();
+      testCond(
+        { conditionType: 'HostRegexCondition', pattern: '^(a+)+$' },
+        'http://' + 'a'.repeat(31) + 'x/',
+        false,
+      );
+      expect(Date.now() - started).toBeLessThan(100);
     });
   });
 

--- a/packages/pac/test/ip.test.ts
+++ b/packages/pac/test/ip.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { formatIp, isInSubnet, netmask, parseIp, subnetSuffix } from '../src/ip.js';
+import { isIp } from '../src/utils.js';
+
+describe('parseIp', () => {
+  it('parses IPv4 with and without a prefix', () => {
+    const plain = parseIp('192.0.2.1');
+    expect(plain).toMatchObject({ v4: true, hasPrefix: false, prefixLength: 32 });
+    expect([...plain!.bytes]).toEqual([192, 0, 2, 1]);
+
+    const cidr = parseIp('192.0.2.0/24');
+    expect(cidr).toMatchObject({ v4: true, hasPrefix: true, prefixLength: 24 });
+    expect([...cidr!.bytes]).toEqual([192, 0, 2, 0]);
+  });
+
+  it('parses IPv6, brackets, zone ids, and embedded v4', () => {
+    const loopback = parseIp('::1');
+    expect(loopback).toMatchObject({ v4: false, hasPrefix: false, prefixLength: 128 });
+    expect(loopback!.bytes[15]).toBe(1);
+    expect(loopback!.bytes.slice(0, 15).every((b) => b === 0)).toBe(true);
+
+    const bracketed = parseIp('[2001:db8::1]/64');
+    expect(bracketed).toMatchObject({ v4: false, hasPrefix: true, prefixLength: 64 });
+    expect(formatIp(bracketed!)).toBe('2001:db8::1');
+
+    const zoned = parseIp('fe80::1%eth0');
+    expect(zoned).not.toBeNull();
+    expect(formatIp(zoned!)).toBe('fe80::1');
+
+    const mapped = parseIp('::ffff:192.0.2.1');
+    expect(mapped).not.toBeNull();
+    expect(formatIp(mapped!)).toBe('::ffff:c000:201');
+  });
+
+  it('rejects hostnames, ports, and illegal prefixes', () => {
+    expect(parseIp('')).toBeNull();
+    expect(parseIp('example.com')).toBeNull();
+    expect(parseIp('256.0.0.1')).toBeNull();
+    expect(parseIp('1.2.3')).toBeNull();
+    expect(parseIp('[::1]:8080')).toBeNull();
+    expect(parseIp('192.0.2.0/33')).toBeNull();
+    expect(parseIp('::1/129')).toBeNull();
+    expect(parseIp('192.0.2.0/')).toBeNull();
+    expect(parseIp('::1:2:3:4:5:6:7:8:9')).toBeNull();
+    // A single leading colon is not a valid IPv6 literal (isIp still says yes).
+    expect(parseIp(':1')).toBeNull();
+  });
+});
+
+describe('formatIp / netmask / isInSubnet', () => {
+  it('canonicalises IPv6 per RFC 5952', () => {
+    expect(formatIp(parseIp('2001:0db8:0000:0000:0000:0000:0000:0001')!)).toBe('2001:db8::1');
+    // Leftmost of two equal-length zero runs wins.
+    expect(formatIp(parseIp('2001:0:0:1:0:0:0:1')!)).toBe('2001:0:0:1::1');
+    expect(formatIp(parseIp('::')!)).toBe('::');
+    expect(formatIp(parseIp('0:0:0:0:0:0:0:0')!)).toBe('::');
+  });
+
+  it('builds a family-matching netmask', () => {
+    const v4 = netmask(parseIp('192.0.2.0/24')!);
+    expect(v4.v4).toBe(true);
+    expect(formatIp(v4)).toBe('255.255.255.0');
+    expect(v4.hasPrefix).toBe(false);
+    expect(subnetSuffix(parseIp('192.0.2.0/24')!)).toBe('/24');
+
+    const v6 = netmask(parseIp('2001:db8::/32')!);
+    expect(v6.v4).toBe(false);
+    expect(formatIp(v6)).toBe('ffff:ffff::');
+  });
+
+  it('tests subnet membership, including IPv6 and mixed families', () => {
+    const net = parseIp('192.0.2.0/24')!;
+    expect(isInSubnet(parseIp('192.0.2.1')!, net)).toBe(true);
+    expect(isInSubnet(parseIp('192.0.2.255')!, net)).toBe(true);
+    expect(isInSubnet(parseIp('192.0.3.1')!, net)).toBe(false);
+
+    const v6net = parseIp('2001:db8::/32')!;
+    expect(isInSubnet(parseIp('2001:db8::1')!, v6net)).toBe(true);
+    expect(isInSubnet(parseIp('2001:db9::1')!, v6net)).toBe(false);
+    expect(isInSubnet(parseIp('192.0.2.1')!, v6net)).toBe(false);
+    expect(isInSubnet(parseIp('::1')!, parseIp('127.0.0.1')!)).toBe(false);
+  });
+});
+
+describe('isIp leading-colon', () => {
+  // Cheap classifier in utils.ts: any colon means "this is an IP", including
+  // the `::1` / `:1` forms that used to be treated as hostnames.
+  it('treats IPv6 literals that begin with a colon as IPs', () => {
+    expect(isIp('::')).toBe(true);
+    expect(isIp('::1')).toBe(true);
+    expect(isIp(':1')).toBe(true);
+    expect(isIp('example.com')).toBe(false);
+  });
+});

--- a/packages/pac/test/rule-list.test.ts
+++ b/packages/pac/test/rule-list.test.ts
@@ -116,6 +116,35 @@ describe('RuleList', () => {
       });
     });
 
+    it('should decode base64 AutoProxy lists', () => {
+      const plain = '[AutoProxy 0.2.9]\n||example.com\n';
+      const encoded = btoa(plain);
+      expect(encoded.startsWith('W0F1dG9Qcm94')).toBe(true);
+      expect(RuleList.AutoProxy.preprocess!(encoded)).toBe(plain);
+      const result = parse(RuleList.AutoProxy.preprocess!(encoded), 'match', 'notmatch');
+      expect(result).toHaveLength(1);
+      expect(result[0]!.condition).toEqual({
+        conditionType: 'HostWildcardCondition',
+        pattern: '*.example.com',
+      });
+    });
+
+    it('should decode base64 AutoProxy lists that contain whitespace', () => {
+      const plain = '[AutoProxy 0.2.9]\n||example.com\n';
+      const encoded = btoa(plain);
+      const wrapped = encoded.slice(0, 16) + '\n' + encoded.slice(16);
+      expect(wrapped.startsWith('W0F1dG9Qcm94')).toBe(true);
+      expect(RuleList.AutoProxy.preprocess!(wrapped)).toBe(plain);
+    });
+
+    it('should not throw on malformed base64 AutoProxy lists', () => {
+      const malformed = 'W0F1dG9Qcm94!!!';
+      expect(RuleList.AutoProxy.detect!(malformed)).toBe(true);
+      expect(() => RuleList.AutoProxy.preprocess!(malformed)).not.toThrow();
+      expect(RuleList.AutoProxy.preprocess!(malformed)).toBe(malformed);
+      expect(() => parse(RuleList.AutoProxy.preprocess!(malformed), 'match', 'notmatch')).not.toThrow();
+    });
+
     it('should put exclusive rules first', () => {
       const result = parse('example.com\n@@||example.com', 'match', 'notmatch');
       expect(result).toHaveLength(2);

--- a/packages/pac/test/shexp.test.ts
+++ b/packages/pac/test/shexp.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { shExp2RegExp, escapeSlash } from '../src/shexp.js';
+import {
+  shExp2RegExp,
+  escapeSlash,
+  safeRegExp,
+  MAX_REGEXP_SOURCE_LENGTH,
+  MAX_SHEXP_LENGTH,
+} from '../src/shexp.js';
 
 describe('ShexpUtils', () => {
   describe('#escapeSlash', () => {
@@ -20,6 +26,59 @@ describe('ShexpUtils', () => {
     it('should escape regex meta chars and back slashes', () => {
       const regex = shExp2RegExp('this.is|a\\test+');
       expect(regex).toBe('^this\\.is\\|a\\\\test\\+$');
+    });
+    it('should linearize interior stars so they do not backtrack', () => {
+      expect(shExp2RegExp('foo*bar')).toBe('^foo(?:(?!bar).)*bar$');
+      expect(shExp2RegExp('*foo*bar*', { trimAsterisk: true })).toBe('foo(?:(?!bar).)*bar');
+    });
+    it('should keep trailing stars as .* so host-wildcard stripping still works', () => {
+      expect(shExp2RegExp('foo*')).toBe('^foo.*$');
+    });
+    it('should reject over-long wildcard patterns', () => {
+      expect(shExp2RegExp('a'.repeat(MAX_SHEXP_LENGTH + 1))).toBe('^(?!)');
+      expect(shExp2RegExp('a'.repeat(MAX_SHEXP_LENGTH + 1), { trimAsterisk: true })).toBe('(?!)');
+    });
+  });
+  describe('#safeRegExp', () => {
+    it('should compile a valid pattern', () => {
+      const re = safeRegExp('example\\.com');
+      expect(re.test('www.example.com')).toBe(true);
+      expect(re.test('www.example.net')).toBe(false);
+    });
+    it('should fallback to never-match if the pattern is invalid', () => {
+      expect(safeRegExp(')Invalid(').source).toBe('(?!)');
+      expect(safeRegExp(')Invalid(').test('anything')).toBe(false);
+    });
+    it('should reject over-long patterns', () => {
+      const re = safeRegExp('a'.repeat(MAX_REGEXP_SOURCE_LENGTH + 1));
+      expect(re.source).toBe('(?!)');
+      expect(re.test('a')).toBe(false);
+    });
+    it('should reject nested unbounded quantifiers', () => {
+      expect(safeRegExp('^(a+)+$').source).toBe('(?!)');
+      expect(safeRegExp('(a*)*').source).toBe('(?!)');
+      expect(safeRegExp('(.+)+').source).toBe('(?!)');
+      expect(safeRegExp('((a)+)+').source).toBe('(?!)');
+    });
+    it('should reject quantified overlapping or empty alternatives', () => {
+      expect(safeRegExp('(a|ab)+').source).toBe('(?!)');
+      expect(safeRegExp('(a|)*').source).toBe('(?!)');
+    });
+    it('should still compile bounded groups and non-overlapping alts', () => {
+      expect(safeRegExp('(abc)+').test('abcabc')).toBe(true);
+      expect(safeRegExp('(a|b)+').test('abab')).toBe(true);
+      expect(safeRegExp('(a+)')).not.toHaveProperty('source', '(?!)');
+    });
+    it('should not hang on a classic nested-quantifier ReDoS pattern', () => {
+      const started = Date.now();
+      expect(safeRegExp('^(a+)+$').test('a'.repeat(31) + 'x')).toBe(false);
+      expect(Date.now() - started).toBeLessThan(100);
+    });
+    it('should not hang on a multi-star wildcard translation', () => {
+      const source = shExp2RegExp('*a*a*a*a*a*b', { trimAsterisk: true });
+      const started = Date.now();
+      expect(safeRegExp(source).test('a'.repeat(40))).toBe(false);
+      expect(Date.now() - started).toBeLessThan(100);
     });
   });
 });

--- a/packages/pac/test/utils.test.ts
+++ b/packages/pac/test/utils.test.ts
@@ -2,6 +2,27 @@ import { describe, it, expect } from 'vitest';
 // getBaseDomain moved from utils.js to the psl.js entry point in the port
 // (kept separate because the public-suffix list is a large data table).
 import { getBaseDomain } from '../src/psl.js';
+import { isIp } from '../src/utils.js';
+
+describe('isIp', () => {
+  it('should treat IPv6 literals beginning with a colon as IPs', () => {
+    expect(isIp('::')).toBe(true);
+    expect(isIp('::1')).toBe(true);
+    expect(isIp('::f')).toBe(true);
+    expect(isIp(':1')).toBe(true);
+  });
+  it('should treat IPv6 literals with an interior colon as IPs', () => {
+    expect(isIp('fe80::')).toBe(true);
+    expect(isIp('fe80::1')).toBe(true);
+  });
+  it('should treat a trailing digit as IPv4', () => {
+    expect(isIp('127.0.0.1')).toBe(true);
+  });
+  it('should not treat ordinary hostnames as IPs', () => {
+    expect(isIp('example.com')).toBe(false);
+    expect(isIp('localhost')).toBe(false);
+  });
+});
 
 describe('getBaseDomain', () => {
   it('should return domains with zero level unchanged', () => {

--- a/packages/target/src/browser-storage.ts
+++ b/packages/target/src/browser-storage.ts
@@ -9,7 +9,7 @@
  *     new BrowserStorage(localStorage, 'delta.local.')  // legacy pages / tests
  */
 
-import { Storage } from './storage.js';
+import { parseStorageErrors, Storage } from './storage.js';
 import type { StorageItems } from './storage.js';
 
 /** The subset of the `Storage` DOM interface the legacy path relies on. */
@@ -39,10 +39,10 @@ async function chromeCall<T>(operation: () => Promise<T>): Promise<T> {
   try {
     result = await operation();
   } catch (e) {
-    throw e instanceof Error ? e : new Error(String(e));
+    return parseStorageErrors(e instanceof Error ? e : new Error(String(e)));
   }
   const message = lastErrorMessage();
-  if (message) throw new Error(message);
+  if (message) return parseStorageErrors(new Error(message));
   return result;
 }
 

--- a/packages/target/src/errors.ts
+++ b/packages/target/src/errors.ts
@@ -51,3 +51,16 @@ export class ProfileNotExistError extends Error {
 export class NoOptionsError extends Error {
   override readonly name: string = 'NoOptionsError';
 }
+
+/** Stored options use a schemaVersion newer than this build understands. */
+export class SchemaTooNewError extends Error {
+  override readonly name: string = 'SchemaTooNewError';
+  readonly schemaVersion: number;
+  readonly options: Record<string, unknown>;
+
+  constructor(schemaVersion: number, options: Record<string, unknown>) {
+    super(`Options schemaVersion ${schemaVersion} is newer than this build supports.`);
+    this.schemaVersion = schemaVersion;
+    this.options = options;
+  }
+}

--- a/packages/target/src/index.ts
+++ b/packages/target/src/index.ts
@@ -13,6 +13,7 @@ export {
   RateLimitExceededError,
   QuotaExceededError,
   StorageUnavailableError,
+  parseStorageErrors,
 } from './storage.js';
 export type {
   StorageItems,
@@ -40,4 +41,5 @@ export {
   ContentTypeRejectedError,
   ProfileNotExistError,
   NoOptionsError,
+  SchemaTooNewError,
 } from './errors.js';

--- a/packages/target/src/options-sync.ts
+++ b/packages/target/src/options-sync.ts
@@ -29,6 +29,114 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
+const KNOWN_PROFILE_TYPES = new Set([
+  'DirectProfile',
+  'SystemProfile',
+  'FixedProfile',
+  'PacProfile',
+  'AutoDetectProfile',
+  'SwitchProfile',
+  'VirtualProfile',
+  'RuleListProfile',
+  'SwitchyRuleListProfile',
+  'AutoProxyRuleListProfile',
+]);
+
+const BOOLEAN_SETTING_KEYS = new Set([
+  '-enableQuickSwitch',
+  '-refreshOnProfileChange',
+  '-revertProxyChanges',
+  '-confirmDeletion',
+  '-showInspectMenu',
+  '-addConditionsToBottom',
+  '-showExternalProfile',
+  '-monitorWebRequests',
+]);
+
+const NUMBER_SETTING_KEYS = new Set(['-downloadInterval']);
+const STRING_SETTING_KEYS = new Set(['-startupProfileName']);
+const ARRAY_SETTING_KEYS = new Set(['-quickSwitchProfiles']);
+
+function isJsonValue(value: unknown): boolean {
+  if (value === null) return true;
+  const t = typeof value;
+  if (t === 'boolean' || t === 'string') return true;
+  if (t === 'number') return Number.isFinite(value);
+  if (t !== 'object') return false;
+  if (Array.isArray(value)) return value.every(isJsonValue);
+  const proto = Object.getPrototypeOf(value);
+  if (proto !== Object.prototype && proto !== null) return false;
+  return Object.values(value as Record<string, unknown>).every(isJsonValue);
+}
+
+function isValidSyncProfile(value: unknown): boolean {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const profile = value as Record<string, unknown>;
+  if (typeof profile['name'] !== 'string' || profile['name'].length === 0) return false;
+  const profileType = profile['profileType'];
+  if (typeof profileType !== 'string' || !KNOWN_PROFILE_TYPES.has(profileType)) return false;
+  if ('rules' in profile && profile['rules'] != null) {
+    if (!Array.isArray(profile['rules'])) return false;
+    for (const rule of profile['rules']) {
+      if (rule == null || typeof rule !== 'object' || Array.isArray(rule)) return false;
+      const condition = (rule as { condition?: unknown }).condition;
+      if (condition != null) {
+        if (typeof condition !== 'object' || Array.isArray(condition)) return false;
+        if (typeof (condition as { conditionType?: unknown }).conditionType !== 'string') {
+          return false;
+        }
+      }
+    }
+  } else if (profileType === 'SwitchProfile' || profileType === 'VirtualProfile') {
+    return false;
+  }
+  if (
+    (profileType === 'SwitchProfile' || profileType === 'VirtualProfile') &&
+    typeof profile['defaultProfileName'] !== 'string'
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function isValidSettingValue(key: string, value: unknown): boolean {
+  if (typeof value === 'undefined') return true;
+  if (BOOLEAN_SETTING_KEYS.has(key)) return typeof value === 'boolean';
+  if (NUMBER_SETTING_KEYS.has(key)) return typeof value === 'number' && Number.isFinite(value);
+  if (STRING_SETTING_KEYS.has(key)) return typeof value === 'string';
+  if (ARRAY_SETTING_KEYS.has(key)) return Array.isArray(value) && value.every(isJsonValue);
+  return isJsonValue(value);
+}
+
+/**
+ * Drop remote values whose `+profile` / `-key` shape would crash the options
+ * controller (primitives under `+`, missing name/profileType, non-array
+ * `rules`, unknown conditionType). Invalid keys are omitted so the local
+ * copy is left as-is rather than deleted.
+ */
+export function sanitizeSyncItems(items: StorageItems): StorageItems {
+  const out: StorageItems = {};
+  for (const [key, value] of Object.entries(items)) {
+    const prefix = key.charCodeAt(0);
+    if (prefix === 43 /* + */) {
+      if (key.length < 2) continue;
+      if (typeof value === 'undefined' || isValidSyncProfile(value)) out[key] = value;
+      continue;
+    }
+    if (prefix === 45 /* - */) {
+      if (key.length < 2) continue;
+      if (isValidSettingValue(key, value)) out[key] = value;
+      continue;
+    }
+    if (key === 'schemaVersion') {
+      if (typeof value === 'number' || typeof value === 'undefined') out[key] = value;
+      continue;
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
 /**
  * Structural equality, used only as an "is this write a no-op?" test.
  *
@@ -269,7 +377,11 @@ export class OptionsSync {
     // always false, so that pass never ran. It is left out rather than
     // "repaired": enabling it now would start deleting local profiles that were
     // simply never uploaded.
-    const operations = await local.apply({ changes, base, merge: this.merge });
+    const operations = await local.apply({
+      changes: sanitizeSyncItems(changes),
+      base,
+      merge: this.merge,
+    });
     this._logOperations('OptionsSync::copyTo', operations);
   }
 
@@ -288,7 +400,10 @@ export class OptionsSync {
       const changes = pull;
       pull = {};
       pullScheduled = null;
-      const operations = Storage.operationsForChanges(changes, { base, merge: this.merge });
+      const operations = Storage.operationsForChanges(sanitizeSyncItems(changes), {
+        base,
+        merge: this.merge,
+      });
       this._logOperations('OptionsSync::pull', operations);
       await local.apply(operations);
     };

--- a/packages/target/src/options.ts
+++ b/packages/target/src/options.ts
@@ -23,7 +23,7 @@ import type {
 import { patch as applyJsonPatch } from 'jsondiffpatch';
 import type { Delta } from 'jsondiffpatch';
 
-import { NoOptionsError, ProfileNotExistError } from './errors.js';
+import { NoOptionsError, ProfileNotExistError, SchemaTooNewError } from './errors.js';
 import { Log } from './log.js';
 import type { Logger } from './log.js';
 import { Storage, StorageUnavailableError } from './storage.js';
@@ -33,6 +33,35 @@ import getDefaultOptions from './default-options.js';
 
 /** The persisted options bag, keyed by `+profileName` and `-settingName`. */
 export type DeltaOptions = OptionsBag;
+
+const CURRENT_SCHEMA_VERSION = 2;
+
+function isUsableProfile(value: unknown): value is Profile {
+  if (value == null || typeof value !== 'object') return false;
+  const profile = value as Partial<Profile>;
+  return typeof profile.name === 'string' && typeof profile.profileType === 'string';
+}
+
+function safeIsIncludable(profile: Profile): boolean {
+  try {
+    return Profiles.isIncludable(profile);
+  } catch {
+    return false;
+  }
+}
+
+function safeIsInclusive(profile: Profile): boolean {
+  try {
+    return Profiles.isInclusive(profile);
+  } catch {
+    return false;
+  }
+}
+
+function isCorruptOptionsError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return error.message === 'Invalid options!' || error.message.startsWith('Invalid schemaVerion');
+}
 
 /** The platform hook that actually programs the browser's proxy settings. */
 export interface ProxyImpl {
@@ -136,18 +165,26 @@ export class Options {
    * URL, and they are large enough to blow the per-item sync quota.
    */
   static transformValueForSync(value: unknown, key: string): unknown {
-    if (key[0] === '+') {
-      const profile = value as Profile | undefined;
-      if (profile && Profiles.updateUrl(profile)) {
-        const stripped: Record<string, unknown> = {};
-        for (const [k, v] of Object.entries(profile as unknown as Record<string, unknown>)) {
-          if (k === 'lastUpdate' || k === 'ruleList' || k === 'pacScript') continue;
-          stripped[k] = v;
-        }
-        return stripped;
+    if (key[0] !== '+') return value;
+    if (value == null || typeof value !== 'object') return value;
+    const profile = value as Record<string, unknown>;
+    let stripDownload = false;
+    if (isUsableProfile(value)) {
+      try {
+        stripDownload = !!Profiles.updateUrl(value);
+      } catch {
+        stripDownload = false;
       }
     }
-    return value;
+    const stripAuth = Object.prototype.hasOwnProperty.call(profile, 'auth');
+    if (!stripDownload && !stripAuth) return value;
+    const stripped: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(profile)) {
+      if (k === 'auth') continue;
+      if (stripDownload && (k === 'lastUpdate' || k === 'ruleList' || k === 'pacScript')) continue;
+      stripped[k] = v;
+    }
+    return stripped;
   }
 
   constructor(
@@ -232,8 +269,11 @@ export class Options {
   /**
    * Attempt to load options from local and remote storage.
    *
-   * On failure this wipes local storage, installs a fallback set of options
-   * (from sync storage if it looks usable, otherwise the defaults) and retries.
+   * First-run (`NoOptionsError`) and genuine corruption (unparseable options
+   * or an unrecognised old schemaVersion) still wipe local storage and
+   * install a fallback. Transport errors retry without touching stored
+   * data. A schemaVersion newer than this build is backed up to state and
+   * left in place — it is never overwritten with defaults.
    */
   loadOptions(args: { retry?: number } = {}): Promise<DeltaOptions> {
     const retry = args.retry ?? 3;
@@ -271,6 +311,16 @@ export class Options {
         return options;
       })
       .catch(async (e: unknown): Promise<DeltaOptions> => {
+        if (e instanceof SchemaTooNewError) {
+          this.log.error(e.stack);
+          try {
+            await this._state.set({ optionsSchemaBackup: e.options });
+          } catch (backupError) {
+            this.log.error(backupError);
+          }
+          throw e;
+        }
+
         if (!(retry > 0)) throw e;
 
         let fallbackOptions: DeltaOptions | null | undefined = null;
@@ -298,12 +348,14 @@ export class Options {
               }
             }
           }
-        } else {
+        } else if (isCorruptOptionsError(e)) {
           this.log.error((e as Error | undefined)?.stack);
-          // Some serious error happened when loading options. Disable syncing
-          // and use fallback options.
           void this._state.remove(['syncOptions']);
           fallbackOptions = null;
+        } else {
+          // Storage transport / transient read failure: retry without wiping.
+          this.log.error((e as Error | undefined)?.stack);
+          return this.loadOptions({ retry: retry - 1 });
         }
 
         const options = fallbackOptions ?? this.parseOptions(this.getDefaultOptions());
@@ -406,9 +458,12 @@ export class Options {
       pending['schemaVersion'] = 2;
       opts['schemaVersion'] = 2;
     }
-    if (version === 2) {
+    if (version === CURRENT_SCHEMA_VERSION) {
       // Current schemaVersion.
       return [options as DeltaOptions, pending];
+    }
+    if (typeof version === 'number' && version > CURRENT_SCHEMA_VERSION) {
+      throw new SchemaTooNewError(version, (options ?? {}) as DeltaOptions);
     }
     throw new Error(`Invalid schemaVerion ${String(version)}!`);
   }
@@ -547,7 +602,9 @@ export class Options {
         void this.applyProfile(this.fallbackProfileName);
         break;
       case 'changed':
-        void this.applyProfile(this._currentProfileName, { update: false });
+        if (this._currentProfileName) {
+          void this.applyProfile(this._currentProfileName, { update: false });
+        }
         break;
       default:
         if (profilesChanged) this._setAvailableProfiles();
@@ -707,15 +764,17 @@ export class Options {
 
   /** Publish the profile list (and valid switch targets) to the UI. */
   protected _setAvailableProfiles(): void {
-    const profile = this._currentProfileName ? this.currentProfile() : null;
+    const raw = this._currentProfileName ? this.currentProfile() : null;
+    const profile = isUsableProfile(raw) ? raw : null;
     const profiles: Record<string, AvailableProfile> = {};
-    const currentIncludable = !!profile && Profiles.isIncludable(profile);
+    const currentIncludable = !!profile && safeIsIncludable(profile);
     let allReferenceSet: Record<string, string> | null = null;
     let results: string[] | undefined;
-    if (!profile || !Profiles.isInclusive(profile)) {
+    if (!profile || !safeIsInclusive(profile)) {
       results = [];
     }
     Profiles.each(this._options, (key, p) => {
+      if (!isUsableProfile(p)) return;
       const entry: AvailableProfile = {
         name: p.name,
         profileType: p.profileType,
@@ -732,17 +791,26 @@ export class Options {
             })
           : {};
         if (allReferenceSet[key]) {
-          entry.validResultProfiles = Profiles.validResultProfilesFor(p, this._options).map(
-            (result) => result.name,
-          );
+          try {
+            entry.validResultProfiles = Profiles.validResultProfilesFor(p, this._options).map(
+              (result) => result.name,
+            );
+          } catch {
+            // Malformed virtual profile: skip the derived list rather than
+            // throwing from handlerFor(null) / a missing rules array.
+          }
         }
       }
-      if (currentIncludable && Profiles.isIncludable(p)) {
+      if (currentIncludable && safeIsIncludable(p)) {
         results?.push(p.name);
       }
     });
-    if (profile && Profiles.isInclusive(profile)) {
-      results = Profiles.validResultProfilesFor(profile, this._options).map((p) => p.name);
+    if (profile && safeIsInclusive(profile)) {
+      try {
+        results = Profiles.validResultProfilesFor(profile, this._options).map((p) => p.name);
+      } catch {
+        results = [];
+      }
     }
     void this._state.set({
       availableProfiles: profiles,
@@ -921,12 +989,19 @@ export class Options {
           // by fetchUrl already, so empty data means success without any
           // update (e.g. a 304).
           if (!data) return profile;
-          const current = Profiles.byKey(key, this._options)!;
-          (current as Profile & { lastUpdate?: string }).lastUpdate = new Date().toISOString();
-          if (Profiles.update(current, data)) {
-            Profiles.dropCache(current);
-            await this._setOptions({ [key]: current });
+          const current = Profiles.byKey(key, this._options);
+          if (!current) return profile;
+          // A concurrent edit bumped the revision while we were fetching.
+          if (Revision.compare(current.revision, profile.revision) !== 0) {
             return current;
+          }
+          const next = { ...current } as Profile;
+          (next as Profile & { lastUpdate?: string }).lastUpdate = new Date().toISOString();
+          if (Profiles.update(next, data)) {
+            Profiles.updateRevision(next);
+            Profiles.dropCache(next);
+            await this._setOptions({ [key]: next }, { checkRevision: true });
+            return (Profiles.byKey(key, this._options) as Profile | undefined) ?? next;
           }
           return current;
         })
@@ -1065,8 +1140,11 @@ export class Options {
       return Promise.reject(new ProfileNotExistError(profileName));
     }
     if (this._tempProfile == null) {
+      const currentProfile = this._currentProfileName
+        ? Profiles.byName(this._currentProfileName, this._options)
+        : undefined;
+      if (!currentProfile) return Promise.resolve();
       const created = Profiles.create('', 'SwitchProfile') as SwitchProfile;
-      const currentProfile = this.currentProfile() as Profile;
       created.color = currentProfile.color;
       created.defaultProfileName = currentProfile.name;
       this._tempProfile = created;
@@ -1241,9 +1319,19 @@ export class Options {
       ? (this._tempProfile as SwitchProfile)
       : Profiles.byName(this._currentProfileName, this._options);
     let lastProfile: Profile | undefined;
+    const visited = new Set<string>();
     while (profile) {
+      if (!isUsableProfile(profile)) break;
+      const key = Profiles.nameAsKey(profile);
+      if (visited.has(key)) break;
+      visited.add(key);
       lastProfile = profile;
-      const result = Profiles.match(profile, request);
+      let result: MatchResult;
+      try {
+        result = Profiles.match(profile, request);
+      } catch {
+        break;
+      }
       if (result == null) break;
       results.push(result);
       let next: string | undefined;
@@ -1306,6 +1394,8 @@ export class Options {
       }
     } else {
       this._currentProfileName = null;
+      this._watchingProfiles = {};
+      this._tempProfileActive = false;
       this._externalProfile = profile;
       profile.color ??= '#49afcd';
       void this._state.set({

--- a/packages/target/src/storage.ts
+++ b/packages/target/src/storage.ts
@@ -25,6 +25,60 @@ export class StorageUnavailableError extends Error {
   override readonly name: string = 'StorageUnavailableError';
 }
 
+const SUSTAINED_PER_MINUTE = 'MAX_SUSTAINED_WRITE_OPERATIONS_PER_MINUTE';
+
+/**
+ * Translate a `chrome.runtime.lastError` (or equivalent) message into one of
+ * the typed storage errors, so callers can react to a quota or rate limit
+ * without matching on English prose.
+ *
+ * Shared by {@link BrowserStorage} and the extension's `ChromeStorage`.
+ */
+export function parseStorageErrors(err: unknown): Promise<never> {
+  const message = (err as { message?: unknown } | null | undefined)?.message;
+  if (typeof message !== 'string') return Promise.reject(err);
+
+  if (message.indexOf('QUOTA_BYTES_PER_ITEM') >= 0) {
+    const error = new QuotaExceededError(message);
+    error.perItem = true;
+    return Promise.reject(error);
+  }
+  if (message.indexOf('QUOTA_BYTES') >= 0) {
+    return Promise.reject(new QuotaExceededError(message));
+  }
+  if (message.indexOf('MAX_ITEMS') >= 0) {
+    const error = new QuotaExceededError(message);
+    error.maxItems = true;
+    return Promise.reject(error);
+  }
+  if (message.indexOf('MAX_WRITE_OPERATIONS_') >= 0) {
+    const error = new RateLimitExceededError(message);
+    // Test the original message, not the freshly constructed error (whose
+    // message would be empty if we had used the no-arg constructor).
+    if (message.indexOf('MAX_WRITE_OPERATIONS_PER_HOUR') >= 0) {
+      error.perHour = true;
+    } else if (message.indexOf('MAX_WRITE_OPERATIONS_PER_MINUTE') >= 0) {
+      error.perMinute = true;
+    }
+    return Promise.reject(error);
+  }
+  if (message.indexOf(SUSTAINED_PER_MINUTE) >= 0) {
+    const error = new RateLimitExceededError(message);
+    error.perMinute = true;
+    error.sustained = true;
+    return Promise.reject(error);
+  }
+  if (message.indexOf('is not available') >= 0) {
+    // Some Chromium-based browsers disable access to the sync storage.
+    return Promise.reject(new StorageUnavailableError(message));
+  }
+  if (message.indexOf('Please set webextensions.storage.sync.enabled to true') >= 0) {
+    // Sync storage disabled in flags.
+    return Promise.reject(new StorageUnavailableError(message));
+  }
+  return Promise.reject(err);
+}
+
 export type StorageItems = Record<string, unknown>;
 
 /** A set of writes to perform against a storage. */
@@ -49,6 +103,7 @@ export class Storage {
   static readonly RateLimitExceededError = RateLimitExceededError;
   static readonly QuotaExceededError = QuotaExceededError;
   static readonly StorageUnavailableError = StorageUnavailableError;
+  static readonly parseStorageErrors = parseStorageErrors;
 
   protected _items: StorageItems | undefined;
 

--- a/packages/target/test/browser-storage.test.ts
+++ b/packages/target/test/browser-storage.test.ts
@@ -1,0 +1,122 @@
+/**
+ * BrowserStorage chrome.storage path: prefixing, defaults, lastError
+ * translation, and "clear only our prefix".
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { BrowserStorage } from '../src/browser-storage.js';
+import { QuotaExceededError, RateLimitExceededError } from '../src/storage.js';
+
+interface AreaMock {
+  data: Record<string, unknown>;
+  get: ReturnType<typeof vi.fn>;
+  set: ReturnType<typeof vi.fn>;
+  remove: ReturnType<typeof vi.fn>;
+}
+
+function mockArea(initial: Record<string, unknown> = {}): AreaMock {
+  const data = { ...initial };
+  return {
+    data,
+    get: vi.fn(async (keys: string | string[] | null) => {
+      if (keys == null) return { ...data };
+      const list = typeof keys === 'string' ? [keys] : keys;
+      const out: Record<string, unknown> = {};
+      for (const key of list) {
+        if (key in data) out[key] = data[key];
+      }
+      return out;
+    }),
+    set: vi.fn(async (items: Record<string, unknown>) => {
+      Object.assign(data, items);
+    }),
+    remove: vi.fn(async (keys: string | string[]) => {
+      for (const key of Array.isArray(keys) ? keys : [keys]) delete data[key];
+    }),
+  };
+}
+
+function installChrome(area: AreaMock, areaName = 'local', lastError?: { message: string }): void {
+  vi.stubGlobal('chrome', {
+    runtime: { lastError },
+    storage: { [areaName]: area },
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('BrowserStorage chrome path', () => {
+  it('prefixes keys on set / get / remove', async () => {
+    const area = mockArea();
+    installChrome(area);
+    const storage = new BrowserStorage('delta.local.');
+
+    await storage.set({ a: 1, skip: undefined });
+    expect(area.set).toHaveBeenCalledWith({ 'delta.local.a': 1 });
+    expect(area.data).toEqual({ 'delta.local.a': 1 });
+
+    expect(await storage.get('a')).toEqual({ a: 1 });
+    expect(await storage.get(['a', 'missing'])).toEqual({ a: 1 });
+    expect(await storage.get({ a: 0, missing: 'fallback' })).toEqual({
+      a: 1,
+      missing: 'fallback',
+    });
+
+    await storage.remove('a');
+    expect(area.remove).toHaveBeenCalledWith('delta.local.a');
+  });
+
+  it('get(null) and remove(null) only touch the prefixed slice', async () => {
+    const area = mockArea({
+      'delta.local.keep': 1,
+      'delta.local.drop': 2,
+      'other.x': 3,
+    });
+    installChrome(area);
+    const storage = new BrowserStorage('delta.local.');
+
+    expect(await storage.get(null)).toEqual({ keep: 1, drop: 2 });
+
+    await storage.remove();
+    expect(area.remove).toHaveBeenCalledWith(['delta.local.keep', 'delta.local.drop']);
+    expect(area.data).toEqual({ 'other.x': 3 });
+  });
+
+  it('uses the named chrome.storage area', async () => {
+    const area = mockArea();
+    installChrome(area, 'sync');
+    const storage = new BrowserStorage('delta.sync.', 'sync');
+    await storage.set({ n: 1 });
+    expect(area.set).toHaveBeenCalledWith({ 'delta.sync.n': 1 });
+    expect(await storage.get('n')).toEqual({ n: 1 });
+  });
+
+  it('returns empty when chrome.storage is absent', async () => {
+    vi.stubGlobal('chrome', { runtime: {} });
+    const storage = new BrowserStorage('delta.local.');
+    expect(await storage.get(null)).toEqual({});
+    expect(await storage.set({ a: 1 })).toEqual({ a: 1 });
+    await storage.remove('a');
+  });
+
+  it('translates a thrown chrome error via parseStorageErrors', async () => {
+    const area = mockArea();
+    area.set.mockRejectedValue(new Error('MAX_WRITE_OPERATIONS_PER_MINUTE'));
+    installChrome(area);
+    const storage = new BrowserStorage('delta.local.');
+    await expect(storage.set({ a: 1 })).rejects.toMatchObject({
+      name: 'RateLimitExceededError',
+      perMinute: true,
+    });
+    expect(RateLimitExceededError).toBeTruthy();
+  });
+
+  it('translates runtime.lastError after a resolved chrome call', async () => {
+    const area = mockArea();
+    installChrome(area, 'local', { message: 'QUOTA_BYTES_PER_ITEM' });
+    const storage = new BrowserStorage('delta.local.');
+    await expect(storage.set({ a: 1 })).rejects.toBeInstanceOf(QuotaExceededError);
+  });
+});

--- a/packages/target/test/options-sync.test.ts
+++ b/packages/target/test/options-sync.test.ts
@@ -7,9 +7,9 @@
  * deliberately changed (the token bucket starting full, `copyTo`'s deletion
  * pass staying dead) during the port, so regressions are caught.
  */
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { OptionsSync } from '../src/options-sync.js';
-import { QuotaExceededError, Storage } from '../src/storage.js';
+import { QuotaExceededError, RateLimitExceededError, Storage } from '../src/storage.js';
 import type { StorageItems, Unwatch, WatchCallback } from '../src/storage.js';
 import { TokenBucket } from '../src/token-bucket.js';
 import { BrowserStorage } from '../src/browser-storage.js';
@@ -19,6 +19,11 @@ beforeAll(() => {
   // Silence storage and sync logging.
   vi.spyOn(Log, 'log').mockImplementation(() => undefined);
   vi.spyOn(Log, 'error').mockImplementation(() => undefined);
+});
+
+beforeEach(() => {
+  vi.mocked(Log.log).mockClear();
+  vi.mocked(Log.error).mockClear();
 });
 
 afterAll(() => {
@@ -189,6 +194,39 @@ describe('OptionsSync', () => {
       expect(setSpy).toHaveBeenCalledWith({ a: 1, b: 1 });
     });
 
+    it('should retry after RateLimitExceededError by draining the bucket', async () => {
+      const storage = new Storage();
+      let failNext = true;
+      const setSpy = vi.spyOn(storage, 'set').mockImplementation(async function (
+        this: Storage,
+        items,
+      ) {
+        if (failNext) {
+          failNext = false;
+          const err = new RateLimitExceededError('MAX_WRITE_OPERATIONS_PER_MINUTE');
+          err.perMinute = true;
+          throw err;
+        }
+        return Storage.prototype.set.call(this, items);
+      });
+
+      // Fast refill after clear() so the retry does not wait a full second.
+      const bucket = new TokenBucket(10, 10, 20);
+      const clearSpy = vi.spyOn(bucket, 'clear');
+      const sync = new OptionsSync(storage, bucket);
+      sync.debounce = 0;
+      sync.requestPush({ a: 1 });
+
+      await vi.waitFor(() => {
+        expect(Log.log).toHaveBeenCalledWith('OptionsSync::rateLimitExceeded');
+      });
+      expect(clearSpy).toHaveBeenCalled();
+      await vi.waitFor(() => {
+        expect(setSpy).toHaveBeenCalledTimes(2);
+      });
+      expect(await storage.get('a')).toEqual({ a: 1 });
+    });
+
     it('should write immediately because the token bucket starts full', async () => {
       // Deliberate deviation from the CoffeeScript version (see MIGRATION.md):
       // `limiter`'s bucket started empty, costing 6 s before the first sync
@@ -246,6 +284,37 @@ describe('OptionsSync', () => {
       expect(removeSpy).toHaveBeenCalledWith(['d']);
     });
 
+    it('should drop malformed +profile and -key values before applying', async () => {
+      const remote = new Storage();
+      await remote.set({
+        '+good': {
+          name: 'good',
+          profileType: 'FixedProfile',
+          color: 'blue',
+        },
+        '+bad': 'not-a-profile',
+        '+broken': { name: 'broken' },
+        '+cycleA': {
+          name: 'cycleA',
+          profileType: 'SwitchProfile',
+          defaultProfileName: 'cycleB',
+          rules: 'not-an-array',
+        },
+        '-downloadInterval': 15,
+        '-quickSwitchProfiles': 'not-an-array',
+        '-enableQuickSwitch': 'yes',
+      });
+
+      const local = new Storage();
+      const sync = new OptionsSync(remote);
+      await sync.copyTo(local);
+
+      expect(await local.get(null)).toEqual({
+        '+good': { name: 'good', profileType: 'FixedProfile', color: 'blue' },
+        '-downloadInterval': 15,
+      });
+    });
+
     it('should leave local-only profiles alone', async () => {
       // The CoffeeScript copyTo had a pass meant to delete local profiles that
       // are gone upstream, dead behind an always-false guard
@@ -255,7 +324,9 @@ describe('OptionsSync', () => {
       // install. This pins the no-op; do not "fix" it here without that
       // decision being made.
       const remote = new Storage();
-      await remote.set({ '+synced': { color: 'blue' } });
+      await remote.set({
+        '+synced': { name: 'synced', profileType: 'FixedProfile', color: 'blue' },
+      });
 
       const local = new Storage();
       await local.set({ '+localOnly': { color: 'red' } });
@@ -265,7 +336,7 @@ describe('OptionsSync', () => {
       await sync.copyTo(local);
 
       expect(await local.get(null)).toEqual({
-        '+synced': { color: 'blue' },
+        '+synced': { name: 'synced', profileType: 'FixedProfile', color: 'blue' },
         '+localOnly': { color: 'red' },
       });
       expect(removeSpy).not.toHaveBeenCalledWith(['+localOnly']);
@@ -357,5 +428,52 @@ describe('BrowserStorage#_legacyGet', () => {
     const bare = await storage.get(['good', 'bad']);
     expect(bare['good']).toEqual({ is: 'good' });
     expect('bad' in bare).toBe(false);
+  });
+});
+
+describe('BrowserStorage chrome.storage error translation', () => {
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('should hit the rate-limit retry path on MAX_WRITE_OPERATIONS_PER_MINUTE', async () => {
+    const data: Record<string, unknown> = {};
+    let failNext = true;
+    let setCalls = 0;
+    const area = {
+      async get(): Promise<Record<string, unknown>> {
+        return { ...data };
+      },
+      async set(items: Record<string, unknown>): Promise<void> {
+        setCalls += 1;
+        if (failNext) {
+          failNext = false;
+          throw new Error('MAX_WRITE_OPERATIONS_PER_MINUTE');
+        }
+        Object.assign(data, items);
+      },
+      async remove(): Promise<void> {
+        return undefined;
+      },
+    };
+    vi.stubGlobal('chrome', {
+      runtime: { lastError: undefined },
+      storage: { sync: area },
+    });
+
+    const storage = new BrowserStorage('delta.sync.', 'sync');
+    const sync = new OptionsSync(storage, unlimited());
+    sync.debounce = 0;
+    const requestPush = vi.spyOn(sync, 'requestPush');
+    sync.requestPush({ a: 1 });
+
+    await vi.waitFor(() => {
+      expect(Log.log).toHaveBeenCalledWith('OptionsSync::rateLimitExceeded');
+    });
+    expect(requestPush).toHaveBeenCalledWith({});
+    await vi.waitFor(() => {
+      expect(setCalls).toBeGreaterThanOrEqual(2);
+    });
+    expect(data['delta.sync.a']).toBe(1);
   });
 });

--- a/packages/target/test/options.test.ts
+++ b/packages/target/test/options.test.ts
@@ -1,0 +1,524 @@
+/**
+ * Options controller: applyProfile, addTempRule, matchProfile cycle,
+ * loadOptions wipe-vs-transport, setExternalProfile, updateProfile revision,
+ * transformValueForSync auth stripping, and malformed-payload guards.
+ */
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { Conditions, Profiles, Revision } from '@switchydelta/pac';
+import type { FixedProfile, PacProfile, Profile, SwitchProfile } from '@switchydelta/pac';
+import { Options } from '../src/options.js';
+import type { DeltaOptions, ProxyImpl } from '../src/options.js';
+import { ProfileNotExistError, SchemaTooNewError } from '../src/errors.js';
+import { Log } from '../src/log.js';
+import { Storage } from '../src/storage.js';
+
+beforeAll(() => {
+  vi.spyOn(Log, 'log').mockImplementation(() => undefined);
+  vi.spyOn(Log, 'error').mockImplementation(() => undefined);
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
+const proxyImpl: ProxyImpl = {
+  applyProfile: async () => undefined,
+};
+
+function bag(extra: DeltaOptions = {}): DeltaOptions {
+  return {
+    schemaVersion: 2,
+    '+proxy': {
+      name: 'proxy',
+      profileType: 'FixedProfile',
+      color: '#99ccee',
+      fallbackProxy: { scheme: 'http', host: 'proxy.example.com', port: 8080 },
+    } satisfies FixedProfile,
+    ...extra,
+  };
+}
+
+class HarnessOptions extends Options {
+  fetchResult: Promise<string> = Promise.resolve('');
+
+  dropProfile(name: string): void {
+    delete this._options[Profiles.nameAsKey(name)];
+  }
+
+  replaceProfile(name: string, profile: Profile): void {
+    this._options[Profiles.nameAsKey(name)] = profile;
+  }
+
+  currentName(): string | null {
+    return this._currentProfileName;
+  }
+
+  tempProfile(): SwitchProfile | null {
+    return this._tempProfile;
+  }
+
+  tempActive(): boolean {
+    return this._tempProfileActive;
+  }
+
+  revertToName(): string | null {
+    return this._revertToProfileName;
+  }
+
+  override fetchUrl(): Promise<string> {
+    return this.fetchResult;
+  }
+}
+
+function recordingProxy(): { impl: ProxyImpl; applied: Profile[] } {
+  const applied: Profile[] = [];
+  return {
+    applied,
+    impl: {
+      applyProfile: async (profile) => {
+        applied.push(profile);
+      },
+    },
+  };
+}
+
+function createLoaded(
+  options: DeltaOptions,
+  impl: ProxyImpl = proxyImpl,
+): Promise<HarnessOptions> {
+  const opts = new HarnessOptions(options, new Storage(), new Storage(), Log, null, impl);
+  return opts.ready.then(() => opts);
+}
+
+describe('Options#loadOptions wipe policy', () => {
+  it('does not wipe stored options on a storage transport error', async () => {
+    const storage = new Storage();
+    const userBag = bag({ '+keep': { name: 'keep', profileType: 'FixedProfile', color: '#000' } });
+    await storage.set(userBag);
+    vi.spyOn(storage, 'get').mockRejectedValue(new Error('transient I/O'));
+
+    const opts = new Options(null, storage, new Storage(), Log, null, proxyImpl);
+    await expect(opts.optionsLoaded).rejects.toThrow('transient I/O');
+
+    vi.mocked(storage.get).mockRestore();
+    expect(await storage.get(null)).toEqual(userBag);
+  });
+
+  it('backs up and refuses to overwrite a newer schemaVersion', async () => {
+    const storage = new Storage();
+    const state = new Storage();
+    const userBag = bag({ schemaVersion: 3, '+custom': { name: 'custom', profileType: 'FixedProfile' } });
+    await storage.set(userBag);
+
+    const opts = new Options(null, storage, state, Log, null, proxyImpl);
+    await expect(opts.optionsLoaded).rejects.toBeInstanceOf(SchemaTooNewError);
+
+    expect(await storage.get(null)).toEqual(userBag);
+    expect(await state.get('optionsSchemaBackup')).toEqual({ optionsSchemaBackup: userBag });
+  });
+
+  it('wipes only on genuinely corrupt options', async () => {
+    const storage = new Storage();
+    await storage.set({
+      schemaVersion: 0,
+      '+keep': { name: 'keep', profileType: 'FixedProfile' },
+    });
+
+    const opts = new Options(null, storage, new Storage(), Log, null, proxyImpl);
+    const loaded = await opts.optionsLoaded;
+
+    expect(loaded['schemaVersion']).toBe(2);
+    expect(loaded['+keep']).toBeUndefined();
+    expect(loaded['+proxy']).toBeTruthy();
+    expect((await storage.get('schemaVersion'))['schemaVersion']).toBe(2);
+  });
+});
+
+describe('Options#matchProfile', () => {
+  it('breaks on a two-profile reference cycle', async () => {
+    const opts = await createLoaded(
+      bag({
+        '+a': {
+          name: 'a',
+          profileType: 'SwitchProfile',
+          color: '#111111',
+          defaultProfileName: 'b',
+          rules: [],
+        } satisfies SwitchProfile,
+        '+b': {
+          name: 'b',
+          profileType: 'SwitchProfile',
+          color: '#222222',
+          defaultProfileName: 'a',
+          rules: [],
+        } satisfies SwitchProfile,
+      }),
+    );
+    await opts.applyProfile('a');
+
+    const request = { url: 'http://example.com/', host: 'example.com', scheme: 'http' };
+    const matched = await opts.matchProfile(request);
+    expect(matched.profile?.name).toBeTruthy();
+    expect(matched.results.length).toBeGreaterThan(0);
+  });
+});
+
+describe('Options#addTempRule', () => {
+  it('bails when the current profile is missing', async () => {
+    const opts = await createLoaded(bag());
+    await opts.applyProfile('proxy');
+    opts.dropProfile('proxy');
+    await expect(opts.addTempRule('example.com', 'direct')).resolves.toBeUndefined();
+  });
+});
+
+describe('Options#updateProfile', () => {
+  it('aborts when the profile key disappears mid-fetch', async () => {
+    const pac = {
+      name: 'pac',
+      profileType: 'PacProfile',
+      pacUrl: 'http://example.com/p.pac',
+      pacScript: 'old',
+      revision: Revision.fromTime(1),
+    } satisfies PacProfile;
+
+    const opts = await createLoaded(bag({ '+pac': pac }));
+    let release!: (data: string) => void;
+    opts.fetchResult = new Promise((resolve) => {
+      release = resolve;
+    });
+
+    const updating = opts.updateProfile('pac');
+    opts.dropProfile('pac');
+    release('function FindProxyForURL(){ return "DIRECT"; }');
+
+    const result = await updating;
+    expect(result['+pac']).toEqual(pac);
+  });
+});
+
+describe('Options.transformValueForSync', () => {
+  it('strips auth credentials from Fixed and Switch profiles', () => {
+    const fixed: FixedProfile = {
+      name: 'proxy',
+      profileType: 'FixedProfile',
+      fallbackProxy: { scheme: 'http', host: 'proxy.example.com', port: 8080 },
+      auth: { all: { username: 'user', password: 's3cret' } },
+    };
+    const strippedFixed = Options.transformValueForSync(fixed, '+proxy') as Profile;
+    expect(strippedFixed).not.toHaveProperty('auth');
+    expect((strippedFixed as FixedProfile).fallbackProxy).toEqual(fixed.fallbackProxy);
+    expect(fixed.auth).toEqual({ all: { username: 'user', password: 's3cret' } });
+
+    const auto: SwitchProfile & { auth?: unknown } = {
+      name: 'auto switch',
+      profileType: 'SwitchProfile',
+      defaultProfileName: 'direct',
+      rules: [],
+      auth: { all: { username: 'user', password: 's3cret' } },
+    };
+    const strippedSwitch = Options.transformValueForSync(auto, '+auto switch') as Record<
+      string,
+      unknown
+    >;
+    expect(strippedSwitch).not.toHaveProperty('auth');
+    expect(strippedSwitch['defaultProfileName']).toBe('direct');
+    expect(auto.auth).toBeTruthy();
+  });
+
+  it('still drops downloaded payloads on updateUrl profiles', () => {
+    const pac: PacProfile & { lastUpdate?: string } = {
+      name: 'pac',
+      profileType: 'PacProfile',
+      pacUrl: 'http://example.com/p.pac',
+      pacScript: 'function FindProxyForURL(){ return "DIRECT"; }',
+      lastUpdate: '2020-01-01T00:00:00.000Z',
+      auth: { all: { username: 'user', password: 's3cret' } },
+    };
+    const stripped = Options.transformValueForSync(pac, '+pac') as Record<string, unknown>;
+    expect(stripped).not.toHaveProperty('auth');
+    expect(stripped).not.toHaveProperty('pacScript');
+    expect(stripped).not.toHaveProperty('lastUpdate');
+    expect(stripped['pacUrl']).toBe('http://example.com/p.pac');
+  });
+});
+
+describe('Options#applyProfile', () => {
+  it('rejects a missing profile', async () => {
+    const opts = await createLoaded(bag());
+    await expect(opts.applyProfile('missing')).rejects.toBeInstanceOf(ProfileNotExistError);
+  });
+
+  it('pushes the named profile through ProxyImpl', async () => {
+    const { impl, applied } = recordingProxy();
+    const opts = await createLoaded(bag(), impl);
+    applied.length = 0;
+    await opts.applyProfile('proxy');
+    expect(applied).toHaveLength(1);
+    expect(applied[0]?.name).toBe('proxy');
+    expect(opts.currentName()).toBe('proxy');
+    expect(opts.isSystem()).toBe(false);
+  });
+
+  it('skips ProxyImpl when proxy is false but still records the current profile', async () => {
+    const { impl, applied } = recordingProxy();
+    const opts = await createLoaded(bag(), impl);
+    applied.length = 0;
+    await opts.applyProfile('proxy', { proxy: false });
+    expect(applied).toHaveLength(0);
+    expect(opts.currentName()).toBe('proxy');
+  });
+
+  it('layers temp rules over an includable profile and drops stale ones', async () => {
+    const other: FixedProfile = {
+      name: 'other',
+      profileType: 'FixedProfile',
+      color: '#abcdef',
+      fallbackProxy: { scheme: 'http', host: 'other.example', port: 9 },
+    };
+    const { impl, applied } = recordingProxy();
+    const opts = await createLoaded(bag({ '+other': other }), impl);
+    await opts.applyProfile('proxy');
+    await opts.addTempRule('example.com', 'other');
+    expect(opts.tempActive()).toBe(true);
+    expect(opts.tempProfile()?.rules).toHaveLength(1);
+
+    opts.dropProfile('other');
+    applied.length = 0;
+    await opts.applyProfile('proxy');
+    const temp = applied[0] as SwitchProfile;
+    expect(temp.profileType).toBe('SwitchProfile');
+    expect(temp.rules).toHaveLength(0);
+    expect(temp.defaultProfileName).toBe('proxy');
+  });
+});
+
+describe('Options#addTempRule', () => {
+  it('indexes a domain once and is a no-op when repeated', async () => {
+    const { impl } = recordingProxy();
+    const opts = await createLoaded(bag(), impl);
+    await opts.applyProfile('proxy');
+    await opts.addTempRule('example.com', 'direct');
+    await opts.addTempRule('example.com', 'direct');
+    expect(opts.tempProfile()?.rules).toHaveLength(1);
+    expect(opts.queryTempRule('example.com')).toBe('direct');
+  });
+
+  it('retargets an existing domain without duplicating the rule', async () => {
+    const other: FixedProfile = {
+      name: 'other',
+      profileType: 'FixedProfile',
+      color: '#abcdef',
+      fallbackProxy: { scheme: 'http', host: 'other.example', port: 9 },
+    };
+    const opts = await createLoaded(bag({ '+other': other }));
+    await opts.applyProfile('proxy');
+    await opts.addTempRule('example.com', 'direct');
+    await opts.addTempRule('example.com', 'other');
+    expect(opts.tempProfile()?.rules).toHaveLength(1);
+    expect(opts.queryTempRule('example.com')).toBe('other');
+  });
+
+  it('rejects a missing target profile', async () => {
+    const opts = await createLoaded(bag());
+    await opts.applyProfile('proxy');
+    await expect(opts.addTempRule('example.com', 'nope')).rejects.toBeInstanceOf(
+      ProfileNotExistError,
+    );
+  });
+});
+
+describe('Options#setExternalProfile', () => {
+  it('reverts the first external change to the currently applied profile', async () => {
+    const { impl, applied } = recordingProxy();
+    const opts = await createLoaded(bag({ '-revertProxyChanges': true }), impl);
+    await opts.applyProfile('proxy');
+    applied.length = 0;
+    opts.setExternalProfile({ name: 'intruder', profileType: 'FixedProfile' });
+    await vi.waitFor(() => {
+      expect(applied.map((p) => p.name)).toEqual(['proxy']);
+    });
+    expect(opts.currentName()).toBe('proxy');
+    expect(opts.revertToName()).toBeNull();
+  });
+
+  it('remembers the applied profile under noRevert and reverts later changes to it', async () => {
+    const { impl, applied } = recordingProxy();
+    const opts = await createLoaded(bag({ '-revertProxyChanges': true }), impl);
+    await opts.applyProfile('proxy');
+    opts.setExternalProfile(
+      { name: 'direct', profileType: 'DirectProfile' },
+      { noRevert: true },
+    );
+    expect(opts.currentName()).toBe('direct');
+    expect(opts.revertToName()).toBe('proxy');
+
+    applied.length = 0;
+    opts.setExternalProfile({ name: 'intruder', profileType: 'FixedProfile' });
+    await vi.waitFor(() => {
+      expect(applied.map((p) => p.name)).toEqual(['proxy']);
+    });
+  });
+
+  it('adopts an unknown profile when revert is off', async () => {
+    const opts = await createLoaded(bag({ '-revertProxyChanges': false }));
+    await opts.applyProfile('proxy');
+    const external: Profile = { name: 'other-ext', profileType: 'SystemProfile' };
+    opts.setExternalProfile(external);
+    expect(opts.currentName()).toBeNull();
+    expect(opts.currentProfile()).toEqual({
+      name: 'other-ext',
+      profileType: 'SystemProfile',
+      color: '#49afcd',
+    });
+    expect(opts.tempActive()).toBe(false);
+  });
+
+  it('applies a known profile without touching the proxy when internal', async () => {
+    const { impl, applied } = recordingProxy();
+    const opts = await createLoaded(bag({ '-revertProxyChanges': false }), impl);
+    await opts.applyProfile('proxy');
+    applied.length = 0;
+    opts.setExternalProfile(
+      { name: 'direct', profileType: 'DirectProfile' },
+      { internal: true },
+    );
+    await vi.waitFor(() => {
+      expect(opts.currentName()).toBe('direct');
+    });
+    expect(applied).toHaveLength(0);
+  });
+});
+
+describe('Options#updateProfile revision', () => {
+  it('keeps a concurrently edited profile instead of applying the fetch', async () => {
+    const pac = {
+      name: 'pac',
+      profileType: 'PacProfile',
+      pacUrl: 'http://example.com/p.pac',
+      pacScript: 'old',
+      revision: Revision.fromTime(1),
+    } satisfies PacProfile;
+
+    const opts = await createLoaded(bag({ '+pac': pac }));
+    let release!: (data: string) => void;
+    opts.fetchResult = new Promise((resolve) => {
+      release = resolve;
+    });
+
+    const updating = opts.updateProfile('pac');
+    const edited: PacProfile = {
+      ...pac,
+      revision: Revision.fromTime(9),
+      pacScript: 'edited-locally',
+    };
+    opts.replaceProfile('pac', edited);
+    release('function FindProxyForURL(){ return "PROXY x:1"; }');
+
+    const result = await updating;
+    expect(result['+pac']).toEqual(edited);
+    expect((opts.profile('pac') as PacProfile).pacScript).toBe('edited-locally');
+  });
+
+  it('writes a new revision when the fetch lands on an unchanged profile', async () => {
+    const pac = {
+      name: 'pac',
+      profileType: 'PacProfile',
+      pacUrl: 'http://example.com/p.pac',
+      pacScript: 'old',
+      revision: Revision.fromTime(1),
+    } satisfies PacProfile;
+
+    const opts = await createLoaded(bag({ '+pac': pac }));
+    opts.fetchResult = Promise.resolve('function FindProxyForURL(){ return "DIRECT"; }');
+    const result = await opts.updateProfile('pac');
+    const updated = result['+pac'] as PacProfile & { lastUpdate?: string };
+    expect(updated.pacScript).toBe('function FindProxyForURL(){ return "DIRECT"; }');
+    expect(updated.revision).not.toBe(pac.revision);
+    expect(updated.lastUpdate).toBeTruthy();
+  });
+});
+
+describe('Options malformed payloads', () => {
+  it('loads cyclic profiles and breaks the cycle in matchProfile', async () => {
+    const storage = new Storage();
+    await storage.set({
+      schemaVersion: 2,
+      '+a': {
+        name: 'a',
+        profileType: 'SwitchProfile',
+        color: '#111111',
+        defaultProfileName: 'b',
+        rules: [],
+      } satisfies SwitchProfile,
+      '+b': {
+        name: 'b',
+        profileType: 'SwitchProfile',
+        color: '#222222',
+        defaultProfileName: 'c',
+        rules: [],
+      } satisfies SwitchProfile,
+      '+c': {
+        name: 'c',
+        profileType: 'SwitchProfile',
+        color: '#333333',
+        defaultProfileName: 'a',
+        rules: [],
+      } satisfies SwitchProfile,
+    });
+
+    const opts = new HarnessOptions(null, storage, new Storage(), Log, null, proxyImpl);
+    await opts.ready;
+    expect(opts.getAll()['+a']).toBeTruthy();
+    await opts.applyProfile('a');
+
+    const matched = await opts.matchProfile(Conditions.requestFromUrl('http://example.com/'));
+    expect(matched.profile?.name).toBeTruthy();
+    expect(matched.results.length).toBeGreaterThan(0);
+    expect(matched.results.length).toBeLessThanOrEqual(3);
+  });
+
+  it('does not wipe a bag that contains a profile missing profileType', async () => {
+    const storage = new Storage();
+    const broken = { name: 'broken' };
+    await storage.set({
+      schemaVersion: 2,
+      '+broken': broken,
+      '+proxy': bag()['+proxy'],
+    });
+
+    const opts = new Options(null, storage, new Storage(), Log, null, proxyImpl);
+    const loaded = await opts.optionsLoaded;
+    expect(loaded['+broken']).toEqual(broken);
+    expect(loaded['schemaVersion']).toBe(2);
+  });
+
+  it('stops matchProfile on a missing profileType instead of throwing', async () => {
+    const opts = await createLoaded(bag());
+    await opts.applyProfile('proxy');
+    opts.replaceProfile('proxy', { name: 'proxy' } as Profile);
+
+    const matched = await opts.matchProfile(Conditions.requestFromUrl('http://example.com/'));
+    expect(matched.profile).toBeUndefined();
+    expect(matched.results).toEqual([]);
+  });
+
+  it('stops matchProfile when a switch chain hits a typeless profile', async () => {
+    const opts = await createLoaded(
+      bag({
+        '+auto': {
+          name: 'auto',
+          profileType: 'SwitchProfile',
+          color: '#99dd99',
+          defaultProfileName: 'proxy',
+          rules: [],
+        } satisfies SwitchProfile,
+      }),
+    );
+    await opts.applyProfile('auto');
+    opts.replaceProfile('proxy', { name: 'proxy' } as Profile);
+    const matched = await opts.matchProfile(Conditions.requestFromUrl('http://example.com/'));
+    expect(matched.profile?.name).toBe('auto');
+    expect(matched.results).toHaveLength(1);
+  });
+});

--- a/packages/target/test/storage.test.ts
+++ b/packages/target/test/storage.test.ts
@@ -1,0 +1,126 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { Log } from '../src/log.js';
+import {
+  parseStorageErrors,
+  QuotaExceededError,
+  RateLimitExceededError,
+  Storage,
+  StorageUnavailableError,
+} from '../src/storage.js';
+
+beforeAll(() => {
+  vi.spyOn(Log, 'log').mockImplementation(() => undefined);
+  vi.spyOn(Log, 'error').mockImplementation(() => undefined);
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
+describe('Storage', () => {
+  it('round-trips get / set / remove for string, array, and default-map keys', async () => {
+    const storage = new Storage();
+    expect(await storage.get(null)).toEqual({});
+
+    await storage.set({ a: 1, b: 2, c: 3 });
+    expect(await storage.get(null)).toEqual({ a: 1, b: 2, c: 3 });
+    expect(await storage.get('a')).toEqual({ a: 1 });
+    expect(await storage.get(['a', 'missing'])).toEqual({ a: 1, missing: undefined });
+    expect(await storage.get({ a: 0, missing: 'fallback' })).toEqual({
+      a: 1,
+      missing: 'fallback',
+    });
+
+    await storage.remove('b');
+    expect(await storage.get(null)).toEqual({ a: 1, c: 3 });
+    await storage.remove(['c']);
+    expect(await storage.get(null)).toEqual({ a: 1 });
+    await storage.remove();
+    expect(await storage.get(null)).toEqual({});
+  });
+
+  it('watch is a no-op that returns an unwatch function', () => {
+    const storage = new Storage();
+    const stop = storage.watch(null, () => undefined);
+    expect(typeof stop).toBe('function');
+    stop();
+  });
+});
+
+describe('Storage.operationsForChanges / apply', () => {
+  it('drops no-ops against a base and honours merge', () => {
+    expect(Storage.operationsForChanges({ a: 1, b: undefined })).toEqual({
+      set: { a: 1 },
+      remove: ['b'],
+    });
+    expect(Storage.operationsForChanges({ a: 1, b: 2 }, { base: { a: 1 } })).toEqual({
+      set: { b: 2 },
+      remove: [],
+    });
+    expect(
+      Storage.operationsForChanges(
+        { a: 2 },
+        { base: { a: 1 }, merge: (_key, _n, oldVal) => oldVal },
+      ),
+    ).toEqual({ set: {}, remove: [] });
+    expect(Storage.operationsForChanges({ gone: undefined }, { base: {} })).toEqual({
+      set: {},
+      remove: [],
+    });
+  });
+
+  it('apply writes the reduced set/remove pair', async () => {
+    const storage = new Storage();
+    await storage.set({ keep: 1, drop: 2 });
+    await storage.apply({
+      changes: { keep: 1, drop: undefined, add: 3 },
+      base: { keep: 1, drop: 2 },
+    });
+    expect(await storage.get(null)).toEqual({ keep: 1, add: 3 });
+  });
+});
+
+describe('parseStorageErrors', () => {
+  it('classifies quota, rate-limit, and unavailable messages', async () => {
+    await expect(parseStorageErrors(new Error('QUOTA_BYTES_PER_ITEM'))).rejects.toMatchObject({
+      name: 'QuotaExceededError',
+      perItem: true,
+    });
+    await expect(parseStorageErrors(new Error('QUOTA_BYTES'))).rejects.toBeInstanceOf(
+      QuotaExceededError,
+    );
+    await expect(parseStorageErrors(new Error('MAX_ITEMS'))).rejects.toMatchObject({
+      name: 'QuotaExceededError',
+      maxItems: true,
+    });
+    await expect(
+      parseStorageErrors(new Error('MAX_WRITE_OPERATIONS_PER_HOUR')),
+    ).rejects.toMatchObject({ name: 'RateLimitExceededError', perHour: true });
+    await expect(
+      parseStorageErrors(new Error('MAX_WRITE_OPERATIONS_PER_MINUTE')),
+    ).rejects.toMatchObject({ name: 'RateLimitExceededError', perMinute: true });
+    await expect(
+      parseStorageErrors(new Error('MAX_SUSTAINED_WRITE_OPERATIONS_PER_MINUTE')),
+    ).rejects.toMatchObject({
+      name: 'RateLimitExceededError',
+      perMinute: true,
+      sustained: true,
+    });
+    await expect(parseStorageErrors(new Error('Sync is not available'))).rejects.toBeInstanceOf(
+      StorageUnavailableError,
+    );
+    await expect(
+      parseStorageErrors(
+        new Error('Please set webextensions.storage.sync.enabled to true in about:config'),
+      ),
+    ).rejects.toBeInstanceOf(StorageUnavailableError);
+  });
+
+  it('re-raises unrecognised errors and non-Error values', async () => {
+    const err = new Error('something else');
+    await expect(parseStorageErrors(err)).rejects.toBe(err);
+    await expect(parseStorageErrors('nope')).rejects.toBe('nope');
+    expect(Storage.parseStorageErrors).toBe(parseStorageErrors);
+    expect(Storage.RateLimitExceededError).toBe(RateLimitExceededError);
+  });
+});

--- a/packages/target/test/token-bucket.test.ts
+++ b/packages/target/test/token-bucket.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Token bucket: starts full (MIGRATION.md deliberate change), lazy refill,
+ * and the wait / overflow paths used by OptionsSync.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TokenBucket } from '../src/token-bucket.js';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('TokenBucket', () => {
+  it('starts full rather than empty', () => {
+    const bucket = new TokenBucket(10, 10, 'minute');
+    expect(bucket.content).toBe(10);
+    expect(bucket.tryRemoveTokens(10)).toBe(true);
+    expect(bucket.content).toBe(0);
+  });
+
+  it('refuses a request larger than the bucket', async () => {
+    const bucket = new TokenBucket(2, 2, 'second');
+    expect(bucket.tryRemoveTokens(3)).toBe(false);
+    expect(bucket.content).toBe(2);
+    await expect(bucket.removeTokens(3)).rejects.toThrow(/exceeds bucket size/);
+  });
+
+  it('credits tokens from elapsed wall clock', () => {
+    vi.useFakeTimers();
+    const bucket = new TokenBucket(4, 4, 1000);
+    expect(bucket.tryRemoveTokens(4)).toBe(true);
+    expect(bucket.tryRemoveTokens(1)).toBe(false);
+    vi.advanceTimersByTime(500);
+    expect(bucket.tryRemoveTokens(2)).toBe(true);
+    expect(bucket.content).toBeCloseTo(0);
+  });
+
+  it('removeTokens waits until a drip covers the request', async () => {
+    vi.useFakeTimers();
+    const bucket = new TokenBucket(1, 1, 1000);
+    expect(bucket.tryRemoveTokens(1)).toBe(true);
+    const pending = bucket.removeTokens(1);
+    await vi.advanceTimersByTimeAsync(1000);
+    await pending;
+    expect(bucket.content).toBe(0);
+  });
+
+  it('clear forces a full wait before the next take', () => {
+    vi.useFakeTimers();
+    const bucket = new TokenBucket(5, 5, 1000);
+    bucket.clear();
+    expect(bucket.content).toBe(0);
+    expect(bucket.tryRemoveTokens(1)).toBe(false);
+    vi.advanceTimersByTime(1000);
+    expect(bucket.tryRemoveTokens(5)).toBe(true);
+  });
+
+  it('rejects an invalid interval', () => {
+    expect(() => new TokenBucket(1, 1, 'nope' as 'second')).toThrow(/Invalid interval/);
+  });
+
+  it('treats a zero drip rate as "always full"', () => {
+    const bucket = new TokenBucket(3, 0, 'second');
+    expect(bucket.tryRemoveTokens(3)).toBe(true);
+    expect(bucket.tryRemoveTokens(3)).toBe(true);
+  });
+});

--- a/packages/ui/src/lib/profile-view.ts
+++ b/packages/ui/src/lib/profile-view.ts
@@ -7,7 +7,34 @@
  * single definition.
  */
 
-import { Profiles, type OptionsBag, type Profile } from '@switchydelta/pac';
+import { Profiles, type FixedProfile, type OptionsBag, type Profile } from '@switchydelta/pac';
+
+/** Proxy protocols the fixed-profile editor (and Chromium) accept. */
+export const PROXY_SCHEMES = ['http', 'https', 'socks4', 'socks5'] as const;
+export type ProxyScheme = (typeof PROXY_SCHEMES)[number];
+
+export function isProxyScheme(value: string): value is ProxyScheme {
+  return (PROXY_SCHEMES as readonly string[]).includes(value);
+}
+
+/**
+ * Clamp stored `fallbackProxy.scheme` values to {@link PROXY_SCHEMES}.
+ *
+ * Imported / synced options can carry an arbitrary string; the editor must
+ * never interpolate one into markup.
+ */
+export function sanitizeFallbackProxySchemes(bag: OptionsBag): void {
+  for (const value of Object.values(bag)) {
+    if (!value || typeof value !== 'object') continue;
+    const profile = value as Profile;
+    if (profile.profileType !== 'FixedProfile') continue;
+    const proxy = (profile as FixedProfile).fallbackProxy;
+    if (!proxy || typeof proxy !== 'object') continue;
+    if (typeof proxy.scheme !== 'string' || !isProxyScheme(proxy.scheme)) {
+      proxy.scheme = 'http';
+    }
+  }
+}
 
 /** Palette offered by the profile colour picker. */
 export const profileColors: readonly string[] = [
@@ -92,9 +119,26 @@ export function iconFor(profile: Profile, options: OptionsBag): string {
   return profileIcons[target.profileType] ?? 'question-sign';
 }
 
+/**
+ * Accept only `#rgb` / `#rrggbb`. A stored `url(...)` (or any other CSS)
+ * must not become `style.background`.
+ */
+export function sanitizeHexColor(color: string | undefined | null): string | undefined {
+  if (!color) return undefined;
+  const raw = color.trim();
+  const short = /^#([0-9a-fA-F]{3})$/.exec(raw);
+  if (short) {
+    const [r, g, b] = short[1]!;
+    return `#${r}${r}${g}${g}${b}${b}`.toLowerCase();
+  }
+  const full = /^#([0-9a-fA-F]{6})$/.exec(raw);
+  if (full) return `#${full[1]!}`.toLowerCase();
+  return undefined;
+}
+
 export function colorFor(profile: Profile, options: OptionsBag): string {
   const target = getVirtualTarget(profile, options);
-  return target.color ?? profile.color ?? '#cccccc';
+  return sanitizeHexColor(target.color) ?? sanitizeHexColor(profile.color) ?? '#cccccc';
 }
 
 /** Order profiles by type then name, the way both old UIs did. */

--- a/packages/ui/src/options/main.ts
+++ b/packages/ui/src/options/main.ts
@@ -11,7 +11,7 @@
 import { must, on, render } from '../lib/dom.js';
 import { localizeDocument, profileDisplayName, t } from '../lib/i18n.js';
 import { api, callBackground, localState, requestHostAccess } from '../lib/messaging.js';
-import { colorFor, listProfiles } from '../lib/profile-view.js';
+import { colorFor, listProfiles, sanitizeFallbackProxySchemes } from '../lib/profile-view.js';
 import { deepEqual } from '../lib/equal.js';
 import {
   renderAbout,
@@ -218,6 +218,7 @@ async function main(): Promise<void> {
     must('#om-view').textContent = err instanceof Error ? err.message : String(err);
     return;
   }
+  sanitizeFallbackProxySchemes(pristine);
   options = snapshot(pristine);
 
   renderProfileNav();

--- a/packages/ui/src/options/views.ts
+++ b/packages/ui/src/options/views.ts
@@ -9,7 +9,16 @@
 import { append, downloadFile, h, must, render } from '../lib/dom.js';
 import { profileDisplayName, t } from '../lib/i18n.js';
 import { api, callBackground, getState, setState } from '../lib/messaging.js';
-import { colorFor, getAttachedName, listProfiles, profileColors } from '../lib/profile-view.js';
+import {
+  colorFor,
+  getAttachedName,
+  isProxyScheme,
+  listProfiles,
+  profileColors,
+  PROXY_SCHEMES,
+  sanitizeFallbackProxySchemes,
+  sanitizeHexColor,
+} from '../lib/profile-view.js';
 import {
   adoptOptionsKey,
   applyChanges,
@@ -309,7 +318,11 @@ export function renderIo(container: HTMLElement): void {
 
   const restore = async (text: string) => {
     try {
-      await api.reset(JSON.parse(text));
+      const parsed: unknown = JSON.parse(text);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        sanitizeFallbackProxySchemes(parsed as typeof options);
+      }
+      await api.reset(parsed);
       location.reload();
     } catch (err) {
       status.className = 'om-error';
@@ -449,21 +462,16 @@ export function renderAbout(container: HTMLElement): void {
 
 // --- Profile editing --------------------------------------------------------
 
-const PROXY_SCHEMES = ['http', 'https', 'socks4', 'socks5'];
 const DEFAULT_PORTS: Record<string, number> = { http: 80, https: 443, socks4: 1080, socks5: 1080 };
 
 /** Expand `#rgb` to `#rrggbb` so `<input type="color">` accepts the value. */
 function normalizeHex(color: string): string {
-  const raw = color.trim();
-  const short = /^#([0-9a-fA-F]{3})$/.exec(raw);
-  if (short) {
-    const [r, g, b] = short[1]!;
-    return `#${r}${r}${g}${g}${b}${b}`.toLowerCase();
-  }
-  const full = /^#([0-9a-fA-F]{6})$/.exec(raw);
-  if (full) return `#${full[1]!}`.toLowerCase();
-  // Fall back to a palette colour when the stored value is not a hex string.
-  return profileColors[0]!;
+  return sanitizeHexColor(color) ?? profileColors[0]!;
+}
+
+/** File-safe stem of a profile name; PAC and rule-list exporters share this. */
+function exportBaseName(name: string): string {
+  return name.replace(/\W+/g, '_');
 }
 
 export function renderProfile(
@@ -972,8 +980,6 @@ function renderSwitchProfile(
     Number(options['-showConditionTypes'] ?? 0) > 0 ||
     profile.rules.some((rule) => !BASIC_CONDITION_TYPE_SET.has(rule.condition.conditionType));
 
-  const exportBaseName = () => profile.name.replace(/\W+/g, '_');
-
   const exportRuleList = () => {
     const eol = '\r\n';
     let info = '\n';
@@ -985,7 +991,7 @@ function renderSwitchProfile(
       rules: profile.rules,
       defaultProfileName: effectiveDefault(),
     }).replace('\n', info);
-    downloadFile(`DeltaRules_${exportBaseName()}.sorl`, text, 'text/plain;charset=utf-8');
+    downloadFile(`DeltaRules_${exportBaseName(profile.name)}.sorl`, text, 'text/plain;charset=utf-8');
   };
 
   const exportLegacyRuleList = () => {
@@ -1021,7 +1027,7 @@ function renderSwitchProfile(
       regexpRules,
       '#END',
     ].join('\n');
-    downloadFile(`SwitchyRules_${exportBaseName()}.ssrl`, text, 'text/plain;charset=utf-8');
+    downloadFile(`SwitchyRules_${exportBaseName(profile.name)}.ssrl`, text, 'text/plain;charset=utf-8');
   };
 
   const exportDeltaButton = h('button', {
@@ -1811,6 +1817,7 @@ const eyeSlashIcon = svgIcon(`${eyeShape}<line x1="3" y1="3" x2="21" y2="21"/>`)
 
 function renderFixedProfile(container: HTMLElement, profile: FixedProfile): void {
   const proxy: ProxyServer = profile.fallbackProxy ?? { scheme: 'http', host: '', port: 80 };
+  if (!isProxyScheme(proxy.scheme)) proxy.scheme = 'http';
   profile.fallbackProxy = proxy;
 
   const touch = () => {
@@ -1844,7 +1851,7 @@ function renderFixedProfile(container: HTMLElement, profile: FixedProfile): void
           password.value = '';
           password.disabled = true;
           authWarning.hidden = false;
-          authWarning.innerHTML = t('options_proxy_authNotSupported', [
+          authWarning.textContent = t('options_proxy_authNotSupported', [
             proxy.scheme.toUpperCase(),
           ]);
         } else {
@@ -1932,7 +1939,7 @@ function renderFixedProfile(container: HTMLElement, profile: FixedProfile): void
 
   const authWarning = h('p', {
     class: 'om-help om-auth-warning',
-    html: t('options_proxy_authNotSupported', [proxy.scheme.toUpperCase()]),
+    text: t('options_proxy_authNotSupported', [proxy.scheme.toUpperCase()]),
     hidden: AUTH_SUPPORTED.has(proxy.scheme),
   });
 
@@ -2289,7 +2296,11 @@ function renderPacProfile(container: HTMLElement, profile: PacProfile): void {
 async function exportPac(profile: Profile): Promise<void> {
   try {
     const pac = await callPac(profile.name);
-    downloadFile(`DeltaProfile_${profile.name}.pac`, pac, 'application/x-ns-proxy-autoconfig');
+    downloadFile(
+      `DeltaProfile_${exportBaseName(profile.name)}.pac`,
+      pac,
+      'application/x-ns-proxy-autoconfig',
+    );
   } catch (err) {
     must('#om-status').textContent = err instanceof Error ? err.message : String(err);
   }

--- a/packages/ui/src/popup/main.ts
+++ b/packages/ui/src/popup/main.ts
@@ -10,6 +10,7 @@
 
 import { h, must, on, render } from '../lib/dom.js';
 import { localizeDocument, profileDisplayName, t } from '../lib/i18n.js';
+import { sanitizeHexColor } from '../lib/profile-view.js';
 import { installShortcuts } from './shortcuts.js';
 import {
   api,
@@ -141,7 +142,7 @@ function renderProfiles(): void {
             'span',
             {
               class: 'om-swatch',
-              style: { background: profile.color ?? '#cccccc' },
+              style: { background: sanitizeHexColor(profile.color) ?? '#cccccc' },
               'aria-hidden': 'true',
             },
             TYPE_INITIAL[profile.profileType] ?? '?',

--- a/packages/ui/test/profile-view.test.ts
+++ b/packages/ui/test/profile-view.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import type { FixedProfile, OptionsBag, Profile } from '@switchydelta/pac';
+import {
+  colorFor,
+  isProxyScheme,
+  sanitizeFallbackProxySchemes,
+  sanitizeHexColor,
+} from '../src/lib/profile-view.js';
+
+function fixed(overrides: Partial<FixedProfile> = {}): FixedProfile {
+  return {
+    name: 'Proxy',
+    profileType: 'FixedProfile',
+    color: '#99ccee',
+    fallbackProxy: { scheme: 'http', host: 'example.com', port: 80 },
+    ...overrides,
+  };
+}
+
+describe('sanitizeHexColor', () => {
+  it('accepts #rgb and expands it', () => {
+    expect(sanitizeHexColor('#AbC')).toBe('#aabbcc');
+  });
+
+  it('accepts #rrggbb', () => {
+    expect(sanitizeHexColor('#99CCEE')).toBe('#99ccee');
+  });
+
+  it('rejects CSS that is not a hex colour', () => {
+    expect(sanitizeHexColor('url("https://evil.example/x")')).toBeUndefined();
+    expect(sanitizeHexColor('red')).toBeUndefined();
+    expect(sanitizeHexColor('#gg0000')).toBeUndefined();
+    expect(sanitizeHexColor('#1234')).toBeUndefined();
+  });
+});
+
+describe('colorFor', () => {
+  it('returns a stored hex colour', () => {
+    expect(colorFor(fixed({ color: '#ff9966' }), {})).toBe('#ff9966');
+  });
+
+  it('falls back when the stored colour is not hex', () => {
+    expect(colorFor(fixed({ color: 'url("https://evil.example/x")' }), {})).toBe('#cccccc');
+  });
+
+  it('does not inherit a non-hex colour from a virtual target', () => {
+    const bag: OptionsBag = {
+      '+real': fixed({ name: 'real', color: 'url(https://evil.example/x)' }),
+    };
+    const virtual: Profile = {
+      name: 'v',
+      profileType: 'VirtualProfile',
+      defaultProfileName: 'real',
+      rules: [],
+    };
+    expect(colorFor(virtual, bag)).toBe('#cccccc');
+  });
+});
+
+describe('sanitizeFallbackProxySchemes', () => {
+  it('clamps a bogus fallbackProxy.scheme to http', () => {
+    const bag: OptionsBag = {
+      '+Proxy': fixed({
+        fallbackProxy: { scheme: 'http"><img src=x>', host: 'h', port: 80 },
+      }),
+    };
+    sanitizeFallbackProxySchemes(bag);
+    expect((bag['+Proxy'] as FixedProfile).fallbackProxy!.scheme).toBe('http');
+  });
+
+  it('leaves accepted schemes alone', () => {
+    for (const scheme of ['http', 'https', 'socks4', 'socks5']) {
+      const bag: OptionsBag = {
+        '+Proxy': fixed({ fallbackProxy: { scheme, host: 'h', port: 80 } }),
+      };
+      sanitizeFallbackProxySchemes(bag);
+      expect((bag['+Proxy'] as FixedProfile).fallbackProxy!.scheme).toBe(scheme);
+    }
+  });
+
+  it('does not invent a fallbackProxy on profiles that have none', () => {
+    const bag: OptionsBag = { '+Proxy': fixed({ fallbackProxy: undefined }) };
+    delete (bag['+Proxy'] as FixedProfile).fallbackProxy;
+    sanitizeFallbackProxySchemes(bag);
+    expect((bag['+Proxy'] as FixedProfile).fallbackProxy).toBeUndefined();
+  });
+});
+
+describe('isProxyScheme', () => {
+  it('accepts only the four editor schemes', () => {
+    expect(isProxyScheme('socks5')).toBe(true);
+    expect(isProxyScheme('HTTP')).toBe(false);
+    expect(isProxyScheme('direct')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the open security-audit issues (#32–#45) on the MV3 worker, options controller, PAC generator, and UI.

- **RPC:** replace reflection dispatch with an explicit allowlist, validate `sender.id`/origin, and strip profile `auth` from untrusted replies (#32).
- **Sync / options:** sanitize remote `+profile`/`-key` payloads, break `matchProfile` cycles, stop `loadOptions` from wiping on transport errors or a newer `schemaVersion`, and guard `applyProfile(null)` / `updateProfile` / `addTempRule` (#33, #34, #43).
- **Credentials:** persist `deltaProxyAuth` to session (local only as fallback, cleared after a session write); strip `auth` from `transformValueForSync` (#39).
- **Fetch:** http(s) only, abort timeout, byte cap, refuse private/metadata hosts, tighter HTML reject (#40).
- **PAC:** ReDoS bounds + nested-quantifier reject, guarded AutoProxy `atob`, `x-(-1)` codegen, leading-colon IPv6 in `isIp` (#36, #37, #42).
- **UI / manifest:** scheme warning is text, hex-only colors, sanitized PAC filename; drop unused `unlimitedStorage`/`activeTab` (#35, #44).
- **Storage errors:** shared `parseStorageErrors` so BrowserStorage hits the rate-limit/quota path (#41).
- **Tests:** options, codegen, ip, TokenBucket, storage, RPC, fetch-url, profile-view (#45).

Leaves the documented `copyTo` `syncOptions` comparison in `MIGRATION.md` alone.

Closes #32
Closes #33
Closes #34
Closes #35
Closes #36
Closes #37
Closes #38
Closes #39
Closes #40
Closes #41
Closes #42
Closes #43
Closes #44
Closes #45

## Test plan

- [x] `npm test` (352 tests)
- [x] `npm run typecheck`
- [ ] CI build + e2e