### PR TITLE
Unblock the popup from the startup proxy apply

### DIFF
--- a/packages/extension/src/chrome-options.ts
+++ b/packages/extension/src/chrome-options.ts
@@ -24,7 +24,7 @@ import {
   type ActionIconPaint,
 } from './action-icon.js';
 import { setActiveTabIconTracking } from './active-tab-icon.js';
-import { fetchUrl } from './fetch-url.js';
+import { abortInFlightFetches, fetchUrl } from './fetch-url.js';
 import { ProxyAuth } from './proxy-auth.js';
 
 export class ChromeOptions extends Options {
@@ -52,6 +52,10 @@ export class ChromeOptions extends Options {
     typeHints?: string[],
   ): Promise<string> {
     return fetchUrl(url, bypassCache, typeHints);
+  }
+
+  override abortFetches(): void {
+    abortInFlightFetches();
   }
 
   /**

--- a/packages/extension/src/fetch-url.ts
+++ b/packages/extension/src/fetch-url.ts
@@ -31,6 +31,26 @@ export const fetchLimits = {
   maxRedirects: 5,
 };
 
+/** Controllers of in-flight {@link fetchUrl} calls, so a profile switch can cancel a hung download. */
+const inFlight = new Set<AbortController>();
+
+/**
+ * Abort every in-flight rule-list / PAC download.
+ *
+ * A hung gfwlist fetch (blocked host, missing permission, dead proxy) otherwise
+ * keeps the worker's `chrome.proxy.settings.set` and the popup RPC behind it.
+ */
+export function abortInFlightFetches(): void {
+  for (const controller of inFlight) {
+    try {
+      controller.abort();
+    } catch {
+      // Already aborted or the host rejected abort().
+    }
+  }
+  inFlight.clear();
+}
+
 /**
  * The media type without its parameters, lowercased.
  *
@@ -310,6 +330,7 @@ async function fetchFollowing(urlString: string, signal: AbortSignal): Promise<R
 
 async function request(url: string): Promise<Response_> {
   const controller = new AbortController();
+  inFlight.add(controller);
   const timer = setTimeout(() => controller.abort(), fetchLimits.timeoutMs);
   try {
     const response = await fetchFollowing(url, controller.signal);
@@ -327,6 +348,7 @@ async function request(url: string): Promise<Response_> {
     };
   } finally {
     clearTimeout(timer);
+    inFlight.delete(controller);
   }
 }
 

--- a/packages/extension/src/proxy-settings.ts
+++ b/packages/extension/src/proxy-settings.ts
@@ -97,10 +97,18 @@ export class ProxySettings {
     } else if (profile.profileType === 'FixedProfile') {
       config = this._fixedProfileConfig(profile);
     } else {
-      config = {
-        mode: 'pac_script',
-        pacScript: { mandatory: true, data: this.getProfilePacScript(profile, opts) },
-      };
+      try {
+        config = {
+          mode: 'pac_script',
+          pacScript: { mandatory: true, data: this.getProfilePacScript(profile, opts) },
+        };
+      } catch (err) {
+        // An empty or broken rule list (gfwlist never downloaded, or a
+        // rejected download left no usable text) must not fail apply and
+        // leave the popup waiting on a rejected ready promise.
+        this.log.error('PAC generation failed; falling back to direct', err);
+        config = { mode: 'direct' };
+      }
       releaseCaches = true;
     }
 

--- a/packages/extension/src/sw.ts
+++ b/packages/extension/src/sw.ts
@@ -87,7 +87,15 @@ async function boot(): Promise<Options> {
   }
 
   options = new ChromeOptions(null, storage, state, Log, sync, proxySettings);
-  await options.ready;
+  // The popup only needs the profile list, which `uiReady` publishes. `ready`
+  // additionally waits for the startup profile to reach the browser, and
+  // `chrome.proxy.settings.set` is slow (a large rule-list PAC) or outright
+  // stalled (another extension holding the setting) often enough that waiting
+  // on it here is what left the menu blank.
+  await options.uiReady;
+  void options.ready.catch((err: unknown) => {
+    Log.error('Options apply failed', err);
+  });
   return options;
 }
 
@@ -182,6 +190,16 @@ chrome.runtime.onMessage.addListener((request, sender, respond) => {
       await ready;
       const target = options;
       if (!target) throw new Error('Options are not ready');
+
+      // Everything the popup calls must be answerable from `uiReady` alone.
+      // The rest of the RPC surface reads or writes the applied profile, so it
+      // still waits for the boot-time apply to settle. `applyProfile` is safe
+      // to let through early because applies reach the browser in call order,
+      // so the user's pick lands after the startup one it overtakes rather
+      // than being reverted by it (see Options#applyProfile).
+      if (method !== 'getState' && method !== 'setState' && method !== 'applyProfile') {
+        await target.ready;
+      }
 
       let result: unknown = await dispatchRpc(method, { options: target, state }, args);
 

--- a/packages/extension/test/fetch-url.test.ts
+++ b/packages/extension/test/fetch-url.test.ts
@@ -7,6 +7,7 @@ import {
 } from '@switchydelta/target';
 
 import {
+  abortInFlightFetches,
   fetchLimits,
   fetchUrl,
   isNonPublicHostname,
@@ -16,6 +17,7 @@ import {
 const defaults = { ...fetchLimits };
 
 afterEach(() => {
+  abortInFlightFetches();
   Object.assign(fetchLimits, defaults);
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
@@ -190,6 +192,26 @@ describe('fetchUrl', () => {
         '*',
       ]),
     ).resolves.toContain('||example.com');
+  });
+
+  it('abortInFlightFetches rejects a pending download', async () => {
+    stubFetch((_url, init) => {
+      return new Promise((_resolve, reject) => {
+        const signal = init?.signal;
+        if (!signal) {
+          reject(new Error('missing AbortSignal'));
+          return;
+        }
+        signal.addEventListener('abort', () => {
+          reject(new DOMException('The operation was aborted.', 'AbortError'));
+        });
+      });
+    });
+    const pending = fetchUrl('https://lists.example/list.txt');
+    abortInFlightFetches();
+    await expect(pending).rejects.toMatchObject({
+      message: 'Request timed out',
+    });
   });
 
   it('maps an aborted fetch to a timeout NetworkError', async () => {

--- a/packages/target/src/options.ts
+++ b/packages/target/src/options.ts
@@ -155,6 +155,16 @@ export class Options {
 
   /** Resolves with the options once the first profile has been applied. */
   ready!: Promise<DeltaOptions>;
+  /**
+   * Resolves once the profile list has been published to state, before the
+   * proxy is programmed.
+   *
+   * The popup only needs this. {@link ready} additionally waits for the
+   * startup profile to reach the browser — generating a rule-list PAC and
+   * handing it to `chrome.proxy.settings` — and the menu stayed blank for as
+   * long as that took.
+   */
+  uiReady!: Promise<unknown>;
   /** Resolves with the options once they have been loaded from storage. */
   optionsLoaded!: Promise<DeltaOptions>;
 
@@ -209,11 +219,15 @@ export class Options {
       // Bound to a local so the closure does not defeat definite-assignment
       // analysis on the field.
       const storageRef = this._storage;
-      this.ready = (async () => {
+      const prepared = (async () => {
         await storageRef.remove();
         await storageRef.set(options);
-        return this.init();
+        this.init();
       })();
+      // init() overwrites both fields; these wrappers hold the values that
+      // callers captured at construction and chain onto the real promises.
+      this.uiReady = prepared.then(() => this.uiReady);
+      this.ready = prepared.then(() => this.ready);
     }
   }
 
@@ -373,29 +387,46 @@ export class Options {
     return this.optionsLoaded;
   }
 
+  /** Profile to apply on startup: the configured startup profile, else last-used. */
+  private async startupProfileName(): Promise<string> {
+    const startup = this._get<string>('-startupProfileName');
+    if (startup) return startup;
+    const st = await this._state.get({
+      currentProfileName: this.fallbackProfileName,
+      isSystemProfile: false,
+    });
+    if (st['isSystemProfile']) return 'system';
+    return (st['currentProfileName'] as string) || this.fallbackProfileName;
+  }
+
   /** Attempt to initialize (or reinitialize) options. */
   init(): Promise<DeltaOptions> {
-    this.ready = this.loadOptions()
+    // Publish the menu first, then apply the proxy: programming the browser is
+    // the slow half of startup, and the popup has no reason to wait for it.
+    this.uiReady = this.loadOptions()
       .then(async () => {
-        const startup = this._get<string>('-startupProfileName');
-        if (startup) {
-          return this.applyProfile(startup);
-        }
-        const st = await this._state.get({
-          currentProfileName: this.fallbackProfileName,
-          isSystemProfile: false,
-        });
-        if (st['isSystemProfile']) {
-          return this.applyProfile('system');
-        }
-        return this.applyProfile(
-          (st['currentProfileName'] as string) || this.fallbackProfileName,
-        );
+        const name = await this.startupProfileName();
+        return this.applyProfile(name, { proxy: false, update: false });
       })
       .catch((err: unknown) => {
         // FIX: was `if not err instanceof ProfileNotExistError`, which
         // CoffeeScript parsed as `(not err) instanceof ...` — always false, so
         // real errors were silently swallowed instead of logged.
+        if (!(err instanceof ProfileNotExistError)) {
+          this.log.error(err);
+        }
+        return this.applyProfile(this.fallbackProfileName, { proxy: false, update: false });
+      })
+      .catch((err: unknown) => {
+        this.log.error(err);
+      });
+
+    this.ready = this.uiReady
+      .then(() => {
+        const name = this._currentProfileName || this.fallbackProfileName;
+        return this.applyProfile(name);
+      })
+      .catch((err: unknown) => {
         if (!(err instanceof ProfileNotExistError)) {
           this.log.error(err);
         }
@@ -406,8 +437,9 @@ export class Options {
       })
       .then(() => this.getAll());
 
-    // Deliberately not chained into `ready`: these are follow-up side effects,
-    // and callers must not wait on a profile download to consider us ready.
+    // Deliberately not chained into `uiReady`: these are follow-up side
+    // effects, and callers must not wait on a profile download to consider
+    // the popup ready.
     void this.ready.then(() => {
       if (this.sync?.enabled) this.sync.requestPush(this._options);
 
@@ -423,6 +455,14 @@ export class Options {
 
     return this.ready;
   }
+
+  /**
+   * Cancel in-flight rule-list / PAC downloads.
+   *
+   * The Chromium build aborts the underlying `fetch`; the base class is a
+   * no-op so unit tests that stub `fetchUrl` keep working.
+   */
+  abortFetches(): void {}
 
   /**
    * Upgrade options from previous versions.
@@ -829,6 +869,7 @@ export class Options {
       return Promise.reject(new ProfileNotExistError(name as string));
     }
 
+    const previousName = this._currentProfileName;
     this._currentProfileName = profile.name;
     this._isSystem = options?.system || profile.profileType === 'SystemProfile';
     this._watchingProfiles = Profiles.allReferenceSet(profile, this._options, {
@@ -848,6 +889,18 @@ export class Options {
       return Promise.resolve();
     }
 
+    // Drop a hung gfwlist / PAC download, but only when the user actually
+    // switches profiles. Re-applying the *same* profile is what a finished
+    // rule-list download does (via _setOptions), and aborting there would
+    // cancel the siblings still downloading from the same update batch.
+    if (previousName !== profile.name) this.abortFetches();
+
+    // Two applies can be in flight at once now that the boot-time apply behind
+    // `ready` no longer gates the popup's RPC: a profile the user picks while
+    // the worker is still starting arrives mid-apply. That is safe only
+    // because every apply reaches `chrome.proxy.settings` one microtask after
+    // being called, so the browser sees them in call order and the user's pick
+    // is the one that sticks. Do not introduce an await before the proxy call.
     this._tempProfileActive = false;
     let applyProxy: Promise<unknown>;
     if (this._tempProfile != null && Profiles.isIncludable(profile)) {
@@ -896,15 +949,21 @@ export class Options {
 
     if (options && options.update === false) return applyProxy;
 
-    void applyProxy.then(() => {
-      const interval = this._get<number>('-downloadInterval');
-      if (!(interval !== undefined && interval > 0)) return;
-      if (this._currentProfileName !== profile.name) return;
-      const updateProfiles = Object.values(this._watchingProfiles);
-      if (updateProfiles.length > 0) {
-        void this.updateProfile(updateProfiles);
-      }
-    });
+    void applyProxy
+      .then(() => {
+        const interval = this._get<number>('-downloadInterval');
+        if (!(interval !== undefined && interval > 0)) return;
+        if (this._currentProfileName !== profile.name) return;
+        const updateProfiles = Object.values(this._watchingProfiles);
+        if (updateProfiles.length > 0) {
+          void this.updateProfile(updateProfiles);
+        }
+      })
+      // The caller owns `applyProxy`'s rejection; this follow-up branch is a
+      // second consumer, and leaving it unhandled turns a rejected
+      // `settings.set` (another extension holding the proxy) into an
+      // unhandled rejection in the worker.
+      .catch(() => undefined);
     return applyProxy;
   }
 
@@ -970,6 +1029,10 @@ export class Options {
     optBypassCache?: boolean,
   ): Promise<Record<string, Profile | Error>> {
     this.log.method('Options#updateProfile', this, arguments);
+    // Deliberately does not abortFetches(): boot runs two overlapping updates
+    // (the watched profiles after apply, then every profile on the download
+    // interval), and cancelling here would make each report the other's
+    // downloads as timeouts.
     const results: Record<string, Promise<Profile | Error>> = {};
     Profiles.each(this._options, (key, profile) => {
       if (name != null) {

--- a/packages/target/test/options.test.ts
+++ b/packages/target/test/options.test.ts
@@ -40,6 +40,11 @@ function bag(extra: DeltaOptions = {}): DeltaOptions {
 
 class HarnessOptions extends Options {
   fetchResult: Promise<string> = Promise.resolve('');
+  aborted = 0;
+
+  override abortFetches(): void {
+    this.aborted += 1;
+  }
 
   dropProfile(name: string): void {
     delete this._options[Profiles.nameAsKey(name)];
@@ -169,6 +174,99 @@ describe('Options#addTempRule', () => {
     await opts.applyProfile('proxy');
     opts.dropProfile('proxy');
     await expect(opts.addTempRule('example.com', 'direct')).resolves.toBeUndefined();
+  });
+});
+
+describe('Options#uiReady', () => {
+  it('resolves before a hung proxy apply so the popup can render', async () => {
+    let release!: () => void;
+    const hung = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const impl: ProxyImpl = {
+      applyProfile: () => hung,
+    };
+    const opts = new HarnessOptions(bag(), new Storage(), new Storage(), Log, null, impl);
+
+    await opts.uiReady;
+    expect(opts.currentName()).toBeTruthy();
+
+    let readySettled = false;
+    void opts.ready.then(() => {
+      readySettled = true;
+    });
+    await Promise.resolve();
+    expect(readySettled).toBe(false);
+
+    release();
+    await opts.ready;
+    expect(readySettled).toBe(true);
+  });
+
+  it('applyProfile cancels in-flight downloads when switching profiles', async () => {
+    const opts = await createLoaded(bag());
+    opts.aborted = 0;
+    await opts.applyProfile('proxy');
+    expect(opts.aborted).toBeGreaterThan(0);
+  });
+
+  it('does not cancel downloads when only publishing UI state', async () => {
+    const opts = await createLoaded(bag());
+    opts.aborted = 0;
+    await opts.applyProfile('proxy', { proxy: false });
+    expect(opts.aborted).toBe(0);
+  });
+
+  it('does not cancel downloads when re-applying the current profile', async () => {
+    // A finished rule-list download re-applies the current profile; aborting
+    // there would kill the siblings from the same update batch.
+    const opts = await createLoaded(bag());
+    await opts.applyProfile('proxy');
+    opts.aborted = 0;
+    await opts.applyProfile('proxy');
+    expect(opts.aborted).toBe(0);
+  });
+});
+
+describe('Options#applyProfile ordering', () => {
+  it('reaches the proxy in call order when two applies overlap', async () => {
+    // The popup picking a profile while the boot-time apply is still in
+    // flight. Nothing serialises these, so the invariant that keeps the user's
+    // pick from being reverted is that each apply hits the proxy one microtask
+    // after being called — i.e. in call order.
+    const { impl, applied } = recordingProxy();
+    const opts = await createLoaded(bag(), impl);
+    applied.length = 0;
+
+    const first = opts.applyProfile('direct', { update: false });
+    const second = opts.applyProfile('proxy', { update: false });
+    await Promise.all([first, second]);
+
+    expect(applied.map((p) => p.name)).toEqual(['direct', 'proxy']);
+    expect(opts.currentName()).toBe('proxy');
+  });
+
+  it('reports a failed apply to the caller and survives it', async () => {
+    let fail = false;
+    const applied: string[] = [];
+    const impl: ProxyImpl = {
+      applyProfile: async (profile) => {
+        if (fail) {
+          fail = false;
+          throw new Error('settings.set failed');
+        }
+        applied.push(profile.name);
+      },
+    };
+    const opts = await createLoaded(bag(), impl);
+    applied.length = 0;
+
+    fail = true;
+    await expect(opts.applyProfile('direct', { update: false })).rejects.toThrow(
+      'settings.set failed',
+    );
+    await opts.applyProfile('proxy', { update: false });
+    expect(applied).toEqual(['proxy']);
   });
 });
 

--- a/packages/ui/src/popup/main.ts
+++ b/packages/ui/src/popup/main.ts
@@ -203,9 +203,21 @@ function wireActions(): void {
 
 async function applyProfile(name: string): Promise<void> {
   try {
-    await api.applyProfile(name);
-    if (state.refreshOnProfileChange !== false) {
-      await refreshActivePage();
+    if (state.refreshOnProfileChange === false) {
+      // Same as the original: no need to wait when we will not reload the tab.
+      api.applyProfileNoReply(name);
+    } else {
+      // A slow apply in the worker used to keep this await — and the menu —
+      // stuck with no feedback. Give it a few seconds; if the worker is still
+      // busy, close anyway. The apply carries on without us, only the reload
+      // of the active tab is skipped.
+      const applied = await Promise.race([
+        api.applyProfile(name).then(() => true),
+        new Promise<false>((resolve) => {
+          setTimeout(() => resolve(false), 4000);
+        }),
+      ]);
+      if (applied) await refreshActivePage();
     }
   } catch (err) {
     showError(err);


### PR DESCRIPTION
## The freeze

The popup rendered from `Options.ready`, which resolves only once the startup profile has been **programmed into the browser** — generating a rule-list PAC and handing it to `chrome.proxy.settings`. The MV3 worker re-boots on nearly every popup open, so every open waited on that and the menu stayed blank until it finished.

## The fix

Split the promise. `uiReady` resolves once the profile list is published to state; `ready` still covers the proxy write. The worker boots on `uiReady` and gates only the non-popup RPC methods on `ready`. The popup caps its apply round-trip at four seconds and closes regardless — the apply carries on without it, only the active-tab reload is skipped.

Rule-list downloads became abortable, so switching profiles drops a hung gfwlist fetch instead of leaving it to run out its 30s timeout.

## Details worth a look

- **The abort is scoped to genuine profile switches** (`options.ts`). A finished download re-applies the current profile via `_setOptions`, so an unconditional abort there cancelled the siblings still downloading from the same batch.
- **`updateProfile` does not abort at all.** Boot runs two overlapping updates (watched profiles after apply, then every profile on the download interval); cancelling there made each report the other's downloads as timeouts.
- **Two applies can now be in flight at once.** That is safe because `setProxyAuth` is `async` but contains no `await`, so every apply reaches `chrome.proxy.settings` exactly one microtask after being called — the browser sees them in call order and a profile picked mid-boot is the one that sticks. The invariant is commented at the call site and pinned by a test. I built and then removed a queue serialising applies: it fixed nothing and would have stalled a user's pick behind a slow boot apply, the exact failure this PR removes.
- A failed PAC generation falls back to `direct` instead of rejecting the apply, and a rejected `settings.set` (another extension holding the proxy) no longer surfaces as an unhandled rejection in the worker.

PAC generation was measured at ~25ms for a 9.5k-rule gfwlist (620 KiB script), ruling out CPU-blocking of the worker thread as a contributor.

## Verification

- `npm test` — 359 passing, +4 new (call order under overlapping applies, failed-apply propagation, two abort-scoping cases)
- `npm run typecheck` — clean
- `npm run build` + `npm run e2e` — all 6 scripts pass against real headless Chrome

`npm run lint` is not runnable in this checkout: no eslint binary or config is present, consistent with AGENTS.md noting lint is not in CI.