### PR TITLE
Ignore local Grok state and AGENTS.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
-node_modules
+node_modules/
 dist/
 *.tsbuildinfo
 .dev-chrome-profile/
 .env
 .DS_Store
+
+# Local Grok session / workflow files
+.grok/
+
+# Local agent notes (not part of the published tree)
+AGENTS.md


### PR DESCRIPTION
## Summary

Stop local-only files showing up as untracked:

- `.grok/` — Grok session/workflow files
- `AGENTS.md` — machine-local agent notes

Also writes `node_modules/` with a trailing slash so it is clearly a directory rule.

## Test plan

- [x] `git status` is clean
- [x] `npm test` (352)